### PR TITLE
Fix Invoice Date Format and icon 

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/InvoiceInfo.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceInfo.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import dayjs from "dayjs";
 import { currencyFormat } from "helpers/currency";
 
-const formatDate = (date) => dayjs(date).format("DD.MM.YYYY");
+const formatDate = (date) => dayjs(date).format("DD-MM-YYYY");
 
 const InvoiceInfo = ({ invoice }) => {
   const formattedIssueDate = formatDate(invoice.issueDate);

--- a/app/javascript/src/components/Invoices/Invoice/InvoiceInfo.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceInfo.tsx
@@ -1,47 +1,55 @@
 import React from "react";
+import dayjs from "dayjs";
 import { currencyFormat } from "helpers/currency";
 
-const InvoiceInfo = ({ invoice }) => (
-  <>
-    <div className="group">
-      <p className="font-normal text-xs text-miru-dark-purple-1000 flex">
-        Date of Issue
-      </p>
-      <p className="font-normal text-base text-miru-dark-purple-1000">
-        {invoice.issueDate}
-      </p>
-      <p className="font-normal text-xs text-miru-dark-purple-1000 mt-4">
-        Due Date
-      </p>
-      <p className="font-normal text-base text-miru-dark-purple-1000">
-        {invoice.dueDate}
-      </p>
-    </div>
+const formatDate = (date) => dayjs(date).format("DD.MM.YYYY");
 
-    <div className="group">
-      <p className="font-normal text-xs text-miru-dark-purple-1000">
-        Invoice Number
-      </p>
-      <p className="font-normal text-base text-miru-dark-purple-1000">
-        {invoice.invoiceNumber}
-      </p>
-      <p className="font-normal text-xs text-miru-dark-purple-1000 mt-4">
-        Reference
-      </p>
-      <p className="font-normal text-base text-miru-dark-purple-1000">
-        {invoice.reference}
-      </p>
-    </div>
+const InvoiceInfo = ({ invoice }) => {
+  const formattedIssueDate = formatDate(invoice.issueDate);
+  const formattedDueDate = formatDate(invoice.dueDate);
 
-    <div>
-      <p className="font-normal text-xs text-miru-dark-purple-1000 text-right">
-        Amount
-      </p>
-      <p className="font-normal text-4xl text-miru-dark-purple-1000 mt-6">
-        {currencyFormat({ baseCurrency: invoice.company.currency, amount: invoice.amount })}
-      </p>
-    </div>
-  </>
-);
+  return (
+    <>
+      <div className="group">
+        <p className="font-normal text-xs text-miru-dark-purple-1000 flex">
+          Date of Issue
+        </p>
+        <p className="font-normal text-base text-miru-dark-purple-1000">
+          {formattedIssueDate}
+        </p>
+        <p className="font-normal text-xs text-miru-dark-purple-1000 mt-4">
+          Due Date
+        </p>
+        <p className="font-normal text-base text-miru-dark-purple-1000">
+          {formattedDueDate}
+        </p>
+      </div>
+
+      <div className="group">
+        <p className="font-normal text-xs text-miru-dark-purple-1000">
+          Invoice Number
+        </p>
+        <p className="font-normal text-base text-miru-dark-purple-1000">
+          {invoice.invoiceNumber}
+        </p>
+        <p className="font-normal text-xs text-miru-dark-purple-1000 mt-4">
+          Reference
+        </p>
+        <p className="font-normal text-base text-miru-dark-purple-1000">
+          {invoice.reference}
+        </p>
+      </div>
+
+      <div>
+        <p className="font-normal text-xs text-miru-dark-purple-1000 text-right">
+          Amount
+        </p>
+        <p className="font-normal text-4xl text-miru-dark-purple-1000 mt-6">
+          {currencyFormat({ baseCurrency: invoice.company.currency, amount: invoice.amount })}
+        </p>
+      </div>
+    </>
+  );
+};
 
 export default InvoiceInfo;

--- a/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import dayjs from "dayjs";
 
 const LineItem = ({ item }) => {
-  const date = dayjs(item.date).format("DD.MM.YYYY");
+  const date = dayjs(item.date).format("DD-MM-YYYY");
   return (
     <tr>
       <td className="border-b-2 border-miru-gray-200 px-1 py-3 font-normal text-base text-miru-dark-purple-1000 text-left ">

--- a/app/javascript/src/components/time-tracking/EntryCard.tsx
+++ b/app/javascript/src/components/time-tracking/EntryCard.tsx
@@ -24,13 +24,13 @@ const EntryCard: React.FC<props> = ({
   bill_status
 }) => (
   <div className="week-card flex justify-between items-center shadow-2xl w-full p-4 mt-10 rounded-lg">
-    <div>
+    <div className="flex-auto">
       <div className="flex">
         <p className="text-lg">{client}</p>
         <p className="text-lg mx-2">•</p>
         <p className="text-lg">{project}</p>
       </div>
-      <p className="max-h-32 w-129 overflow-scroll text-sm text-miru-dark-purple-400 break-words whitespace-pre-wrap">
+      <p className="max-h-32 overflow-scroll text-sm text-miru-dark-purple-400 break-words whitespace-pre-wrap">
         {note}
       </p>
     </div>
@@ -43,14 +43,14 @@ const EntryCard: React.FC<props> = ({
         <BillTag color="miru-alert-green-400" text="billed" />
       )}
       <p className="text-4xl">{minutesToHHMM(duration)}</p>
-      <button onClick={() => setEditEntryId(id)} className="mx-10 h-4 w-4">
+      <button onClick={() => setEditEntryId(id)} className="mx-10">
         <img
           src="/edit.svg"
           alt="edit"
           className="icon-hover text-miru-han-purple-600 hover:text-miru-han-purple-1000"
         />
       </button>
-      <button onClick={() => handleDeleteEntry(id)} className="mr-10 h-4 w-4">
+      <button onClick={() => handleDeleteEntry(id)} className="mr-10">
         <img
           src="/delete.svg"
           alt="delete"

--- a/app/javascript/stylesheets/time-tracking.scss
+++ b/app/javascript/stylesheets/time-tracking.scss
@@ -1,7 +1,7 @@
 .icon-hover {
-  display: none;
+  visibility: hidden;
 }
 
 .week-card:hover .icon-hover {
-  display: inline-block;
+  visibility: visible;
 }


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/The-date-format-on-view-invoice-should-be-in-the-format-dd-mm-yyyy-0ce738de497341f888c086f6bcf8ccc5

## Summary
- Update date format to DD-MM-YYYY on invoice page.
- update css to resolve icon cropping on safari browser.

## Preview

https://user-images.githubusercontent.com/20780979/172403249-9ae73f7a-9032-469d-b0b4-72c0d3520e4f.mp4



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Checklist:

- [X] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
