### PR TITLE
Fix: Show entered date on the calendar on invoice page

### DIFF
--- a/app/javascript/src/common/CustomDatePicker/index.tsx
+++ b/app/javascript/src/common/CustomDatePicker/index.tsx
@@ -5,7 +5,7 @@ import { CaretCircleLeft, CaretCircleRight } from "phosphor-react";
 
 import "react-datepicker/dist/react-datepicker.css";
 
-const CustomDatePicker = ({ handleChange }) => {
+const CustomDatePicker = ({ handleChange, dueDate }) => {
   const range = (start, end) => {
     const ans = [];
     for (let i = start; i <= end; i++) {
@@ -34,6 +34,7 @@ const CustomDatePicker = ({ handleChange }) => {
       wrapperClassName="datePicker absolute"
       inline
       calendarClassName="miru-calendar"
+      selected={dueDate}
       renderCustomHeader={({
         date,
         changeYear,

--- a/app/javascript/src/components/Invoices/Generate/InvoiceDetails.tsx
+++ b/app/javascript/src/components/Invoices/Generate/InvoiceDetails.tsx
@@ -63,7 +63,7 @@ const InvoiceDetails = ({
               <PencilSimple size={13} color="#1D1A31" />
             </button>
           </p>
-          {showDueDatePicker && <CustomDatePicker handleChange={handleDueDatePicker} />}
+          {showDueDatePicker && <CustomDatePicker handleChange={handleDueDatePicker} dueDate={dueDate} />}
           <p className="font-normal text-base text-miru-dark-purple-1000">
             {getDueDate}
           </p>


### PR DESCRIPTION
## Notion card
https://saeloun.notion.site/Show-entered-date-on-the-calendar-on-invoice-page-61b0fc040fde41d1a3d9d19eaad45e8a

## Summary
The entered date was not being marked on the calendar as selected on the invoice page for the due date.

## Preview
[Video preview](https://www.loom.com/share/8f88668d8cf64af58618bf311b098741)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
