### PR TITLE
Add unauthenticated action for client invoice view

### DIFF
--- a/app/controllers/invoices/view_controller.rb
+++ b/app/controllers/invoices/view_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Invoices::ViewController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_after_action :verify_authorized
+
+  def show
+    render :show, layout: false
+  end
+end

--- a/app/views/invoices/view/show.html.erb
+++ b/app/views/invoices/view/show.html.erb
@@ -1,0 +1,6 @@
+<div class="max-w-6xl mx-auto px-2 md:px-11 font-manrope">
+  <div>
+    <%# react_component("Invoices/RouteConfig") %>
+    Client view goes here
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,10 @@ Rails.application.routes.draw do
         get :cancel
       end
     end
+
+    member do
+      get :view, to: "view#show", as: :view
+    end
   end
 
   get "clients/*path", to: "clients#index", via: :all

--- a/spec/requests/invoices/view_spec.rb
+++ b/spec/requests/invoices/view_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Invoices::View", type: :request do
+  describe "#show" do
+    let(:company) { create(:company) }
+    let(:client) { create(:client, company:) }
+    let(:invoice) { create(:invoice, client:, company:) }
+
+    context "when unauthenticated" do
+      it "is able to view the client invoice successfully" do
+        send_request :get, view_invoice_path(invoice)
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Notion card
https://www.notion.so/Add-a-route-for-client-invoice-view-7c497f0103e94e359414605f64e5a2e4
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
Create a new controller under the `invoices` namespace called `ViewController`
Skip authentication for the show action as we want to open the client view of an invoice outside Miru as well (Using a link in Gmail)
Add a spec for unauthenticated action

Format of the added route is as `getmiru.com/invoices/:id/view` where `:id` is the invoice id
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
