### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ add `EMAIL_DELIVERY_METHOD='letter_opener_web'` to `.env`)
 | Admin    | supriya@example.com | password |
 | Employee | akhil@example.com   | password |
 
-## Installation of cypress dependencies
+## Installation of Cypress Dependencies
 
 Install the cypress dependencies using the following command:
 


### PR DESCRIPTION
Updates readme file:

## Installation of Cypress Dependencies

Install the cypress dependencies using the following command:

```sh
cd cypress
yarn install
```

## Running Cypress tests

Cypress tests can be run on local, staging and production environment.

To run the cypress tests on the local environment and in headless mode use the
following command:

```sh
cd cypress
yarn run cy:run:dev
```

To run the tests on local environment and in chrome browser use the following
command:

```sh
cd cypress
yarn run cy:open:dev
```

To run the tests on staging environment and in headless mode use the following
command:

```sh
cd cypress
yarn run cy:run:staging
```

To run the tests on staging environment and in chrome browser use the following
command

```sh
cd cypress
yarn run cy:open:staging
```
