### PR TITLE
Fix: Edit invoice page layout

### DIFF
--- a/app/javascript/src/components/Invoices/Edit/InvoiceTable.tsx
+++ b/app/javascript/src/components/Invoices/Edit/InvoiceTable.tsx
@@ -4,12 +4,14 @@ import NewLineItemTable from "./NewLineItemTable";
 import useOutsideClick from "../../../helpers/outsideClick";
 import ManualEntry from "../Generate/ManualEntry";
 import NewLineItemRow from "../Generate/NewLineItemRow";
+import LineItem from "../Invoice/LineItem";
 
 const InvoiceTable = ({
   lineItems,
   selectedLineItems,
   setLineItems,
-  setSelectedLineItems
+  setSelectedLineItems,
+  items
 }) => {
   const [addNew, setAddNew] = useState<boolean>(false);
   const [manualEntry, setManualEntry] = useState<boolean>(false);
@@ -98,6 +100,8 @@ const InvoiceTable = ({
                 item={item}
               />
             ))}
+          {items.length > 0 &&
+            items.map((item) => <LineItem key={item.id} item={item} />)}
         </tbody>
       </table>
     </React.Fragment>

--- a/app/javascript/src/components/Invoices/Edit/index.tsx
+++ b/app/javascript/src/components/Invoices/Edit/index.tsx
@@ -10,7 +10,6 @@ import InvoiceTable from "./InvoiceTable";
 import InvoiceTotal from "./InvoiceTotal";
 import CompanyInfo from "../CompanyInfo";
 import InvoiceDetails from "../Generate/InvoiceDetails";
-import InvoiceLineItems from "../Invoice/InvoiceLineItems";
 
 const EditInvoice = () => {
   const navigate = useNavigate();
@@ -136,12 +135,9 @@ const EditInvoice = () => {
               setLineItems={setLineItems}
               selectedLineItems={selectedLineItems}
               setSelectedLineItems={setSelectedLineItems}
+              items={invoiceDetails.invoiceLineItems}
             />
           </div>
-          <InvoiceLineItems
-            items={invoiceDetails.invoiceLineItems}
-            showHeader={false}
-          />
           <InvoiceTotal
             currency={invoiceDetails.company.currency}
             newLineItems={selectedLineItems}


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/The-layout-for-edit-invoice-should-be-the-same-as-view-and-generate-invoice-069a301f10fc468ab745d14464a5c94d

## Summary
Edit invoice page's layout was not identical to the invoice show page.

## Preview
![Screenshot_20220524_225434](https://user-images.githubusercontent.com/57438322/170095975-0dbea538-c97c-4776-93c3-67aaeaa6c2bb.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?


### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
