### PR TITLE
Fix blank password error message formatting on Sign Up page

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -51,7 +51,7 @@
                   <div class="field" x-data="{ show: true }">
                     <div class="field_with_errors">
                       <%= f.label t('registration.password').capitalize, class: "form__label" %>
-                      <div class="miru_form_error">
+                      <div class="form__error">
                         <%= error_message_on(f.object, :password) %>
                       </div>
                     </div>


### PR DESCRIPTION
Updated password error message class to 'form__error'.

## Notion card
Fixes issue - https://www.notion.so/saeloun/Password-can-t-be-left-blank-message-not-formatted-on-sign-up-page-5736e7679e3047ce87e6970756f1a7c1

## Summary
User should get an error on leaving the password blank. The formatting was fixed to be the same as other error messages on the sign-up page.

## Preview
<img width="1792" alt="Screenshot 2022-04-26 at 12 31 58 PM" src="https://user-images.githubusercontent.com/5313625/165241345-194b6620-7ce4-48f1-a85f-0bb4e433dd0d.png">
