### PR TITLE
Email Verification Window - Backend

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -3,14 +3,11 @@
 class EmailConfirmationsController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_authorized
+  before_action :verify_confirmed_user
 
   def show
-    if user.confirmed?
-      redirect_to root_path
-    else
-      resend_url = resend_email_confirmation_path({ email: user.email })
-      render :show, locals: { user:, resend_url: }
-    end
+    resend_url = resend_email_confirmation_path({ email: user.email })
+    render :show, locals: { user:, resend_url: }
   end
 
   def resend
@@ -20,6 +17,12 @@ class EmailConfirmationsController < ApplicationController
   end
 
   private
+
+    def verify_confirmed_user
+      if user.confirmed?
+        redirect_to root_path
+      end
+    end
 
     def user
       @_user ||= User.kept.find_by_email!(params[:email])

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -8,13 +8,20 @@ class EmailConfirmationsController < ApplicationController
     if user.confirmed?
       redirect_to root_path
     else
-      render json: { user: }
+      resend_url = resend_email_confirmation_path({ email: user.email })
+      render :show, locals: { user:, resend_url: }
     end
+  end
+
+  def resend
+    user.send_confirmation_instructions
+    flash[:notice] = t("confirmation.send_instructions", email: user.email)
+    redirect_to new_user_session_path
   end
 
   private
 
     def user
-      @_user ||= User.kept.find_by_email(params[:email])
+      @_user ||= User.kept.find_by_email!(params[:email])
     end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class EmailConfirmationsController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_after_action :verify_authorized
+
+  def show
+    if user.confirmed?
+      redirect_to root_path
+    else
+      render json: { user: }
+    end
+  end
+
+  private
+
+    def user
+      @_user ||= User.kept.find_by_email(params[:email])
+    end
+end

--- a/app/views/email_confirmations/show.html.erb
+++ b/app/views/email_confirmations/show.html.erb
@@ -1,0 +1,4 @@
+<br/>
+<br/>
+<h1><%= user.email %></h1>
+<a href="<%= resend_url %>">resend</a>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -327,10 +327,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
     signup_with_google: sign up with google
     signup_with_apple: sign up with apple
     signin_with_google: sign in with google
+  confirmation:
+    send_instructions: "A confirmation email has been sent to %{email}."
   shared_links:
     already_have_an_account: already have an account?
     dont_have_an_account: don't have an account?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,9 @@ Rails.application.routes.draw do
   get "subscriptions/*path", to: "subscriptions#index", via: :all
   resources :subscriptions, only: [:index]
 
-  resource :email_confirmation, only: :show
+  resource :email_confirmation, only: :show do
+    get :resend
+  end
 
   devise_scope :user do
     get "profile", to: "users/registrations#edit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,8 @@ Rails.application.routes.draw do
   get "subscriptions/*path", to: "subscriptions#index", via: :all
   resources :subscriptions, only: [:index]
 
+  resource :email_confirmation, only: :show
+
   devise_scope :user do
     get "profile", to: "users/registrations#edit"
     get "profile/edit", to: "users/registrations#edit"

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -5,8 +5,7 @@ class CustomFailure < Devise::FailureApp
   def redirect_url
     if warden_message == :unconfirmed
       email = params[:user][:email]
-      puts email
-      false
+      email_confirmation_path({ email: })
     else
       super
     end

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Override Devise::FailureApp
+class CustomFailure < Devise::FailureApp
+  def redirect_url
+    if warden_message == :unconfirmed
+      email = params[:user][:email]
+      puts email
+      false
+    else
+      super
+    end
+  end
+
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+end

--- a/spec/requests/email_confirmations/resend_spec.rb
+++ b/spec/requests/email_confirmations/resend_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "EmailConfirmationsController", type: :request do
+  let(:user) { create(:user) }
+
+  describe "GET #resend" do
+    context "when user is not confirmed" do
+      before do
+        user.update(confirmed_at: nil)
+      end
+
+      it "sent confirmation instructions" do
+        get resend_email_confirmation_path(email: user.email)
+
+        expect(Devise::Mailer.deliveries.count).to eq 1
+        expect(flash[:notice]).to eq(
+          I18n.t("confirmation.send_instructions", email: user.email)
+        )
+      end
+
+      it "redirects to new_user_session_path" do
+        get resend_email_confirmation_path(email: user.email)
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when user is already confirmed" do
+      before do
+        user.confirm
+      end
+
+      it "redirects to root_path" do
+        get resend_email_confirmation_path(email: user.email)
+
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end

--- a/spec/requests/email_confirmations/show_spec.rb
+++ b/spec/requests/email_confirmations/show_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "EmailConfirmationsController", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user) }
+
+  describe "GET show" do
+    context "when user is not confirmed" do
+      before do
+        user.update(confirmed_at: nil)
+        get email_confirmation_path(email: user.email)
+      end
+
+      it "renders email confirmation page" do
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context "when user is confirmed" do
+      before do
+        user.update(confirmed_at: Time.zone.now)
+        get email_confirmation_path(email: user.email)
+      end
+
+      it "redirects to root path" do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when user is not found" do
+      before do
+        get email_confirmation_path(email: "invalid")
+      end
+
+      it "responds with :not_found" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Notion card
REF: [https://www.notion.so/saeloun/Once-the-user-signs-up-email-verification-window-shou[…]e-displayed-as-per-the-design-aeef4cccf92042c4bca82023aa68e9c9](https://www.notion.so/saeloun/Once-the-user-signs-up-email-verification-window-should-be-displayed-as-per-the-design-aeef4cccf92042c4bca82023aa68e9c9)

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Earlier the routing for Unconfirmed User was handled directly by Devise
- Override Device:FailureApp to add custom handler 
- the Verification Screen will be replace with a React component as per the Design in a Separate PR.


## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/cc2059d3a80f4c459426a948aa637533

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
