### PR TITLE
owner can access new client button

### DIFF
--- a/app/views/clients/index.html.erb
+++ b/app/views/clients/index.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-6xl mx-auto px-2 md:px-11 font-manrope" x-data="{ 'isDialogOpen': <%= keep_new_client_dialog_open %> }" @keydown.escape="isDialogOpen = false">
   <div>
   <%= react_component("Clients/RouteConfig", {
-    isAdminUser: current_user.has_role?(:book_keeper, current_user.current_workspace) || current_user.has_role?(:admin, current_user.current_workspace)
+    isAdminUser: current_user.has_role?(:owner, current_user.current_workspace) || current_user.has_role?(:book_keeper, current_user.current_workspace) || current_user.has_role?(:admin, current_user.current_workspace)
     }) %>
   </div>
 </div>


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Add-new-client-button-not-showing-when-no-clients-are-present-012178159d6a4672a9849a83cc0bef3f

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Owner can now access add new client button and client details page
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
![ownerAccess](https://user-images.githubusercontent.com/72149587/177706007-7716fd3d-aa15-4adb-973d-3806ed34a568.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
