### PR TITLE
Fix reports test failing due to date range on month change

### DIFF
--- a/spec/requests/internal_api/v1/reports/index_spec.rb
+++ b/spec/requests/internal_api/v1/reports/index_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "InternalApi::V1::Reports#index", type: :request do
         @timesheet_entry6 = create(
           :timesheet_entry,
           project:,
-          work_date: this_week_start_date,
+          work_date: Date.today,
           user: @user1,
           bill_status: "unbilled")
         TimesheetEntry.search_index.refresh


### PR DESCRIPTION
## Notion card

## Summary
Test creates one timesheet entry with date as starting of this week and causes issue when new month starts and week overlaps over the month.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
