### PR TITLE
Bug/close add line item box on edit page

### DIFF
--- a/app/javascript/src/components/Invoices/Edit/InvoiceTable.tsx
+++ b/app/javascript/src/components/Invoices/Edit/InvoiceTable.tsx
@@ -54,7 +54,7 @@ const InvoiceTable = ({
   };
 
   useOutsideClick(wrapperRef, () => {
-    setAddNew(addNew);
+    setAddNew(false);
   }, addNew);
 
   return (


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/The-add-line-item-box-is-not-closing-on-edit-invoice-page-96af1beddb8f40acae4612ff890e78b3
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

- Admin/Owner can now close the add line item box on edit invoice

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/b5794a2ecf92462c8181e9eadfb97ee3

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code

