### PR TITLE
Edit client name without editing address

### DIFF
--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -12,11 +12,12 @@ const newClientSchema = Yup.object().shape({
   address: Yup.string().required("Address cannot be blank")
 });
 
-const getInitialvalues = ({ name, email }) => ({
-  name: name,
-  email: email,
-  phoneNo: "",
-  address: ""
+const getInitialvalues = (client) => ({
+  name: client.name,
+  email: client.email,
+  phone: client.phone,
+  address: client.address,
+  minutes: client.minutes
 });
 
 export interface IEditClient {
@@ -35,6 +36,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
       }
     }).then(() => {
       setShowEditDialog(false);
+      document.location.reload();
     }).catch((e) => {
       setApiError(e.message);
     });
@@ -51,7 +53,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
         <div className="relative px-4 h-full w-full md:flex md:items-center md:justify-center">
           <div className="rounded-lg px-6 pb-6 bg-white shadow-xl transform transition-all sm:align-middle sm:max-w-md modal-width">
             <div className="flex justify-between items-center mt-6">
-              <h6 className="text-base font-extrabold">Add New Client</h6>
+              <h6 className="text-base font-extrabold">Edit Client</h6>
               <button type="button" onClick={() => { setShowEditDialog(false); }}>
                 <X size={16} color="#CDD6DF" weight="bold" />
               </button>

--- a/app/javascript/src/mapper/client.mapper.ts
+++ b/app/javascript/src/mapper/client.mapper.ts
@@ -1,6 +1,8 @@
 const getClientList = (input) => input.client_details.map((client) => ({
   email: client.email,
   id: client.id,
+  address: client.address,
+  phone: client.phone,
   minutes: client.minutes_spent,
   name: client.name
 }));


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Editing-client-name-without-updating-it-s-address-32eb2ce543474ba386115de9642bb073
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Can edit client name without editing address.
-Address is getting fetched in edit client modal.
- chnaged the heading of edit modal from 'Add New Client' to 'Edit Client'
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://www.loom.com/share/164b1f965ac14c76a0c34998f2844b5b
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
