### PR TITLE
Use slice instead of fetch-values

### DIFF
--- a/app/services/report/result.rb
+++ b/app/services/report/result.rb
@@ -29,7 +29,7 @@ module Report
         buckets = es_response.aggs["grouped_reports"]["buckets"]
         buckets.map do |bucket|
           timesheet_entry_ids = bucket["top_report_hits"]["hits"]["hits"].pluck("_id")
-          timesheet_entries = id_to_timesheet_entry.fetch_values(*timesheet_entry_ids)
+          timesheet_entries = id_to_timesheet_entry.slice(*timesheet_entry_ids).values
           {
             label: group_label(timesheet_entries.first, bucket["key_as_string"]),
             entries: timesheet_entries


### PR DESCRIPTION
## Notion card

## Summary
We are getting following error on prod.

> KeyError key not found: "417"
> path="/internal_api/v1/reports" 
> Parameters: {"group_by"=>"team_member"} 

FetchValues raises exception if doesn't find any key. Used slice instead of it.
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
