### PR TITLE
resolved cash formatter issue

### DIFF
--- a/app/javascript/src/helpers/cashFormater.ts
+++ b/app/javascript/src/helpers/cashFormater.ts
@@ -1,9 +1,9 @@
 const cashFormatter = (num: number, digits = 2) => {
-  if (!num) return "0.00k";
+  if (!num) return "0.00";
   const units = ["k", "M", "G", "T", "P", "E", "Z", "Y"];
   const floor = Math.floor(Math.abs(num).toString().length / 3);
   const value = +(num / Math.pow(1000, floor));
-  const currency = units[floor - 1] ? units[floor - 1] : "k";
+  const currency = units[floor - 1] ? units[floor - 1] : "";
   return value.toFixed(value > 1 ? digits : 2) + currency;
 };
 


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Fix-the-overdue-and-oustanding-amount-displayed-on-the-client-details-page-31856b5d1ac140efb34b6f7a8377740c

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
Two issues:-
- For undefined condition instead of returning amount in K format, the amount is now showing as 0.00
- For amount less than 1000 i.e. 10 previously it was showing as 10.00 K but now it will show as 10.00 so no misguiding will be there.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://user-images.githubusercontent.com/104751221/172842971-9703e148-edb7-42dc-aab3-e58f3eb77634.mp4

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->
Manually tested against condition ranging from 0 - 1 M.

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
