### PR TITLE
Fixed the decimal issue in manual line item

### DIFF
--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -32,5 +32,5 @@ class InvoiceLineItem < ApplicationRecord
 
   validates :name, :date, :rate, :quantity, presence: true
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
-  validates :quantity, numericality: { only_integer: true, greater_than: 0 }
+  validates :quantity, numericality: { greater_than: 0 }
 end

--- a/spec/models/invoice_line_item_spec.rb
+++ b/spec/models/invoice_line_item_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InvoiceLineItem, type: :model do
     end
 
     describe "validate numericality of" do
-      it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0).only_integer }
+      it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
       it { is_expected.to validate_numericality_of(:rate).is_greater_than_or_equal_to(0) }
     end
   end

--- a/spec/requests/internal_api/v1/invoices/create_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/create_spec.rb
@@ -17,12 +17,23 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
     end
 
     describe "invoice creation" do
-      it "creates invoice successfully" do
-        invoice = attributes_for(
+      let(:invoice) {
+        attributes_for(
           :invoice,
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft)
+          status: :draft,
+          invoice_line_item: {
+            name: "Test",
+            description: "test description",
+            data: Faker::Date.in_date_period,
+            rate: 12.4,
+            quantity: 34.54
+          }
+        )
+      }
+
+      it "creates invoice successfully" do
         send_request :post, internal_api_v1_invoices_path(invoice:)
         expect(response).to have_http_status(:ok)
         expected_attrs = ["amount", "amountDue", "amountPaid",
@@ -58,7 +69,14 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
           :invoice,
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft
+          status: :draft,
+          invoice_line_item: {
+            name: "Test",
+            description: "test description",
+            data: Faker::Date.in_date_period,
+            rate: 12.4,
+            quantity: 34.54
+          }
         )
       )
     end
@@ -78,7 +96,14 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
           :invoice,
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft
+          status: :draft,
+          invoice_line_item: {
+            name: "Test",
+            description: "test description",
+            data: Faker::Date.in_date_period,
+            rate: 12.4,
+            quantity: 34.54
+          }
         )
       )
     end


### PR DESCRIPTION
## Notion card

https://www.notion.so/saeloun/Backend-Number-of-hours-should-allow-decimal-values-on-manual-entry-64e29983400644c2a4740de0c7a5602c

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

Removed the validation constrain in line item `quantity` attribute.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/564efd3f02de40d2a607a76309a72054

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [X] I have manually tested all workflows
- [X] I have performed a self-review of my own code
- [X] I have added automated tests for my code
