### PR TITLE
Creates devices table and associations

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -31,6 +31,7 @@ class Company < ApplicationRecord
   has_many :invoices, through: :clients
   has_one :stripe_connected_account, dependent: :destroy
   has_many :payments_providers, dependent: :destroy
+  has_many :devices, dependent: :destroy
   resourcify
 
   # Validations

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: devices
+#
+#  id             :bigint           not null, primary key
+#  device_type    :string           default("laptop")
+#  model          :string
+#  serial_number  :string
+#  specifications :jsonb
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  company_id     :bigint           not null
+#  user_id        :bigint           not null
+#
+# Indexes
+#
+#  index_devices_on_company_id  (company_id)
+#  index_devices_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Device < ApplicationRecord
+  # associations
+  belongs_to :issued_by, class_name: "Company", foreign_key: "company_id"
+  belongs_to :issued_to, class_name: "User", foreign_key: "user_id"
+
+  # device type values
+  enum device_type: { laptop: "laptop", mobile: "mobile" }
+
+  # specifications values
+  store_accessor :specifications, :processor, :ram, :graphics
+
+  # validations
+  after_initialize :set_default_specifications, if: :new_record?
+  validates :model, length: { maximum: 100 }
+
+  private
+
+    def set_default_specifications
+      self.specifications = {
+        "processor": "",
+        "ram": "",
+        "graphics": ""
+      }
+    end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,17 +25,17 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Device < ApplicationRecord
-  # associations
+  # Associations
   belongs_to :issued_by, class_name: "Company", foreign_key: "company_id"
   belongs_to :issued_to, class_name: "User", foreign_key: "user_id"
 
-  # device type values
+  # Device type values
   enum device_type: { laptop: "laptop", mobile: "mobile" }
 
-  # specifications values
+  # Specifications values
   store_accessor :specifications, :processor, :ram, :graphics
 
-  # validations
+  # Validations
   after_initialize :set_default_specifications, if: :new_record?
   validates :model, length: { maximum: 100 }
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -6,7 +6,7 @@
 #
 #  id             :bigint           not null, primary key
 #  device_type    :string           default("laptop")
-#  model          :string
+#  name           :string
 #  serial_number  :string
 #  specifications :jsonb
 #  created_at     :datetime         not null
@@ -37,7 +37,7 @@ class Device < ApplicationRecord
 
   # Validations
   after_initialize :set_default_specifications, if: :new_record?
-  validates :model, length: { maximum: 100 }
+  validates :name, length: { maximum: 100 }
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ApplicationRecord
   has_one :wise_account, dependent: :destroy
   has_many :previous_employments, dependent: :destroy
   has_one_attached :avatar
+  has_many :devices, dependent: :destroy
   rolify strict: true
 
   # Social account details
@@ -124,5 +125,5 @@ class User < ApplicationRecord
         "github_url": "",
         "linkedin_url": ""
       }
-  end
+    end
 end

--- a/db/migrate/20220621054843_create_devices.rb
+++ b/db/migrate/20220621054843_create_devices.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateDevices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :devices do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :company, null: false, foreign_key: true
+      t.string :device_type, default: "laptop"
+      t.string :model
+      t.string :serial_number
+      t.jsonb :specifications
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220621150746_change_column_name_in_devices.rb
+++ b/db/migrate/20220621150746_change_column_name_in_devices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnNameInDevices < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :devices, :model, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_054843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "devices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "company_id", null: false
+    t.string "device_type", default: "laptop"
+    t.string "model"
+    t.string "serial_number"
+    t.jsonb "specifications"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_devices_on_company_id"
+    t.index ["user_id"], name: "index_devices_on_user_id"
   end
 
   create_table "employment_details", force: :cascade do |t|
@@ -214,7 +227,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
     t.bigint "user_id", null: false
     t.bigint "project_id", null: false
     t.float "duration", null: false
-    t.text "note"
+    t.text "note", default: ""
     t.date "work_date", null: false
     t.integer "bill_status", null: false
     t.datetime "created_at", null: false
@@ -291,6 +304,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
   add_foreign_key "clients", "companies"
   add_foreign_key "company_users", "companies"
   add_foreign_key "company_users", "users"
+  add_foreign_key "devices", "companies"
+  add_foreign_key "devices", "users"
   add_foreign_key "employment_details", "company_users"
   add_foreign_key "identities", "users"
   add_foreign_key "invoice_line_items", "invoices"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,7 +227,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_150746) do
     t.bigint "user_id", null: false
     t.bigint "project_id", null: false
     t.float "duration", null: false
-    t.text "note", default: ""
+    t.text "note"
     t.date "work_date", null: false
     t.integer "bill_status", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_21_054843) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_150746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,7 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_054843) do
     t.bigint "user_id", null: false
     t.bigint "company_id", null: false
     t.string "device_type", default: "laptop"
-    t.string "model"
+    t.string "name"
     t.string "serial_number"
     t.jsonb "specifications"
     t.datetime "created_at", null: false
@@ -227,7 +227,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_054843) do
     t.bigint "user_id", null: false
     t.bigint "project_id", null: false
     t.float "duration", null: false
-    t.text "note"
+    t.text "note", default: ""
     t.date "work_date", null: false
     t.integer "bill_status", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,7 +227,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_054843) do
     t.bigint "user_id", null: false
     t.bigint "project_id", null: false
     t.float "duration", null: false
-    t.text "note", default: ""
+    t.text "note"
     t.date "work_date", null: false
     t.integer "bill_status", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :device do
+    issued_to factory: :user
+    issued_by factory: :company
+    model { Faker::Alphanumeric.alphanumeric }
+    serial_number { Faker::Number.number(digits: 100) }
+  end
+end

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :device do
     issued_to factory: :user
     issued_by factory: :company
-    model { Faker::Alphanumeric.alphanumeric }
+    name { Faker::Alphanumeric.alphanumeric }
     serial_number { Faker::Number.number(digits: 100) }
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Company, type: :model do
     it { is_expected.to have_many(:projects).through(:clients).dependent(:destroy) }
     it { is_expected.to have_one_attached(:logo) }
     it { is_expected.to have_many(:current_workspace_users).dependent(:nullify) }
+    it { is_expected.to have_many(:devices).dependent(:destroy) }
   end
 
   describe "Validations" do

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe Device, type: :model do
         expect(device.device_type).to eq("laptop")
       end
     end
+
+    describe "Enums" do
+      it {
+  expect(subject).to define_enum_for(:device_type).with_values(
+    laptop: "laptop",
+    mobile: "mobile").backed_by_column_of_type(:string)
+}
+    end
   end
 end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Device, type: :model do
     end
 
     describe "Length" do
-      it { is_expected.to validate_length_of(:model).is_at_most(100) }
+      it { is_expected.to validate_length_of(:name).is_at_most(100) }
     end
 
     describe "Defaults" do

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Device, type: :model do
+  let(:device) { create(:device) }
+
+  describe "Validations" do
+    describe "Associations" do
+      it { is_expected.to belong_to(:issued_by) }
+      it { is_expected.to belong_to(:issued_to) }
+    end
+
+    describe "Length" do
+      it { is_expected.to validate_length_of(:model).is_at_most(100) }
+    end
+
+    describe "Defaults" do
+      it "default specifications to be empty strings" do
+        expect(device.specifications["processor"]).to eq("")
+        expect(device.specifications["ram"]).to eq("")
+        expect(device.specifications["graphics"]).to eq("")
+      end
+
+      it "default device_type to be laptop" do
+        expect(device.device_type).to eq("laptop")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:timesheet_entries) }
     it { is_expected.to have_many(:previous_employments).dependent(:destroy) }
     it { is_expected.to have_one_attached(:avatar) }
+    it { is_expected.to have_many(:devices).dependent(:destroy) }
   end
 
   describe "Validations" do


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Add-tables-for-personal-employment-Allocated-devices-Address-71ef49d0c38e4242bd2998120141372d

## Summary
1. Created devices table.
2. Added reference of User and Company with aliases issued_to and issued_by.
3. Added Validations
4. Added RSpecs
5. Updated RSpecs for User and Company.

## Preview
![Employee Details Schema-updated](https://user-images.githubusercontent.com/5313625/174801263-21ac5236-3020-4a25-9f29-8f9574256073.png)


## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

On Rails console as well as RSpecs Test run.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
