### PR TITLE
Multiple decimal value issue on client list page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,14 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    elasticsearch (7.13.3)
+      elasticsearch-api (= 7.13.3)
+      elasticsearch-transport (= 7.13.3)
+    elasticsearch-api (7.13.3)
+      multi_json
+    elasticsearch-transport (7.13.3)
+      faraday (~> 1)
+      multi_json
     erubi (1.10.0)
     execjs (2.8.1)
     factory_bot (6.2.0)
@@ -412,6 +420,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    searchkick (5.0.3)
+      activemodel (>= 5.2)
+      hashie
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -495,6 +506,7 @@ DEPENDENCIES
   devise_invitable (~> 2.0, >= 2.0.6)
   discard (~> 1.2)
   dotenv-rails
+  elasticsearch (< 7.14)
   factory_bot_rails
   faker
   foreman
@@ -525,6 +537,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec (~> 2.8)
   sass-rails
+  searchkick
   selenium-webdriver (>= 4.0.0)
   shoulda-callback-matchers (~> 1.1.1)
   shoulda-matchers (~> 5.1)

--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -20,7 +20,7 @@ import NewClient from "../Modals/NewClient";
 const getTableData = (clients) => {
   if (clients) {
     return clients.map((client) => {
-      const hours = client.minutes / 60;
+      const hours = (client.minutes / 60).toFixed(2);
       return {
         col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
         col2: <div className="text-base text-miru-dark-purple-1000 text-right">{client.email}</div>,


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Logged-hours-for-this-year-are-displayed-with-multiple-decimal-values-on-client-lists-page-ae6640c7085c4ccf9636ca5533e8af19

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

Truncated logged hour value to 2 decimal places on the client list page.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

<img width="1093" alt="Screenshot 2022-05-20 at 10 31 05 AM" src="https://user-images.githubusercontent.com/52308930/169454305-13c2fe0f-823b-4cda-997e-dd244289dfcf.png">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [X] I have manually tested all workflows
- [X] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
