### PR TITLE
[BE]Remove redundant associations from invoice line item

### DIFF
--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -8,7 +8,6 @@
 #  date               :date
 #  rate               :decimal(20, 2)   default("0.0")
 #  quantity           :integer          default("1")
-#  user_id            :integer          not null
 #  invoice_id         :integer          not null
 #  timesheet_entry_id :integer
 #  created_at         :datetime         not null
@@ -18,13 +17,11 @@
 #
 #  index_invoice_line_items_on_invoice_id          (invoice_id)
 #  index_invoice_line_items_on_timesheet_entry_id  (timesheet_entry_id)
-#  index_invoice_line_items_on_user_id             (user_id)
 #
 
 # frozen_string_literal: true
 
 class InvoiceLineItem < ApplicationRecord
-  belongs_to :user
   belongs_to :invoice
   belongs_to :timesheet_entry, optional: true
 

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -26,6 +26,8 @@ class TimesheetEntry < ApplicationRecord
   belongs_to :user
   belongs_to :project
 
+  has_one :invoice_line_item
+
   before_validation :ensure_bill_status_is_set
   before_validation :ensure_bill_status_is_not_billed, on: :create
   before_validation :ensure_billed_status_should_not_be_changed, on: :update

--- a/db/migrate/20220414122335_remove_user_id_from_invoice_line_items.rb
+++ b/db/migrate/20220414122335_remove_user_id_from_invoice_line_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveUserIdFromInvoiceLineItems < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :invoice_line_items, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_14_091256) do
+ActiveRecord::Schema.define(version: 2022_04_14_122335) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,14 +97,12 @@ unique: true
     t.date "date"
     t.decimal "rate", precision: 20, scale: 2, default: "0.0"
     t.integer "quantity", default: 1
-    t.bigint "user_id", null: false
     t.bigint "invoice_id", null: false
     t.bigint "timesheet_entry_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["invoice_id"], name: "index_invoice_line_items_on_invoice_id"
     t.index ["timesheet_entry_id"], name: "index_invoice_line_items_on_timesheet_entry_id"
-    t.index ["user_id"], name: "index_invoice_line_items_on_user_id"
   end
 
   create_table "invoices", force: :cascade do |t|
@@ -229,7 +227,6 @@ unique: true
   add_foreign_key "identities", "users"
   add_foreign_key "invoice_line_items", "invoices"
   add_foreign_key "invoice_line_items", "timesheet_entries"
-  add_foreign_key "invoice_line_items", "users"
   add_foreign_key "invoices", "clients"
   add_foreign_key "project_members", "projects"
   add_foreign_key "project_members", "users"

--- a/spec/factories/invoice_line_items.rb
+++ b/spec/factories/invoice_line_items.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     date { Faker::Date.between(from: "2019-04-01", to: Date.today) }
     rate { Faker::Number.between(from: 0, to: 1000) }
     quantity { Faker::Number.between(from: 1, to: 10) }
-    user
     invoice
     timesheet_entry
   end

--- a/spec/models/invoice_line_item_spec.rb
+++ b/spec/models/invoice_line_item_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe InvoiceLineItem, type: :model do
 
   describe "Associations" do
     describe "belongs to" do
-      it { is_expected.to belong_to(:user) }
       it { is_expected.to belong_to(:invoice) }
       it { is_expected.to belong_to(:timesheet_entry).optional(true) }
     end

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe TimesheetEntry, type: :model do
   describe "Associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:project) }
+    it { is_expected.to have_one(:invoice_line_item) }
   end
 
   describe "Validations" do


### PR DESCRIPTION
## Notion card
NA
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
This PR removes `belongs_to :user` association from `invoice_line_item` model since that can be indirectly inferred via `belongs_to :timesheet_entry` association. Also, it establishes bi-directional relation between `timesheet_entry` and `invoice_line_item` via `has_one :invoice_line_item` association in `timesheet_entry`.
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
