### PR TITLE
Creates addresses table and associations

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: addresses
+#
+#  id               :bigint           not null, primary key
+#  address_line_1   :string           not null
+#  address_line_2   :string
+#  address_type     :string
+#  addressable_type :string
+#  city             :string           not null
+#  country          :string           not null
+#  pin              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  addressable_id   :bigint
+#
+# Indexes
+#
+#  index_addresses_on_addressable                   (addressable_type,addressable_id)
+#  index_addresses_on_addressable_and_address_type  (addressable_type,addressable_id,address_type) UNIQUE
+#
+class Address < ApplicationRecord
+  # Associations
+  belongs_to :addressable, polymorphic: true
+
+  # Addresss type values
+  enum address_type: { current: "current", permanent: "permanent" }
+
+  # Validations
+  validates :address_type, :address_line_1, :city, :country, :pin, presence: true
+  validates :address_type, uniqueness: { scope: [ :addressable_id, :addressable_type ] }
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -31,6 +31,7 @@ class Company < ApplicationRecord
   has_many :invoices, through: :clients
   has_one :stripe_connected_account, dependent: :destroy
   has_many :payments_providers, dependent: :destroy
+  has_many :addresses, as: :addressable, dependent: :destroy
   resourcify
 
   # Validations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ApplicationRecord
   has_one :wise_account, dependent: :destroy
   has_many :previous_employments, dependent: :destroy
   has_one_attached :avatar
+  has_many :addresses, as: :addressable, dependent: :destroy
   rolify strict: true
 
   # Social account details

--- a/db/migrate/20220621130413_create_addresses.rb
+++ b/db/migrate/20220621130413_create_addresses.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.references :addressable, polymorphic: true
+      t.string :address_type
+      t.string :address_line_1, null: false
+      t.string :address_line_2
+      t.string :city, null: false
+      t.string :country, null: false
+      t.string :pin, null: false
+      t.index [ :addressable_type, :addressable_id, :address_type ], unique: true, name: "index_addresses_on_addressable_and_address_type"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_150746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "addressable_type"
+    t.bigint "addressable_id"
+    t.string "address_type"
+    t.string "address_line_1", null: false
+    t.string "address_line_2"
+    t.string "city", null: false
+    t.string "country", null: false
+    t.string "pin", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["addressable_type", "addressable_id", "address_type"],
+      name: "index_addresses_on_addressable_and_address_type", unique: true
+    t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
   end
 
   create_table "clients", force: :cascade do |t|
@@ -86,6 +102,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "devices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "company_id", null: false
+    t.string "device_type", default: "laptop"
+    t.string "name"
+    t.string "serial_number"
+    t.jsonb "specifications"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_devices_on_company_id"
+    t.index ["user_id"], name: "index_devices_on_user_id"
   end
 
   create_table "employment_details", force: :cascade do |t|
@@ -291,6 +320,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_20_122048) do
   add_foreign_key "clients", "companies"
   add_foreign_key "company_users", "companies"
   add_foreign_key "company_users", "users"
+  add_foreign_key "devices", "companies"
+  add_foreign_key "devices", "users"
   add_foreign_key "employment_details", "company_users"
   add_foreign_key "identities", "users"
   add_foreign_key "invoice_line_items", "invoices"

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :address do
+    with_user
+    address_type { Address.address_types.keys.sample }
+    address_line_1 { Faker::Address.full_address }
+    address_line_2 { Faker::Address.full_address }
+    city { Faker::Address.city }
+    country { Faker::Address.country }
+    pin { Faker::Address.postcode }
+
+    trait :with_company do
+      association(:addressable, factory: :company)
+    end
+
+    trait :with_user do
+      association(:addressable, factory: :user)
+    end
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Address, type: :model do
+  subject { build(:address) }
+
+  describe "Associations" do
+    it "has a polymorphic relationship" do
+      expect(subject).to belong_to(:addressable)
+    end
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of(:address_type) }
+    it { is_expected.to validate_presence_of(:address_line_1) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:country) }
+    it { is_expected.to validate_presence_of(:pin) }
+    it { is_expected.to validate_uniqueness_of(:address_type).scoped_to(:addressable_id, :addressable_type) }
+  end
+
+  describe "Enums" do
+    it {
+  expect(subject).to define_enum_for(:address_type).with_values(
+    current: "current",
+    permanent: "permanent").backed_by_column_of_type(:string)
+}
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Company, type: :model do
     it { is_expected.to have_many(:projects).through(:clients).dependent(:destroy) }
     it { is_expected.to have_one_attached(:logo) }
     it { is_expected.to have_many(:current_workspace_users).dependent(:nullify) }
+    it { is_expected.to have_many(:addresses).dependent(:destroy) }
   end
 
   describe "Validations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:project_members).dependent(:destroy) }
     it { is_expected.to have_many(:timesheet_entries) }
     it { is_expected.to have_many(:previous_employments).dependent(:destroy) }
+    it { is_expected.to have_many(:addresses).dependent(:destroy) }
     it { is_expected.to have_one_attached(:avatar) }
   end
 


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Add-tables-for-personal-employment-Allocated-devices-Address-71ef49d0c38e4242bd2998120141372d

## Summary
1. Created addresses table with columns(address_line_1, address_line_2, city, country, pin, address_type and addressable).
2. Addressable can be referenced by user_id and company_id
3. Created Address model and updated associations to User and Company.
4. Created RSpecs.
5. Tested manually on console.

## Preview
![Emp-details updated 22June](https://user-images.githubusercontent.com/5313625/174965115-f3590c15-f813-4400-a04f-904211448ef0.png)


## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
With RSpecs and on the console.

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
