### PR TITLE
Fix: Address overlapping

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/CompanyInfo.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/CompanyInfo.tsx
@@ -14,7 +14,7 @@ const CompanyInfo = ({ company }) => (
       </div>
     </div>
 
-    <div className="font-normal text-base text-right text-miru-dark-purple-1000 w-36">
+    <div className="font-normal text-base text-right text-miru-dark-purple-1000 w-72">
       <p>{company.address}</p>
       <p>{company.country}</p>
     </div>


### PR DESCRIPTION
## Notion card
https://saeloun.notion.site/The-address-is-overlapping-on-the-next-section-on-view-invoice-page-6b8ca21f9a894486bec9bd4bd139971d

## Summary
Fixed the address overlapping issue where the organization address was overlapping.

## Preview
![Screenshot_20220524_174241](https://user-images.githubusercontent.com/57438322/170034144-54e1b6f5-a427-40cd-b4bb-c869be85b5ed.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
