### PR TITLE
Fixed the weekly time entry view after week change

### DIFF
--- a/app/javascript/src/components/time-tracking/WeeklyEntries.tsx
+++ b/app/javascript/src/components/time-tracking/WeeklyEntries.tsx
@@ -92,7 +92,7 @@ const WeeklyEntries: React.FC<Props> = ({
 
   useEffect(() => {
     handleSetData();
-  }, []);
+  }, [entries]);
 
   return projectSelected ?
     <WeeklyEntriesCard


### PR DESCRIPTION
Signed-off-by: sudeeptarlekar <sudeeptarlekar@gmail.com>

## Notion card

## Summary
When we change the week in weekly view, time entries are not getting updated correctly. Fixed the issue.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
1. Select week view on time entries page.
2. Change week and observe that time entries are not getting updated.

Expected: Time entries should update according to week.

### Checklist:
- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
