### PR TITLE
Validate user details before inviting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@
 #  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
-#  first_name             :string           default(""), not null
+#  first_name             :string           not null
 #  invitation_accepted_at :datetime
 #  invitation_created_at  :datetime
 #  invitation_limit       :integer
@@ -19,7 +19,7 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  last_name              :string           default(""), not null
+#  last_name              :string           not null
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  remember_created_at    :datetime

--- a/app/views/devise/invitations/_new.html.erb
+++ b/app/views/devise/invitations/_new.html.erb
@@ -15,10 +15,10 @@
       </div>
       <div class="mt-1 flex -space-x-px">
         <div class="mr-4 w-1/2 flex-1 min-w-0">
-          <%= f.text_field :first_name, id:"team_first_name", placeholder: t('team.first_name'),  class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, :first_name)}" ,"data-cy": "new-member-firstName" %>
+          <%= f.text_field :first_name, id:"team_first_name",required: true, placeholder: t('team.first_name'),  class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, :first_name)}" ,"data-cy": "new-member-firstName" %>
         </div>
         <div class="w-1/2 flex-1 min-w-0">
-          <%= f.text_field :last_name, id:"team_last_name", placeholder: t('team.last_name'), class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, :last_name)}" ,"data-cy": "new-member-lastname" %>
+          <%= f.text_field :last_name, id:"team_last_name",required: true, placeholder: t('team.last_name'), class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, :last_name)}" ,"data-cy": "new-member-lastname" %>
         </div>
       </div>
     </div>
@@ -33,7 +33,7 @@
           <%= error_message_on(f.object, field) %>
         </div>
         <div class="mt-1">
-          <%= f.text_field field, id:"team_email", placeholder: t('team.email'), class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, field)}" , "data-cy": "new-member-email" %>
+          <%= f.text_field field, id:"team_email",required: true, placeholder: t('team.email'), class: "rounded tracking-wider appearance-none border block w-full px-3 py-2 bg-miru-gray-100 h-8 shadow-sm font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base #{error_message_class(f.object, field)}" , "data-cy": "new-member-email" %>
         </div>
       </div>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -158,7 +158,7 @@ Devise.setup do |config|
   # Ensure that invited record is valid.
   # The invitation won't be sent if this check fails.
   # Default: false
-  # config.validate_on_invite = true
+  config.validate_on_invite = true
 
   # Resend invitation if user with invited status is invited again
   # Default: true

--- a/db/migrate/20220527065234_remove_default_value_from_names.rb
+++ b/db/migrate/20220527065234_remove_default_value_from_names.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveDefaultValueFromNames < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :users, :first_name, nil
+    change_column_default :users, :last_name, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_06_085404) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_27_065234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -184,8 +184,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_06_085404) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "first_name", default: "", null: false
-    t.string "last_name", default: "", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/spec/requests/users/invitations/create_spec.rb
+++ b/spec/requests/users/invitations/create_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe "Users::Invitations#create", type: :request do
     create(:company_user, company:, user:)
     user.add_role :admin, company
     sign_in user
-    send_request :post, user_invitation_path, params: { user: { email: "invited@example.com", roles: "employee" } }
+    send_request(
+      :post, user_invitation_path, params: {
+        user: {
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email: "invited@example.com",
+          roles: "employee"
+        }
+      })
   end
 
   it "creates new user with invitation token" do


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=8986924f16fd43ec80ba31ef2672f005

## Summary
Validate the presence of first_name, last_name, and email before sending an invite to a user.

## Preview
https://www.loom.com/share/779e6af4fe7a4a9a87197d5399340ee7

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
