### PR TITLE
Remove i18n gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,6 +184,4 @@ gem "searchkick"
 # PDF generator
 gem "grover"
 
-gem "rails-i18n", "~> 7.0.0"
-
 gem "activerecord-import"


### PR DESCRIPTION
## Notion card

## Summary
Added this gem initially as I was using to set i18n localization which was required for us-IN locale. Updated code to not use this any longer and hence gem is not required. 

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
