### PR TITLE
clear form fields once the timesheet entry is submitted

### DIFF
--- a/app/javascript/src/components/time-tracking/AddEntry.tsx
+++ b/app/javascript/src/components/time-tracking/AddEntry.tsx
@@ -82,6 +82,9 @@ const AddEntry: React.FC<Iprops> = ({
         }
         return newState;
       });
+      setNote("");
+      setDuration("");
+      setBillable(false);
     }
   };
 

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -8,7 +8,7 @@
 #  user_id     :integer          not null
 #  project_id  :integer          not null
 #  duration    :float            not null
-#  note        :text
+#  note        :text             default("")
 #  work_date   :date             not null
 #  bill_status :integer          not null
 #  created_at  :datetime         not null

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ unique: true
     t.bigint "user_id", null: false
     t.bigint "project_id", null: false
     t.float "duration", null: false
-    t.text "note"
+    t.text "note", default: ""
     t.date "work_date", null: false
     t.integer "bill_status", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=b4528f26f4424af7beaf036262796cb3&p=78c15513bdbd4515ad57d362fbcb6c8b

## Summary

Clear the notes field and hours field after a timesheet entry is created.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code