### PR TITLE
Redirect to email verification window

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,7 +22,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
 
     def after_inactive_sign_up_path_for(resource)
-      set_flash_message! :notice, :signed_up_but_unconfirmed
-      new_user_session_path
+      email = resource.email
+      email_confirmation_path({ email: })
     end
 end

--- a/app/javascript/src/components/EmailVerification/index.tsx
+++ b/app/javascript/src/components/EmailVerification/index.tsx
@@ -1,14 +1,21 @@
-import React from "react";
+import React, { useEffect, useCallback } from "react";
 
 const miruLogo = require("../../../../assets/images/miru-logo.svg"); //eslint-disable-line
 
 const EmailVerification = ({ userEmail }) => {
 
-  document.addEventListener("keydown", function (event) {
+  const handleKeyPress = useCallback((event) => {
     if (event.key === "Escape") {
       location.assign(window.location.origin + "/users/sign_in");
     }
-  });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyPress);
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [handleKeyPress]);
 
   return (
     <div className="modal__modal bg-miru-dark-purple-1000 flex-col justify-start pt-32">

--- a/app/javascript/src/components/EmailVerification/index.tsx
+++ b/app/javascript/src/components/EmailVerification/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const miruLogo = require("../../../../assets/images/miru-logo.svg"); //eslint-disable-line
+
+const EmailVerification = () => (
+  <div className="modal__modal bg-miru-dark-purple-1000 flex-col justify-start pt-32">
+    <img src={miruLogo} width="64px" height="64px" />
+    <div className="modal__container modal-container mt-10">
+      <div className="modal__content text-center">
+        <h6 className="modal__title ">Email Verification</h6>
+        <div className="modal__form flex-col">
+          <h3 className="my-6 font-sm font-normal text-center leading-4 text-miru-dark-purple-1000">
+              Verification link has been sent to your email ID:
+            <br />
+            <h3 className="font-sm font-bold text-center leading-4 text-miru-dark-purple-1000">
+                john.smith@saeloun.com
+            </h3>
+          </h3>
+
+          <h3 className="font-xs font-normal text-center leading-4 text-miru-dark-purple-1000">
+              Didn’t recieve verification link? <a className="font-bold text-miru-han-purple-1000 underline">Resend</a>
+          </h3>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default EmailVerification;

--- a/app/javascript/src/components/EmailVerification/index.tsx
+++ b/app/javascript/src/components/EmailVerification/index.tsx
@@ -2,28 +2,40 @@ import React from "react";
 
 const miruLogo = require("../../../../assets/images/miru-logo.svg"); //eslint-disable-line
 
-const EmailVerification = () => (
-  <div className="modal__modal bg-miru-dark-purple-1000 flex-col justify-start pt-32">
-    <img src={miruLogo} width="64px" height="64px" />
-    <div className="modal__container modal-container mt-10">
-      <div className="modal__content text-center">
-        <h6 className="modal__title ">Email Verification</h6>
-        <div className="modal__form flex-col">
-          <h3 className="my-6 font-sm font-normal text-center leading-4 text-miru-dark-purple-1000">
-              Verification link has been sent to your email ID:
-            <br />
-            <h3 className="font-sm font-bold text-center leading-4 text-miru-dark-purple-1000">
-                john.smith@saeloun.com
-            </h3>
-          </h3>
+const EmailVerification = ({ userEmail }) => {
 
-          <h3 className="font-xs font-normal text-center leading-4 text-miru-dark-purple-1000">
-              Didn’t recieve verification link? <a className="font-bold text-miru-han-purple-1000 underline">Resend</a>
-          </h3>
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      location.assign(window.location.origin + "/users/sign_in");
+    }
+  });
+
+  return (
+    <div className="modal__modal bg-miru-dark-purple-1000 flex-col justify-start pt-32">
+      <img src={miruLogo} width="64px" height="64px" />
+      <div className="modal__container modal-container mt-10">
+        <div className="modal__content text-center">
+          <h6 className="modal__title ">Email Verification</h6>
+          <div className="modal__form flex-col">
+            <h3 className="my-6 font-sm font-normal text-center leading-4 text-miru-dark-purple-1000">
+              Verification link has been sent to your email ID:
+              <br />
+              <h3 className="font-sm font-bold text-center leading-4 text-miru-dark-purple-1000">
+                {userEmail}
+              </h3>
+            </h3>
+
+            <h3 className="font-xs font-normal text-center leading-4 text-miru-dark-purple-1000">
+              Didn’t recieve verification link?{" "}
+              <a className="font-bold text-miru-han-purple-1000 underline cursor-pointer">
+                Resend
+              </a>
+            </h3>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default EmailVerification;

--- a/app/views/email_confirmations/show.html.erb
+++ b/app/views/email_confirmations/show.html.erb
@@ -1,4 +1,3 @@
-<br/>
-<br/>
-<h1><%= user.email %></h1>
-<a href="<%= resend_url %>">resend</a>
+<div>
+  <%= react_component("EmailVerification", {userEmail: user.email , resendUrl: resend_url }) %>
+</div>

--- a/spec/requests/users/registrations/create_spec.rb
+++ b/spec/requests/users/registrations/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Users::RegistrationsController#create", type: :request do
       user_params = {
         first_name: "First name",
         last_name: "Last name",
-        email: "sam@example.com",
+        email:,
         password: "testing!@",
         password_confirmation: "testing!@"
       }
@@ -19,7 +19,7 @@ RSpec.describe "Users::RegistrationsController#create", type: :request do
       message = "A message with a confirmation link has been sent to your email address. " \
                 "Please follow the link to activate your account."
       expect(flash[:notice]).to eq(message)
-      expect(response).to redirect_to(new_user_session_path)
+      expect(response).to redirect_to(email_confirmation_path({ email: }))
     end
   end
 end

--- a/spec/requests/users/registrations/create_spec.rb
+++ b/spec/requests/users/registrations/create_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe "Users::RegistrationsController#create", type: :request do
   describe "after_inactive_sign_up_path_for" do
+    let(:email) { "sam@example.com" }
+
     before do
       user_params = {
         first_name: "First name",


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Once-the-user-signs-up-email-verification-window-should-be-displayed-as-per-the-design-aeef4cccf92042c4bca82023aa68e9c9
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Email verification window design 
- Redirecting to email verification window after sign up
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://www.loom.com/share/e3043ed8e72a41649d53f83da7fa2c92
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
