### PR TITLE
Amount in project detail page will have company default currency symbol

### DIFF
--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -32,6 +32,7 @@ const getTableData = (project) => {
       const hours = member.minutes / 60;
       const hour = hours.toFixed(2);
       const cost = (hours * parseInt(member.hourlyRate)).toFixed(2);
+      const currencySymb = currencySymbol(member.currency);
       return {
         col1: (
           <div className="text-base text-miru-dark-purple-1000">
@@ -40,7 +41,7 @@ const getTableData = (project) => {
         ),
         col2: (
           <div className="text-base text-miru-dark-purple-1000 text-right">
-            ${member.hourlyRate}
+            {currencySymb}{member.hourlyRate}
           </div>
         ),
         col3: (
@@ -50,7 +51,7 @@ const getTableData = (project) => {
         ),
         col4: (
           <div className="text-lg font-bold text-miru-dark-purple-1000 text-right">
-            ${cost}
+            {currencySymb}{cost}
           </div>
         )
       };

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -31,8 +31,6 @@ const getTableData = (project) => {
     return project.members.map((member) => {
       const hours = member.minutes / 60;
       const hour = hours.toFixed(2);
-      const cost = (hours * parseInt(member.hourlyRate)).toFixed(2);
-      const currencySymb = currencySymbol(member.currency);
       return {
         col1: (
           <div className="text-base text-miru-dark-purple-1000">
@@ -41,7 +39,7 @@ const getTableData = (project) => {
         ),
         col2: (
           <div className="text-base text-miru-dark-purple-1000 text-right">
-            {currencySymb}{member.hourlyRate}
+            {member.formattedHourlyRate}
           </div>
         ),
         col3: (
@@ -51,7 +49,7 @@ const getTableData = (project) => {
         ),
         col4: (
           <div className="text-lg font-bold text-miru-dark-purple-1000 text-right">
-            {currencySymb}{cost}
+            {member.formattedCost}
           </div>
         )
       };

--- a/app/javascript/src/mapper/project.mapper.ts
+++ b/app/javascript/src/mapper/project.mapper.ts
@@ -3,7 +3,8 @@ const getMember = (input:any) => input.map((elem) => ({
   hourlyRate: elem.hourly_rate,
   id: elem.id,
   minutes: elem.minutes_logged,
-  name: elem.name
+  name: elem.name,
+  currency: elem.currency
 }));
 
 export const unmapper = (data:any = {}) => ({

--- a/app/javascript/src/mapper/project.mapper.ts
+++ b/app/javascript/src/mapper/project.mapper.ts
@@ -1,10 +1,10 @@
 
 const getMember = (input:any) => input.map((elem) => ({
-  hourlyRate: elem.hourly_rate,
+  formattedHourlyRate: elem.formatted_hourly_rate,
   id: elem.id,
   minutes: elem.minutes_logged,
   name: elem.name,
-  currency: elem.currency
+  formattedCost: elem.formatted_cost
 }));
 
 export const unmapper = (data:any = {}) => ({

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -107,13 +107,13 @@ class Project < ApplicationRecord
     }
   end
 
+  def format_amount(amount)
+    FormatAmountService.new(client.company.base_currency, amount).process
+  end
+
   private
 
     def discard_project_members
       project_members.discard_all
-    end
-
-    def format_amount(amount)
-      FormatAmountService.new(client.company.base_currency, amount).process
     end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,19 +53,21 @@ class Project < ApplicationRecord
         {
           id: member.user_id,
           name: member.full_name,
-          hourly_rate: member.hourly_rate,
+          formatted_hourly_rate: format_amount(member.hourly_rate),
           minutes_logged: 0,
-          currency: client.company.base_currency
+          formatted_cost: format_amount(0)
         }
       end
     else
       entries.map do |entry|
+        hourly_rate = members[entry.user_id]
+        cost = (entry.duration / 60) * hourly_rate
         {
           id: entry.user_id,
           name: entry.user.full_name,
-          hourly_rate: members[entry.user_id],
+          formatted_hourly_rate: format_amount(hourly_rate),
           minutes_logged: entry.duration,
-          currency: client.company.base_currency
+          formatted_cost: format_amount(cost)
         }
       end
     end
@@ -109,5 +111,9 @@ class Project < ApplicationRecord
 
     def discard_project_members
       project_members.discard_all
+    end
+
+    def format_amount(amount)
+      FormatAmountService.new(client.company.base_currency, amount).process
     end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,7 +54,8 @@ class Project < ApplicationRecord
           id: member.user_id,
           name: member.full_name,
           hourly_rate: member.hourly_rate,
-          minutes_logged: 0
+          minutes_logged: 0,
+          currency: client.company.base_currency
         }
       end
     else
@@ -63,7 +64,8 @@ class Project < ApplicationRecord
           id: entry.user_id,
           name: entry.user.full_name,
           hourly_rate: members[entry.user_id],
-          minutes_logged: entry.duration
+          minutes_logged: entry.duration,
+          currency: client.company.base_currency
         }
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -40,7 +40,16 @@ RSpec.describe Project, type: :model do
       let(:time_frame) { "last_week" }
 
       it "returns data with 0 values" do
-        expect(subject).to eq([{ id: member.user_id, name: user.full_name, hourly_rate: 5000, minutes_logged: 0 }])
+        expect(subject).to eq(
+          [
+                    {
+                      id: member.user_id,
+                      name: user.full_name,
+                      hourly_rate: 5000,
+                      minutes_logged: 0,
+                      currency: company.base_currency
+                    }
+                  ])
       end
     end
 
@@ -49,6 +58,7 @@ RSpec.describe Project, type: :model do
 
       it "returns the project_team_member_details for a project in the last week" do
         create(:timesheet_entry, user:, project:, work_date: Date.today.last_week)
+        result.first[:currency] = company.base_currency
         expect(subject).to eq(result)
       end
     end
@@ -58,6 +68,7 @@ RSpec.describe Project, type: :model do
 
       it "returns the project_team_member_details for a project in a week" do
         create(:timesheet_entry, user:, project:, work_date: Date.today)
+        result.first[:currency] = company.base_currency
         expect(subject).to eq(result)
       end
     end
@@ -67,6 +78,7 @@ RSpec.describe Project, type: :model do
 
       it "returns the project_team_member_details for a project in a month" do
         create(:timesheet_entry, user:, project:, work_date: Date.today.next_week)
+        result.first[:currency] = company.base_currency
         expect(subject).to eq(result)
       end
     end
@@ -76,6 +88,7 @@ RSpec.describe Project, type: :model do
 
       it "returns the project_team_member_details for a project in a year" do
         create(:timesheet_entry, user:, project:, work_date: Date.today.last_month)
+        result.first[:currency] = company.base_currency
         expect(subject).to eq(result)
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Project, type: :model do
             name: user.full_name,
             formatted_hourly_rate:,
             minutes_logged: 0,
-            formatted_cost: format_amount(company.base_currency, 0)
+            formatted_cost: project.format_amount(0)
           }])
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe Project, type: :model do
         timesheet_entry = create(:timesheet_entry, user:, project:, work_date: Date.today.last_week)
         result.first[:formatted_hourly_rate] = formatted_hourly_rate
         cost = (timesheet_entry.duration / 60) * member.hourly_rate
-        result.first[:formatted_cost] = format_amount(company.base_currency, cost)
+        result.first[:formatted_cost] = project.format_amount(cost)
         expect(subject).to eq(result)
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Project, type: :model do
         timesheet_entry = create(:timesheet_entry, user:, project:, work_date: Date.today.at_beginning_of_week)
         result.first[:formatted_hourly_rate] = formatted_hourly_rate
         cost = (timesheet_entry.duration / 60) * member.hourly_rate
-        result.first[:formatted_cost] = format_amount(company.base_currency, cost)
+        result.first[:formatted_cost] = project.format_amount(cost)
         expect(subject).to eq(result)
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe Project, type: :model do
         timesheet_entry = create(:timesheet_entry, user:, project:, work_date: Date.today.at_beginning_of_month)
         result.first[:formatted_hourly_rate] = formatted_hourly_rate
         cost = (timesheet_entry.duration / 60) * member.hourly_rate
-        result.first[:formatted_cost] = format_amount(company.base_currency, cost)
+        result.first[:formatted_cost] = project.format_amount(cost)
         expect(subject).to eq(result)
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Project, type: :model do
         timesheet_entry = create(:timesheet_entry, user:, project:, work_date: Date.today.beginning_of_year)
         result.first[:formatted_hourly_rate] = formatted_hourly_rate
         cost = (timesheet_entry.duration / 60) * member.hourly_rate
-        result.first[:formatted_cost] = format_amount(company.base_currency, cost)
+        result.first[:formatted_cost] = project.format_amount(cost)
         expect(subject).to eq(result)
       end
     end
@@ -226,9 +226,5 @@ RSpec.describe Project, type: :model do
         expect(overdue_and_outstanding_amounts[:outstanding_amount]).to eq(outstanding_amount)
       end
     end
-  end
-
-  def format_amount(currency, amount)
-    FormatAmountService.new(currency, amount).process
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -41,15 +41,13 @@ RSpec.describe Project, type: :model do
 
       it "returns data with 0 values" do
         expect(subject).to eq(
-          [
-                    {
-                      id: member.user_id,
-                      name: user.full_name,
-                      hourly_rate: 5000,
-                      minutes_logged: 0,
-                      currency: company.base_currency
-                    }
-                  ])
+          [{
+            id: member.user_id,
+            name: user.full_name,
+            hourly_rate: 5000,
+            minutes_logged: 0,
+            currency: company.base_currency
+          }])
       end
     end
 


### PR DESCRIPTION
## Notion card

https://www.notion.so/saeloun/Team-member-hourly-rate-currency-bug-080f697e4cef4cab9bbd0f10add3570b

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

On the project detail page, the amount displayed against each team member will have the company's default currency symbol before it.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

<img width="1791" alt="Screenshot 2022-06-28 at 12 18 54 PM" src="https://user-images.githubusercontent.com/52308930/176112268-7a1cab33-7bdd-426b-99b4-31239751f136.png">

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [X] I have manually tested all workflows
- [X] I have performed a self-review of my own code
- [X] I have added automated tests for my code
