### PR TITLE
Client details menu options added

### DIFF
--- a/app/controllers/internal_api/v1/clients_controller.rb
+++ b/app/controllers/internal_api/v1/clients_controller.rb
@@ -21,7 +21,7 @@ class InternalApi::V1::ClientsController < InternalApi::V1::ApplicationControlle
   def show
     authorize client
     project_details = client.project_details(params[:time_frame])
-    client_details = { id: client.id, name: client.name, email: client.email }
+    client_details = { id: client.id, name: client.name, email: client.email, address: client.address }
     total_minutes = (project_details.map { |project| project[:minutes_spent] }).sum
     overdue_outstanding_amount = client.client_overdue_and_outstanding_calculation
     render json: { client_details:, project_details:, total_minutes:, overdue_outstanding_amount: }, status: :ok

--- a/app/javascript/src/components/Clients/Details/Header.tsx
+++ b/app/javascript/src/components/Clients/Details/Header.tsx
@@ -2,10 +2,17 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft, DotsThreeVertical, Receipt, Pencil, CaretDown, Trash } from "phosphor-react";
 
+import AddProject from "../Modals/AddProject";
+import DeleteClient from "../Modals/DeleteClient";
+import EditClient from "../Modals/EditClient";
+
 const Header = ({ clientDetails }) => {
 
   const [isHeaderMenuVisible, setHeaderMenuVisibility] = useState<boolean>(false);
   const [isClientOpen, toggleClientDetails] = useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
+  const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
+  const [showProjectModal, setShowProjectModal] = useState<boolean>(false);
 
   const navigate = useNavigate();
 
@@ -19,6 +26,19 @@ const Header = ({ clientDetails }) => {
 
   const handleBackButtonClick = () => {
     navigate("/clients");
+  };
+
+  const handleDelete = () => {
+    setShowDeleteDialog(true);
+  };
+
+  const handleEdit = () => {
+    setShowEditDialog(true);
+  };
+
+  const handleAddProject = () => {
+    setShowProjectModal(true);
+    setHeaderMenuVisibility(false);
   };
 
   const menuBackground = isHeaderMenuVisible ? "bg-miru-gray-1000" : "";
@@ -41,19 +61,19 @@ const Header = ({ clientDetails }) => {
             <DotsThreeVertical size={20} color="#000000" />
           </button>
           { isHeaderMenuVisible && <ul className="menuButton__wrapper">
-            <li>
+            <li onClick={handleAddProject}>
               <button className="menuButton__list-item">
                 <Receipt size={16} color="#5B34EA" weight="bold" />
-                <span className="ml-3">Add Client</span>
+                <span className="ml-3">Add Project</span>
               </button>
             </li>
-            <li>
+            <li onClick={handleEdit}>
               <button className="menuButton__list-item">
                 <Pencil size={16} color="#5b34ea" weight="bold" />
                 <span className="ml-3">Edit</span>
               </button>
             </li>
-            <li>
+            <li onClick={handleDelete}>
               <button className="menuButton__list-item text-miru-red-400">
                 <Trash size={16} color="#E04646" weight="bold" />
                 <span className="ml-3">Delete</span>
@@ -76,6 +96,24 @@ const Header = ({ clientDetails }) => {
           <p>{clientDetails.phone}</p>
         </div>
       </div>
+      }
+      { showDeleteDialog &&
+          <DeleteClient
+            client={clientDetails}
+            setShowDeleteDialog={setShowDeleteDialog}
+          />
+      }
+      { showEditDialog &&
+          <EditClient
+            client={clientDetails}
+            setShowEditDialog={setShowEditDialog}
+          />
+      }
+      { showProjectModal &&
+          <AddProject
+            setShowProjectModal = {setShowProjectModal}
+            clientDetails = {clientDetails}
+          />
       }
     </div>
   );

--- a/app/javascript/src/components/Clients/Modals/AddProject.tsx
+++ b/app/javascript/src/components/Clients/Modals/AddProject.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import projectApi from "apis/projects";
+import { X } from "phosphor-react";
+
+const AddProject = ({ setShowProjectModal, clientDetails }) => {
+
+  const [client, setClient] = useState<any>(null);
+  const [projectName, setProjectName] = useState<any>(null);
+  const [projectType, setProjectType] = useState<any>("Billable");
+
+  const navigate = useNavigate();
+
+  const handleSubmit = () => {
+    projectApi.create({
+      project: {
+        "client_id": client,
+        "name": projectName,
+        "billable": projectType === "Billable"
+      }
+    }).then(() => {
+      navigate(0);
+      setShowProjectModal(false);
+    });
+  };
+
+  return (
+    <div className="modal__modal main-modal" style={{ background: "rgba(29, 26, 49,0.6)" }}>
+      <div className="modal__container modal-container">
+        <div className="modal__content modal-content">
+          <div className="modal__position">
+            <h6 className="modal__title"> Add New Project </h6>
+            <div className="modal__close">
+              <button
+                className="modal__button"
+                onClick={() => {
+                  setShowProjectModal(false);
+                }}
+              >
+                <X size={15} color="#CDD6DF" />
+              </button>
+            </div>
+          </div>
+          <div className="modal__form flex-col">
+            <div className="mt-4">
+              <div className="field">
+                <div className="field_with_errors">
+                  <label className="tracking-wider block text-xs font-normal text-miru-dark-purple-1000">
+                    Client
+                  </label>
+                </div>
+                <div className="mt-1">
+                  <select
+                    defaultValue={client}
+                    className="rounded border-0 block w-full px-2 py-1 bg-miru-gray-100 h-8 font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base"
+                    onChange={(e) => setClient(e.target.value)}>
+                    <option value='0'>Select Client</option>
+                    <option value={clientDetails.id}>{clientDetails.name}</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div className="mt-4">
+              <div className="field">
+                <div className="field_with_errors">
+                  <label className="tracking-wider block text-xs font-normal text-miru-dark-purple-1000">
+                    Project Name
+                  </label>
+                </div>
+                <div className="mt-1">
+                  <input type="text" placeholder=" Enter Project Name" className="rounded appearance-none border-0 block w-full px-3 py-2 bg-miru-gray-100 h-8 font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base" value={projectName} onChange={(e) => setProjectName(e.target.value)} />
+                </div>
+              </div>
+            </div>
+            <div className="mt-4">
+              <div className="field">
+                <label className="tracking-wider block text-xs font-normal text-miru-dark-purple-1000">Project Type</label>
+                <div className="mt-1">
+                  <div className="space-y-4 sm:flex sm:items-center sm:space-y-0 sm:space-x-10">
+                    <div className="flex items-center">
+                      <input type="radio" id='billable' name='project_type' defaultChecked={true} className="focus:ring-miru-han-purple-1000 h-4 w-4 border-miru-han-purple-1000 text-miru-dark-purple-1000 cursor-pointer" onClick={() => setProjectType("Billable")} />
+                      <label htmlFor="billable" className="ml-3 block text-sm font-medium text-miru-dark-purple-1000">
+                        Billable
+                      </label>
+                    </div>
+
+                    <div className="flex items-center">
+                      <input type="radio" id='non-billable' name='project_type' defaultChecked={false} className="focus:ring-miru-han-purple-1000 h-4 w-4 bg--miru-han-purple-1000 border-miru-han-purple-1000 text-miru-dark-purple-1000 cursor-pointer" onClick={() => setProjectType("Non-Billable")} />
+                      <label htmlFor="non-billable" className="ml-3 block text-sm font-medium text-miru-dark-purple-1000 ">
+                        Non-billable
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="actions mt-4">
+              {client && projectName && projectType ?
+                <button type="submit" className="tracking-widest h-10 w-full flex justify-center py-1 px-4 border border-transparent shadow-sm text-base font-sans font-medium text-miru-white-1000 bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:outline-none rounded cursor-pointer" onClick={() => handleSubmit()}> ADD PROJECT </button>
+                : <button type="submit" className="tracking-widest h-10 w-full flex justify-center py-1 px-4 border border-transparent shadow-sm text-base font-sans font-medium text-miru-white-1000 bg-miru-gray-1000 focus:outline-none rounded cursor-pointer" disabled> ADD PROJECT </button>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddProject;

--- a/app/javascript/src/components/Clients/Modals/DeleteClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/DeleteClient.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import clients from "apis/clients";
 
 interface IProps {
@@ -7,11 +8,13 @@ interface IProps {
 }
 
 const DeleteClient = ({ client, setShowDeleteDialog }: IProps) => {
+
+  const navigate = useNavigate();
+
   const deleteClient = async client => {
     await clients.destroy(client.id);
-    setTimeout(() => {
-      window.location.reload();
-    }, 500);
+    setShowDeleteDialog(false);
+    window.location.pathname == "/clients" ? navigate(0) : navigate("/clients");
   };
   return (
     <div className="px-4 flex items-center justify-center">

--- a/spec/requests/internal_api/v1/clients/show_spec.rb
+++ b/spec/requests/internal_api/v1/clients/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "InternalApi::V1::Clients#show", type: :request do
       let(:time_frame) { "week" }
 
       it "returns the total hours logged for a client in that week" do
-        client_details = { id: client_1.id, name: client_1.name, email: client_1.email }
+        client_details = { id: client_1.id, name: client_1.name, email: client_1.email, address: client_1.address }
         project_details = client_1.project_details(time_frame)
         total_minutes = (project_details.map { |project| project[:minutes_spent] }).sum
         overdue_outstanding_amount = client_1.client_overdue_and_outstanding_calculation


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Admin-should-be-able-to-add-a-new-project-edit-delete-a-client-from-a-the-client-details-page-676c9b3a6897458c97c45a3f3618f847
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

-Admin can add project
-Delete client
-Edit client from client details page.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/793e49e2b1a746f4bdd809e863a3aa91

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code

