### PR TITLE
Create seed files for new employee details tables

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -7,7 +7,7 @@
 #  id               :bigint           not null, primary key
 #  address_line_1   :string           not null
 #  address_line_2   :string
-#  address_type     :string
+#  address_type     :string           default("current")
 #  addressable_type :string
 #  city             :string           not null
 #  country          :string           not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@
 #  last_name              :string           not null
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
+#  phone                  :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/db/migrate/20220703091224_add_phone_number_to_users.rb
+++ b/db/migrate/20220703091224_add_phone_number_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPhoneNumberToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :phone, :string
+  end
+end

--- a/db/migrate/20220704070130_add_default_address_type_to_addresses.rb
+++ b/db/migrate/20220704070130_add_default_address_type_to_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultAddressTypeToAddresses < ActiveRecord::Migration[7.0]
+  def change
+    change_column :addresses, :address_type, :string, default: "current"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_03_091224) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_04_070130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,7 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_03_091224) do
   create_table "addresses", force: :cascade do |t|
     t.string "addressable_type"
     t.bigint "addressable_id"
-    t.string "address_type"
+    t.string "address_type", default: "current"
     t.string "address_line_1", null: false
     t.string "address_line_2"
     t.string "city", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_24_121802) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_03_091224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -276,6 +276,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_24_121802) do
     t.string "personal_email_id"
     t.date "date_of_birth"
     t.jsonb "social_accounts"
+    t.string "phone"
     t.index ["current_workspace_id"], name: "index_users_on_current_workspace_id"
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds/10_addresses.rb
+++ b/db/seeds/10_addresses.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Address Start
+address =
+  {
+    address_type: "current",
+    address_line_1: "Saeloun India Pvt. Ltd",
+    address_line_2: "403, Sky Vista, Viman Nagar",
+    city: "Pune",
+    state: "Maharashtra",
+    country: "India",
+    pin: "411014"
+  }
+
+# Create Address for Companies
+@companies.each { | company | company.addresses.create!(address) }
+
+# Create Address for Users
+@users.each { | user | user.addresses.create!(address) }
+
+puts "Address Created"
+# Address End

--- a/db/seeds/11_devices.rb
+++ b/db/seeds/11_devices.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Devices Start
+device =
+  {
+    device_type: "laptop",
+    name: "MacBook Pro",
+    serial_number: "1234567890",
+    specifications:
+          {
+            ram: "32GB",
+            graphics: "Intel UHD Graphics 630",
+            processor: "Intel Core i7"
+          },
+    company_id: 1
+  }
+
+# Create Devices for Users
+@users.each { | user | user.devices.create!(device) }
+
+puts "Device Created"
+# Device End

--- a/db/seeds/12_previous_employment.rb
+++ b/db/seeds/12_previous_employment.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Previous Employment Start
+previous_employment =
+  {
+    company_name: "XYZ",
+    role: "SDE"
+  }
+
+# Create Previous Employment for Users
+@users.each { | user | user.previous_employments.create!(previous_employment) }
+
+puts "Previous Employment Created"
+# Previous Employment End

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :address do
-    address_type { Address.address_types.keys.sample }
     address_line_1 { Faker::Address.full_address }
     address_line_2 { Faker::Address.full_address }
     state { Faker::Address.state }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe Address, type: :model do
       ).backed_by_column_of_type(:string)
     end
   end
+
+  describe "Defaults" do
+     it "default address_type to be current" do
+       expect(subject.address_type).to eq("current")
+     end
+   end
 end


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Create-APIs-to-add-and-view-personal-details-for-a-user-e312e4f0ceb849fda5f14eb05f8b2cf3

## Summary

1. Created seed files for new tables- **addresses**, **devices** & **previous_employments**
2. Added column- "phone" to the **users** table.
3. Set default "**address_type**" to "current"


## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on local rails console and with RSpecs

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
