### PR TITLE
Rename company_users as employments

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -20,8 +20,8 @@
 
 class Company < ApplicationRecord
   # Associations
-  has_many :company_users, dependent: :destroy
-  has_many :users, through: :company_users
+  has_many :employments, dependent: :destroy
+  has_many :users, through: :employments
   has_many :timesheet_entries, through: :users
   has_many :clients, dependent: :destroy
   has_many :projects, through: :clients, dependent: :destroy

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: company_users
+# Table name: employments
 #
 #  id              :bigint           not null, primary key
 #  designation     :string
@@ -18,9 +18,9 @@
 #
 # Indexes
 #
-#  index_company_users_on_company_id    (company_id)
-#  index_company_users_on_discarded_at  (discarded_at)
-#  index_company_users_on_user_id       (user_id)
+#  index_employments_on_company_id    (company_id)
+#  index_employments_on_discarded_at  (discarded_at)
+#  index_employments_on_user_id       (user_id)
 #
 # Foreign Keys
 #
@@ -28,7 +28,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 
-class CompanyUser < ApplicationRecord
+class Employment < ApplicationRecord
   include Discard::Model
 
   # Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,8 +56,8 @@ class User < ApplicationRecord
   include Discard::Model
 
   # Associations
-  has_many :company_users, dependent: :destroy
-  has_many :companies, through: :company_users
+  has_many :employments, dependent: :destroy
+  has_many :companies, through: :employments
   has_many :project_members, dependent: :destroy
   has_many :timesheet_entries
   has_many :identities, dependent: :delete_all

--- a/db/migrate/20220622163255_change_company_users_table_name_to_employments.rb
+++ b/db/migrate/20220622163255_change_company_users_table_name_to_employments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeCompanyUsersTableNameToEmployments < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :company_users, :employments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_22_160123) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_06_22_163255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,22 +91,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_160123) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "company_users", force: :cascade do |t|
-    t.bigint "company_id", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "discarded_at"
-    t.string "employee_id"
-    t.string "designation"
-    t.string "employment_type"
-    t.date "joined_at"
-    t.date "resigned_at"
-    t.index ["company_id"], name: "index_company_users_on_company_id"
-    t.index ["discarded_at"], name: "index_company_users_on_discarded_at"
-    t.index ["user_id"], name: "index_company_users_on_user_id"
-  end
-
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
@@ -122,6 +105,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_160123) do
     t.datetime "updated_at", null: false
     t.index ["company_id"], name: "index_devices_on_company_id"
     t.index ["user_id"], name: "index_devices_on_user_id"
+  end
+
+  create_table "employments", force: :cascade do |t|
+    t.bigint "company_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.string "employee_id"
+    t.string "designation"
+    t.string "employment_type"
+    t.date "joined_at"
+    t.date "resigned_at"
+    t.index ["company_id"], name: "index_employments_on_company_id"
+    t.index ["discarded_at"], name: "index_employments_on_discarded_at"
+    t.index ["user_id"], name: "index_employments_on_user_id"
   end
 
   create_table "identities", force: :cascade do |t|
@@ -314,10 +313,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_160123) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clients", "companies"
-  add_foreign_key "company_users", "companies"
-  add_foreign_key "company_users", "users"
   add_foreign_key "devices", "companies"
   add_foreign_key "devices", "users"
+  add_foreign_key "employments", "companies"
+  add_foreign_key "employments", "users"
   add_foreign_key "identities", "users"
   add_foreign_key "invoice_line_items", "invoices"
   add_foreign_key "invoice_line_items", "timesheet_entries"

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :company_user do
+  factory :employment do
     company
     user
     employee_id { Faker::Alphanumeric.alphanumeric(number: 10, min_alpha: 3) }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Company, type: :model do
   subject { create(:company) }
 
   describe "Associations" do
-    it { is_expected.to have_many(:users).through(:company_users) }
-    it { is_expected.to have_many(:company_users).dependent(:destroy) }
+    it { is_expected.to have_many(:users).through(:employments) }
+    it { is_expected.to have_many(:employments).dependent(:destroy) }
     it { is_expected.to have_many(:clients).dependent(:destroy) }
     it { is_expected.to have_many(:projects).through(:clients).dependent(:destroy) }
     it { is_expected.to have_one_attached(:logo) }
@@ -58,8 +58,8 @@ RSpec.describe Company, type: :model do
     end
 
     before do
-      create(:company_user, company_id: company.id, user_id: user_1.id)
-      create(:company_user, company_id: company.id, user_id: user_2.id)
+      create(:employment, company_id: company.id, user_id: user_1.id)
+      create(:employment, company_id: company.id, user_id: user_2.id)
       create(:project_member, user_id: user_1.id, project_id: project_1.id)
       create(:project_member, user_id: user_1.id, project_id: project_2.id)
       create(:project_member, user_id: user_2.id, project_id: project_1.id)

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Employment, type: :model do
+  let(:employment) { create(:employment) }
+  let(:company) { employment.company }
+  let(:user) { employment.user }
+
+  describe "Associations" do
+    it { is_expected.to belong_to(:company) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_one(:employment_detail) }
+  end
+
+  describe "Discard" do
+    let(:company_user) { create(:company_user) }
+    let(:company) { company_user.company }
+    let(:user) { company_user.user }
+
+    it "discards the company user" do
+      expect { employment.discard! }.to change(company.employments.discarded, :count).by(1)
+      expect(employment.reload.discarded?).to be_truthy
+      expect(user.reload.employments.discarded.count).to eq(1)
+    end
+
+    it "does not discard the company user if already discarded" do
+      employment.discard!
+      expect { employment.discard! }.to raise_error(Discard::RecordNotDiscarded)
+    end
+  end
+
+  describe "Presence" do
+    it { is_expected.to validate_presence_of(:designation) }
+    it { is_expected.to validate_presence_of(:employment_type) }
+    it { is_expected.to validate_presence_of(:joined_at) }
+    it { is_expected.to validate_presence_of(:employee_id) }
+  end
+
+  describe "Comparisons" do
+    it "resignation date should be nil by default" do
+      expect(employment.resigned_at).to be nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe User, type: :model do
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   before do
-    create(:company_user, company:, user:)
+    create(:employment, company:, user:)
   end
 
   describe "Associations" do
-    it { is_expected.to have_many(:companies).through(:company_users) }
-    it { is_expected.to have_many(:company_users).dependent(:destroy) }
+    it { is_expected.to have_many(:companies).through(:employments) }
+    it { is_expected.to have_many(:employments).dependent(:destroy) }
     it { is_expected.to have_many(:identities).dependent(:delete_all) }
     it { is_expected.to have_many(:project_members).dependent(:destroy) }
     it { is_expected.to have_many(:timesheet_entries) }


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Add-tables-for-personal-employment-Allocated-devices-Address-71ef49d0c38e4242bd2998120141372d

## Summary

1. Renamed table company_users as employments
2. Updated Model file name and replaced company_user instances with employment
3. Updated reference name in User and Company model
4. Updated RSpecs- Employment, User and Company
5. Update all instances of company_user


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

On Rails console and manually.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
