### PR TITLE
Removed devise toaster from the sign up page

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -60,9 +60,7 @@ en:
       signed_up_but_locked:
         "You have signed up successfully. However, we could not sign you in
         because your account is locked."
-      signed_up_but_unconfirmed:
-        "A message with a confirmation link has been sent to your email address.
-        Please follow the link to activate your account."
+      signed_up_but_unconfirmed: ""
       update_needs_confirmation:
         "You updated your account successfully, but we need to verify your new
         email address. Please check your email and follow the confirmation link

--- a/spec/requests/users/registrations/create_spec.rb
+++ b/spec/requests/users/registrations/create_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe "Users::RegistrationsController#create", type: :request do
     end
 
     it "sets flash message to signed_up_but_unconfirmed and return new_user_session_path" do
-      message = "A message with a confirmation link has been sent to your email address. " \
-                "Please follow the link to activate your account."
-      expect(flash[:notice]).to eq(message)
       expect(response).to redirect_to(email_confirmation_path({ email: }))
     end
   end


### PR DESCRIPTION
## Notion card
https://www.notion.so/Remove-toast-message-on-new-user-Sign-up-flow-13d9652bf0674f49ad6cbee57457ac2d
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->

## Preview
https://www.loom.com/share/e84b14254d364cec9ae6cb7ed3a149f6

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
