### PR TITLE
Forgot password- User doesn’t receive any email after password is successfully reset

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -132,7 +132,7 @@ Devise.setup do |config|
   # config.send_email_changed_notification = false
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :invitable
   # The period the generated invitation token is valid.


### PR DESCRIPTION
# Pull Request Template

## Description

There was a bug wherein the user was not able to receive an email after the password was reset successfully.
Fixes #134 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
