### PR TITLE
Fixes #131 Teams page- showing ‘invitation pending’ for owner- admin member

### DIFF
--- a/app/views/team/_team.html.erb
+++ b/app/views/team/_team.html.erb
@@ -29,7 +29,6 @@
       <span class="px-2 inline-flex text-xs leading-5 tracking-widest font-semibold rounded-full bg-miru-han-purple-100 text-miru-han-purple-1000">
        <%= t('team.invitation') %>
       </span>
-    <% else %>
     <% end %>
   <% end %>
 </td>


### PR DESCRIPTION
# Pull Request Template

## Description

When Admin user SignIn, Owner status was showing INVITATION PENDING

Fixes # (issue)

Fixes #131 

https://www.loom.com/share/923bdc9f5a6445d7b94b42976b2ac52a

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

## Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
