### PR TITLE
API integration for create manual entry and invoice list

### DIFF
--- a/app/javascript/src/apis/payments/payments.ts
+++ b/app/javascript/src/apis/payments/payments.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+const path = "/payments";
+
+const get = async () => axios.get(`${path}`);
+
+const create = async (payload) => axios.post(`${path}`, payload);
+
+const show = async (id, queryParam) => axios.get(`${path}/${id}${queryParam}`);
+
+const update = async (id, payload) => axios.patch(`${path}/${id}`, payload);
+
+const destroy = async id => axios.delete(`${path}/${id}`);
+
+const getInvoiceList = () => axios.get(`${path}/new`);
+
+const payments = { update, destroy, get, show, create, getInvoiceList };
+
+export default payments;

--- a/app/javascript/src/apis/payments/payments.ts
+++ b/app/javascript/src/apis/payments/payments.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const path = "/payments";
 
-const get = async () => axios.get(`${path}`);
+const get = () => axios.get(`${path}`);
 
 const create = async (payload) => axios.post(`${path}`, payload);
 

--- a/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
+++ b/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
@@ -43,7 +43,6 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceList }) => {
         note
       });
       await payment.create(sanitized);
-
       Toastr.success("Manual entry added successfully.");
       setInvoice("");
       setTransactionDate("");

--- a/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
+++ b/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
@@ -1,35 +1,65 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState } from "react";
 import Select, { DropdownIndicatorProps, components } from "react-select";
+import payment from "apis/payments/payments";
 import CustomDatePicker from "common/CustomDatePicker";
+import Toastr from "common/Toastr";
 import dayjs from "dayjs";
+
 import { X, Calendar } from "phosphor-react";
 import { MagnifyingGlass } from "phosphor-react";
+import { mapPayment } from "../../../mapper/payment.mapper";
 
-const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
+const AddManualEntry = ({ setShowManualEntryModal, invoiceList }) => {
   const [invoice, setInvoice] = useState<any>(null);
-  const [transcationDate, setTranscationDate] = useState<any>(null);
-  const [transcationType, setTranscationType] = useState<any>(null);
+  const [transactionDate, setTransactionDate] = useState<any>(null);
+  const [transactionType, setTransactionType] = useState<any>(null);
   const [amount, setAmount] = useState<any>(null);
+  const [note, setNote] = useState<any>(null);
   const [showDatePicker, setShowDatePicker] = useState<any>(false);
   const [isOpen, setOpen] = useState<any>(false);
 
-  const transcationTypes = [
-    "Visa",
-    "Mastercard",
-    "Bank Transfer",
-    "ACH",
-    "Amex",
-    "Cash",
-    "Cheque",
-    "Credit Card",
-    "Debit",
-    "PayPal"
+  const transactionTypes = [
+    { label: "Visa", value: "visa" },
+    { label: "Mastercard", value: "mastercard" },
+    { label: "Bank Transfer", value: "bank_transfer" },
+    { label: "ACH", value: "ach" },
+    { label: "Amex", value: "amex" },
+    { label: "Cash", value: "cash" },
+    { label: "Cheque", value: "cheque" },
+    { label: "Credit Card", value: "credit_card" },
+    { label: "Debit Card", value: "debit_card" },
+    { label: "Paypal", value: "paypal" },
+    { label: "Stripe", value: "stripe" }
   ];
+
+  const handleAddPayment = async () => {
+    try {
+      const sanitized = mapPayment({
+        invoice,
+        transactionDate,
+        transactionType,
+        amount,
+        note
+      });
+      await payment.create(sanitized);
+
+      Toastr.success("Manual entry added successfully.");
+      setInvoice("");
+      setTransactionDate("");
+      setTransactionType("");
+      setAmount("");
+      setNote("");
+      setShowManualEntryModal(false);
+
+    } catch (err) {
+      Toastr.error("Failed to add manual entry");
+    }
+  };
 
   const handleDatePicker = (date) => {
     const formattedDate = dayjs(date).format("DD.MM.YYYY");
-    setTranscationDate(formattedDate);
+    setTransactionDate(formattedDate);
     setShowDatePicker(false);
   };
 
@@ -81,7 +111,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
             {props.data.label}
           </h1>
           <h3 className="pt-1 font-normal text-sm text-miru-dark-purple-400 leading-5">
-            {props.data.number}
+            {props.data.invoiceNumber}
           </h3>
         </div>
         <div className="px-6 py-2.5 text-left">
@@ -89,7 +119,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
             {props.data.amount}
           </h1>
           <h3 className="pt-1 font-normal text-sm text-miru-dark-purple-400 leading-5">
-            {props.data.date}
+            {props.data.invoiceDate}
           </h3>
         </div>
         <div className="pl-6 pr-0 py-2.5 text-sm font-semibold tracking-wider leading-4 text-right">
@@ -133,7 +163,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
                     onMenuClose={() => setOpen(false)}
                     defaultValue={null}
                     onChange={handleInvoiceSelect}
-                    options={invoiceOptions}
+                    options={invoiceList.invoiceList}
                     placeholder="Search by client name or invoice ID"
                     isSearchable={true}
                     className="m-0 mt-2 w-full font-medium text-miru-dark-purple-1000 border-0"
@@ -152,7 +182,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
               <div className="field">
                 <div className="field_with_errors">
                   <label className="tracking-wider block text-xs font-normal text-miru-dark-purple-1000">
-                    Transcation Date
+                    Transaction Date
                   </label>
                 </div>
                 <div
@@ -164,7 +194,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
                     disabled
                     placeholder="DD.MM.YYYY"
                     className="rounded appearance-none border-0 block w-full px-3 py-2 bg-miru-gray-100 h-8 font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base"
-                    value={transcationDate}
+                    value={transactionDate}
                   />
                   <Calendar
                     size={20}
@@ -174,7 +204,7 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
                   {showDatePicker && (
                     <CustomDatePicker
                       handleChange={handleDatePicker}
-                      dueDate={transcationDate}
+                      dueDate={transactionDate}
                     />
                   )}
                 </div>
@@ -185,13 +215,13 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
               <div className="field">
                 <div className="field_with_errors">
                   <label className="tracking-wider block text-xs font-normal text-miru-dark-purple-1000">
-                    Transcation Type
+                    Transaction Type
                   </label>
                 </div>
                 <div className="mt-1">
                   <select
                     className="rounded border-0 block w-full px-2 py-1 bg-miru-gray-100 h-8 font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base"
-                    onChange={(e) => setTranscationType(e.target.value)}
+                    onChange={(e) => setTransactionType(e.target.value)}
                   >
                     <option
                       value=""
@@ -202,7 +232,9 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
                     >
                       Select
                     </option>
-                    {transcationTypes.map((type) => <option value={type}>{type}</option>)}
+                    {transactionTypes.map((type) => (
+                      <option value={type.value}>{type.label}</option>
+                    ))}
                   </select>
                 </div>
               </div>
@@ -236,7 +268,8 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
                 <div className="mt-1">
                   <textarea
                     rows={3}
-                    placeholder="Payment Amount"
+                    onChange={(e) => setNote(e.target.value)}
+                    placeholder="Note"
                     className="rounded appearance-none border-0 block w-full px-3 py-2 bg-miru-gray-100 font-medium text-sm text-miru-dark-purple-1000 focus:outline-none sm:text-base"
                   />
                 </div>
@@ -244,8 +277,9 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceOptions }) => {
             </div>
 
             <div className="actions mt-4">
-              {invoice && transcationDate && transcationType && amount ? (
+              {invoice && transactionDate && transactionType && amount ? (
                 <button
+                  onClick={handleAddPayment}
                   type="submit"
                   className="tracking-widest h-10 w-full flex justify-center py-1 px-4 border border-transparent shadow-sm text-base font-sans font-medium text-miru-white-1000 bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:outline-none rounded cursor-pointer"
                 >

--- a/app/javascript/src/components/payments/index.tsx
+++ b/app/javascript/src/components/payments/index.tsx
@@ -1,14 +1,34 @@
-import React from "react";
+import React, { useState } from "react";
+import { setAuthHeaders, registerIntercepts } from "apis/axios";
+import payment from "apis/payments/payments";
 import Pagination from "common/Pagination";
+import Logger from "js-logger";
+
 import Header from "./Header";
 import AddManualEntry from "./Modals/AddManualEntry";
 import Table from "./Table/index";
+import { unmapPayment } from "../../mapper/payment.mapper";
 
 const Payments = () => {
 
   const [showManualEntryModal, setShowManualEntryModal] = React.useState<boolean>(false);
+  const [invoiceList, setInvoiceList] = useState<any>([]);
 
-  const invoiceOptions = [];
+  const fetchInvoiceList = async () => {
+    try {
+      const res = await payment.getInvoiceList();
+      const sanitzed = await unmapPayment(res.data);
+      setInvoiceList(sanitzed);
+    } catch (err) {
+      Logger.error(err);
+    }
+  };
+
+  React.useEffect(() => {
+    setAuthHeaders();
+    registerIntercepts();
+    fetchInvoiceList();
+  }, []);
 
   const payments = [
     {
@@ -114,7 +134,7 @@ const Payments = () => {
         setParams=""
       />
       {
-        showManualEntryModal && <AddManualEntry setShowManualEntryModal={setShowManualEntryModal} invoiceOptions={invoiceOptions}/>
+        showManualEntryModal && <AddManualEntry setShowManualEntryModal={setShowManualEntryModal} invoiceList={invoiceList} />
       }
     </div>
   );

--- a/app/javascript/src/mapper/interface.ts
+++ b/app/javascript/src/mapper/interface.ts
@@ -1,0 +1,8 @@
+export interface InvoiceList {
+  id: number;
+  clientName: string;
+  invoiceNumber: string;
+  invoiceDate: string;
+  amount: string;
+  status: string;
+}

--- a/app/javascript/src/mapper/payment.mapper.ts
+++ b/app/javascript/src/mapper/payment.mapper.ts
@@ -1,11 +1,4 @@
-interface InvoiceList {
-  id: number;
-  clientName: string;
-  invoiceNumber: string;
-  invoiceDate: string;
-  amount: string;
-  status: string;
-}
+import { InvoiceList } from "./interface";
 
 const getInvoiceList = (invoiceList: Array<InvoiceList>) =>
   invoiceList.map((invoice) => ({

--- a/app/javascript/src/mapper/payment.mapper.ts
+++ b/app/javascript/src/mapper/payment.mapper.ts
@@ -1,0 +1,35 @@
+interface InvoiceList {
+  id: number;
+  clientName: string;
+  invoiceNumber: string;
+  invoiceDate: string;
+  amount: string;
+  status: string;
+}
+
+const getInvoiceList = (invoiceList: Array<InvoiceList>) =>
+  invoiceList.map((invoice) => ({
+    value: invoice.id,
+    label: invoice.clientName,
+    invoiceNumber: invoice.invoiceNumber,
+    invoiceDate: invoice.invoiceDate,
+    amount: invoice.amount,
+    status: invoice.status
+  }));
+
+const unmapPayment = (input) => {
+  const invoiceList = getInvoiceList(input.invoices);
+  return {
+    invoiceList
+  };
+};
+
+const mapPayment = (input) => ({
+  invoice_id: input.invoice.value,
+  transaction_date: input.transactionDate,
+  transaction_type: input.transactionType,
+  amount: input.amount,
+  note: input.note
+});
+
+export { unmapPayment, mapPayment };


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Integration-of-API-to-be-able-to-add-manual-entry-for-payments-received-0bc6a82ead40489ebd59b736a43f352b
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- API integration for create manual entry
- API integration for invoice list in manual entry modal
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://www.loom.com/share/d3286ede32f34cc1b3d5a3d9b99c1bba
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
