### PR TITLE
added phone and address with clients fetch api

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -85,6 +85,8 @@ class Client < ApplicationRecord
       id: id,
       name: name,
       email: email,
+      phone: phone,
+      address: address,
       minutes_spent: total_hours_logged(time_frame)
     }
   end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Company, type: :model do
         it "returns the total hours logged for all the clients of a Company in the last_week" do
           result = [client_1, client_2].map do |client|
             {
-              id: client.id, name: client.name, email: client.email,
+              id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address,
               minutes_spent: client.total_hours_logged(time_frame)
             }
           end
@@ -61,7 +61,8 @@ RSpec.describe Company, type: :model do
           result = [client_1, client_2].map do |client|
             {
               id: client.id,
-              name: client.name, email: client.email, minutes_spent: client.total_hours_logged(time_frame)
+              name: client.name, email: client.email,
+              phone: client.phone, address: client.address, minutes_spent: client.total_hours_logged(time_frame)
             }
           end
           expect(company.client_details(time_frame)).to eq(result)
@@ -74,7 +75,7 @@ RSpec.describe Company, type: :model do
         it "returns the total hours logged for all the clients of a Company in that week" do
           result = [client_1, client_2].map do |client|
             {
-              id: client.id, name: client.name, email: client.email,
+              id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address,
               minutes_spent: client.total_hours_logged(time_frame)
             }
           end
@@ -88,7 +89,7 @@ RSpec.describe Company, type: :model do
         it "returns the total hours logged for all the clients of a Company in that week" do
           result = [client_1, client_2].map do |client|
             {
-              id: client.id, name: client.name, email: client.email,
+              id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address,
               minutes_spent: client.total_hours_logged(time_frame)
             }
           end

--- a/spec/requests/internal_api/v1/clients/index_spec.rb
+++ b/spec/requests/internal_api/v1/clients/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
       it "returns the total hours logged for a Company in the last_week" do
         client_details = user.current_workspace.clients.kept.map do |client|
           {
-            id: client.id, name: client.name, email: client.email,
+            id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address,
             minutes_spent: client.total_hours_logged(time_frame)
           }
         end
@@ -46,7 +46,7 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
 
       it "finds specific client by name" do
         client_details = [{
-          id: client_1.id, name: client_1.name, email: client_1.email,
+          id: client_1.id, name: client_1.name, email: client_1.email, phone: client_1.phone, address: client_1.address,
           minutes_spent: client_1.total_hours_logged(time_frame)
         }]
         expect(response).to have_http_status(:ok)
@@ -56,9 +56,9 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
 
     it "returns all the clients when query params are empty" do
       client_details = [{
-        id: client_1.id, name: client_1.name, email: client_1.email,
+        id: client_1.id, name: client_1.name, email: client_1.email, phone: client_1.phone, address: client_1.address,
         minutes_spent: client_1.total_hours_logged(time_frame)
-      }, id: client_2.id, name: client_2.name, email: client_2.email,
+      }, id: client_2.id, name: client_2.name, email: client_2.email, phone: client_2.phone, address: client_2.address,
          minutes_spent: client_2.total_hours_logged(time_frame) ]
 
       expect(response).to have_http_status(:ok)
@@ -82,7 +82,7 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
       it "returns the total hours logged for a Company in the last_week" do
         client_details = user.current_workspace.clients.kept.map do |client|
           {
-            id: client.id, name: client.name, email: client.email,
+            id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address,
             minutes_spent: client.total_hours_logged(time_frame)
           }
         end


### PR DESCRIPTION
## Notion card

Client Index API to fetch phone number and Address along with other fields 

````json
{
  "client_details": [
    {
      "id": 1,
      "name": "client_1_saeloun_India",
      "email": "client_one@saeloun_india.com",
      "phone": "+91 9999999991",
      "address": "Somewhere on Earth",
      "minutes_spent": 1680
    },
    {
      "id": 2,
      "name": "client_2_saeloun_India",
      "email": "client_two@saeloun_india.com",
      "phone": "+91 9999999992",
      "address": "Somewhere on Earth",
      "minutes_spent": 0
    }
  ],
  "total_minutes": 1680
}
````

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
