### PR TITLE
add api for profile update

### DIFF
--- a/app/controllers/internal_api/v1/profile_controller.rb
+++ b/app/controllers/internal_api/v1/profile_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::ProfileController < InternalApi::V1::ApplicationController
+  def remove_avatar
+    authorize :remove_avatar, policy_class: ProfilePolicy
+    current_user.avatar.destroy
+    render json: { notice: " avatar deleted successfully" }, status: :ok
+  end
+
+  def update
+    authorize :update, policy_class: ProfilePolicy
+    if params[:user][:current_password].blank?
+      current_user.update_without_password(user_params.except(:current_password))
+      render json: { notice: "user updated" }, status: :ok
+    elsif validate_current_password && validate_password_length && validate_password_confirmation
+      current_user.update_with_password(user_params.except)
+      render json: { notice: "password updated" }, status: :ok
+    else
+      render json: { error: "something went wrong" }, status: :unprocessable_entity
+    end
+    rescue Exception => e
+      render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(
+        :first_name, :last_name, :current_password, :password, :password_confirmation, :avatar
+      )
+    end
+
+    def validate_current_password
+      return true if current_user.valid_password?(params[:user][:current_password])
+
+      raise Exception.new("current password is not correct")
+    end
+
+    def validate_password_confirmation
+      return true if params[:user][:password] == params[:user][:password_confirmation]
+
+      raise Exception.new("password and password confirmation does not match")
+    end
+
+    def validate_password_length
+      return true if params[:user][:password].present? &&
+      params[:user][:password].length > 5 &&
+      params[:user][:password_confirmation].length > 5
+
+      raise Exception.new("password and password confirmation should be of minimum 6 characters")
+    end
+end

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProfilePolicy < ApplicationPolicy
+  def remove_avatar?
+    true
+  end
+
+  def update?
+    true
+end
+end

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -25,6 +25,7 @@ namespace :internal_api, defaults: { format: "json" } do
     resources :project_members, only: [:update]
     resources :company_users, only: [:index]
     resources :timezones, only: [:index]
+
     resources :companies, only: [:index, :create, :update] do
       resource :purge_logo, only: [:destroy], controller: "companies/purge_logo"
     end
@@ -35,5 +36,8 @@ namespace :internal_api, defaults: { format: "json" } do
     namespace :payments do
       resources :providers, only: [:create, :index, :update]
     end
+
+    delete "profile/remove_avatar", to: "profile#remove_avatar"
+    put "profile", to: "profile#update"
   end
 end


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=1e983c2b00964a228c9ceabc2157b6d8

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

## Preview
Added profile settings API to update first_name, last_name, password, and remove avatar of the user.

<img width="1792" alt="Screenshot 2022-06-06 at 9 44 14 AM" src="https://user-images.githubusercontent.com/18750194/172093674-c6b4cd03-7047-4eb8-8b1b-7cd5f1c3185d.png">


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
