### PR TITLE
Wrap note text on reports page

### DIFF
--- a/app/javascript/src/components/Reports/TimeEntry.tsx
+++ b/app/javascript/src/components/Reports/TimeEntry.tsx
@@ -29,7 +29,7 @@ export const TimeEntry = ({
         {client}
       </p>
     </td>
-    <td className="w-full px-6 py-4 text-left whitespace-nowrap text-xs font-normal text-miru-dark-purple-1000">
+    <td className="w-full px-6 py-4 text-left text-xs font-normal text-miru-dark-purple-1000 whitespace-pre-wrap">
       {note}
     </td>
     <td className="w-full px-6 py-4 text-left whitespace-nowrap">


### PR DESCRIPTION
## Notion card

## Summary
https://www.notion.so/saeloun/Text-wrapping-is-required-on-notes-field-on-time-entry-report-5d312940b2644b879dd076d7496b8fd2
Fixed the wrapping of note on reports page

## Preview
Before
<img width="1507" alt="Screenshot 2022-03-15 at 2 56 34 PM" src="https://user-images.githubusercontent.com/3153596/158347313-f5662c65-bcbe-42a6-b30c-c32d0d78369c.png">

after
<img width="1549" alt="Screenshot 2022-03-15 at 2 55 34 PM" src="https://user-images.githubusercontent.com/3153596/158347368-0672232f-c117-4a99-a0b4-462f6fd7bd58.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
