### PR TITLE
Add/edit invoice Number without clicking on icon

### DIFF
--- a/app/javascript/src/components/Invoices/Generate/InvoiceDetails.tsx
+++ b/app/javascript/src/components/Invoices/Generate/InvoiceDetails.tsx
@@ -4,7 +4,6 @@ import dayjs from "dayjs";
 import { currencyFormat } from "helpers/currency";
 import { PencilSimple } from "phosphor-react";
 import ClientSelection from "./ClientSelection";
-import useOutsideClick from "../../../helpers/outsideClick";
 
 const InvoiceDetails = ({
   currency,
@@ -19,12 +18,9 @@ const InvoiceDetails = ({
   optionSelected, clientVisible
 }) => {
 
-  const [isEditing, setIsEditing] = useState<boolean>(false);
   const [showDateOfIssuePicker, setShowDateOfIssuePicker] = useState<boolean>(false);
   const [showDueDatePicker, setShowDueDatePicker] = useState<boolean>(false);
   const wrapperRef = useRef(null);
-
-  useOutsideClick(wrapperRef, () => setIsEditing(false), isEditing);
 
   const getIssuedDate = dayjs(issueDate).format("DD.MM.YYYY");
   const getDueDate = dayjs(dueDate).format("DD.MM.YYYY");
@@ -79,15 +75,10 @@ const InvoiceDetails = ({
 
       <div>
         <div className="flex flex-col" ref={wrapperRef}>
-          <div className="flex flex-row">
-            <p className="font-normal text-xs text-miru-dark-purple-1000">
-              Invoice Number
-            </p>
-            <button onClick={() => { setIsEditing(!isEditing); }}>
-              <PencilSimple size={13} color="#1D1A31" />
-            </button>
-          </div>
-          <input type="text" disabled={!isEditing} value={invoiceNumber} onChange={(e) => setInvoiceNumber(e.target.value)} />
+          <p className="font-normal text-xs text-miru-dark-purple-1000">
+            Invoice Number
+          </p>
+          <input type="text" value={invoiceNumber} onChange={(e) => setInvoiceNumber(e.target.value)} className="px-2 w-3/5"/>
         </div>
         <p className="font-normal text-xs text-miru-dark-purple-1000 mt-4">
           Reference


### PR DESCRIPTION
## Notion card

https://www.notion.so/saeloun/user-should-be-able-to-add-invoice-number-without-clicking-on-the-edit-icon-a1b62e4e67384573b417ae25836bcae4

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

- Able to add or edit invoice number without clicking on edit icon
- removed edit icon

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/c3599a8c924d4b9395091c0cc780fcc9

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
