### PR TITLE
[BUGFIX]Allow invitation to another workspace

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -7,16 +7,39 @@ class Users::InvitationsController < Devise::InvitationsController
   protected
 
     def assign_company
-      resource.companies << current_company
+      unless invited_user.errors.present? ||
+          invited_user.companies.exists?(id: current_company.id)
+        invited_user.companies << current_company
+      end
     end
 
     def assign_role
-      if resource.errors.empty? && current_company
-        resource.add_role(params[:user][:roles].downcase.to_sym, current_company)
+      if invited_user.errors.empty? && current_company
+        invited_user.add_role(params[:user][:roles].downcase.to_sym, current_company)
       end
     end
 
     def after_invite_path_for(inviter)
       team_index_path
+    end
+
+  private
+
+    def invite_resource
+      if invited_user.present? && invited_user.invitation_accepted_at.present?
+        send_confirmation_email
+        return invited_user
+      end
+
+      super
+    end
+
+    def invited_user
+      User.find_by(email: invite_params[:email])
+    end
+
+    def send_confirmation_email
+      # https://github.com/scambra/devise_invitable/blob/7c4b1f6d19135b2cfed4685735a646a28bbc5191/lib/devise_invitable/models.rb#L211
+      invited_user.send_devise_notification(:invitation_instructions, invited_user.invitation_token)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,6 +105,11 @@ class User < ApplicationRecord
     write_attribute(:current_workspace_id, workspace&.id)
   end
 
+  # https://github.com/scambra/devise_invitable/blob/7c4b1f6d19135b2cfed4685735a646a28bbc5191/test/rails_app/app/models/user.rb#L59
+  def send_devise_notification(notification, *args)
+    super
+  end
+
   private
 
     def discard_project_members

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,11 @@
 
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+<% if @token.present? %>
+  <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+<% else %>
+  <p><%= link_to t("devise.mailer.invitation_instructions.accept"), root_url %></p>
+<% end %>
 
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>


### PR DESCRIPTION
## Notion card
NA

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
Currently, a user can't be invited to another workspace which is undesirable. This PR fixes it by overriding `devise_invitable`'s default behaviour as per the [docs](https://github.com/scambra/devise_invitable#configuring-controllers-).

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
