### PR TITLE
Add and Configure Env files.

### DIFF
--- a/cypress/config/cypress.development.json
+++ b/cypress/config/cypress.development.json
@@ -1,0 +1,21 @@
+{
+  "baseUrl": "http://localhost:3000",
+  "testFiles": "**/*.spec.js",
+  "execTimeout": 1800000,
+  "defaultCommandTimeout": 10000,
+  "requestTimeout": 30000,
+  "pageLoadTimeout": 60000,
+  "responseTimeout": 10000,
+  "viewportWidth": 1200,
+  "viewportHeight": 1200,
+  "videoUploadOnPasses": true,
+  "screenshotsFolder": "cypress/artifacts/screenshots",
+  "videosFolder": "cypress/artifacts/videos",
+  "retries": {
+    "runMode": 2,
+    "openMode": 2
+  },
+  "env": {
+    "apiUrl": "http://localhost:3000"
+  }
+}

--- a/cypress/config/cypress.production.json
+++ b/cypress/config/cypress.production.json
@@ -1,0 +1,21 @@
+{
+  "baseUrl": "",
+  "testFiles": "**/*.spec.js",
+  "execTimeout": 1800000,
+  "defaultCommandTimeout": 10000,
+  "requestTimeout": 30000,
+  "pageLoadTimeout": 60000,
+  "responseTimeout": 10000,
+  "viewportWidth": 1200,
+  "viewportHeight": 1200,
+  "videoUploadOnPasses": true,
+  "screenshotsFolder": "cypress/artifacts/screenshots",
+  "videosFolder": "cypress/artifacts/videos",
+  "retries": {
+    "runMode": 2,
+    "openMode": 2
+  },
+  "env": {
+    "apiUrl": ""
+  }
+}

--- a/cypress/config/cypress.staging.json
+++ b/cypress/config/cypress.staging.json
@@ -1,0 +1,22 @@
+{
+  "baseUrl": "https://miru-web-staging.herokuapp.com/",
+  "testFiles": "**/*.spec.js",
+  "execTimeout": 1800000,
+  "defaultCommandTimeout": 10000,
+  "requestTimeout": 30000,
+  "pageLoadTimeout": 120000,
+  "responseTimeout": 10000,
+  "viewportWidth": 1200,
+  "viewportHeight": 1200,
+  "videoUploadOnPasses": true,
+  "screenshotsFolder": "cypress/artifacts/screenshots",
+  "videosFolder": "cypress/artifacts/videos",
+  "trashAssetsBeforeRuns": false,
+  "retries": {
+    "runMode": 2,
+    "openMode": 2
+  },
+  "env": {
+    "apiUrl": ""
+  }
+}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -16,7 +16,18 @@
  * @type {Cypress.PluginConfig}
  */
 // eslint-disable-next-line no-unused-vars
+const fs = require("fs-extra");
+const path = require("path");
+
+const getConfigurationByFile = file => {
+  const pathToConfigFile = `config/cypress.${file}.json`;
+
+  return file && fs.readJson(path.join(__dirname, "../", pathToConfigFile));
+};
+
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-}
+  const environment = config.env.configFile;
+  const configForEnvironment = getConfigurationByFile(environment);
+
+  return configForEnvironment || config;
+};

--- a/package.json
+++ b/package.json
@@ -74,7 +74,11 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cy:open:dev": "cypress open --env configFile=development",
+    "cy:run:dev": "cypress run --browser chrome --headless --record --env configFile=development",
+    "cy:run:staging": "cypress run --browser chrome --headless --record --env configFile=staging",
+    "cy:open:staging": "cypress open --env configFile=staging",
+    "lint": "eslint ./cypress",
+    "lint:fix": "eslint --fix ./cypress"
   }
 }


### PR DESCRIPTION
Add Development(local) and Staging envs to config files.
To run cypress tests we can just run commands:
 "npm run cy:open:dev": for opening cypress on localhost.
 "npm run cy:run:dev": for running headless tests on localhost.
 "npm run cy:run:staging": for opening cypress on staging url.
 "npm run cy:open:staging": for running headless tests on staging url.