### PR TITLE
Add wait_until option while generating pdf via grover

### DIFF
--- a/app/services/invoice_payment/pdf_generation.rb
+++ b/app/services/invoice_payment/pdf_generation.rb
@@ -23,7 +23,11 @@ module InvoicePayment
           total: formatted_invoice[:total]
         }
       )
-      Grover.new(html).to_pdf
+
+      options = {
+        wait_until: ["networkidle0", "load", "domcontentloaded", "networkidle2"]
+      }
+      Grover.new(html, options).to_pdf
     end
 
     private


### PR DESCRIPTION
## Notion card

## Summary
The company logo is rendering fine in PDF on local but not on production. To fix this, we are trying out the solution as per the https://github.com/Studiosity/grover/issues/30.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
