### PR TITLE
Fix: Logged hours not upto two decimal places

### DIFF
--- a/app/javascript/src/components/Clients/Details/index.tsx
+++ b/app/javascript/src/components/Clients/Details/index.tsx
@@ -19,7 +19,7 @@ import DeleteProject from "../../Projects/Modals/DeleteProject";
 const getTableData = (clients) => {
   if (clients) {
     return clients.map((client) => {
-      const hours = client.minutes/60;
+      const hours = (client.minutes/60).toFixed(2);
       return {
         col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
         col2: <div className="text-base text-miru-dark-purple-1000">{client.team.map(member => <span>{member},&nbsp;</span>)}</div>,


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/The-logged-hours-should-be-displayed-upto-2-decimal-points-on-client-details-page-94bc4df7f9204c02905042413b2b775e

## Summary
When logged hours had more than two decimal places, it was not being rounded up to two decimal places.

## Preview
![Screenshot_20220525_115104](https://user-images.githubusercontent.com/57438322/170193865-737bcf57-4b04-43ad-af3d-b270776aa2a1.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This was fixed using JavaScript's `toFixed()` function and supplying it with the digit 2 so that it rounds up the decimals to two decimal places.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
