### PR TITLE
Team page ui fixes

### DIFF
--- a/app/javascript/src/components/Team/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Team/List/Table/TableRow.tsx
@@ -28,13 +28,13 @@ const TableRow = ({ item }) => {
       <td className="table__data p-6">
         <img src={item.profilePicture} className="table__avatar" />
       </td>
-      <td className="table__data p-6">
+      <td className="table__data p-6 capitalize">
         {item.name}
       </td>
       <td className="table__data table__text p-6">
         {item.email}
       </td>
-      <td className="table__data table__text p-6">
+      <td className="table__data table__text p-6 capitalize">
         {item.role}
       </td>
       {isAdminUser &&

--- a/app/javascript/src/components/Team/modals/AddEditMember.tsx
+++ b/app/javascript/src/components/Team/modals/AddEditMember.tsx
@@ -81,7 +81,11 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
           <div className="rounded-lg px-6 pb-6 bg-white shadow-xl transform transition-all sm:align-middle sm:max-w-md modal-width">
             <div className="flex justify-between items-center mt-6">
               <h6 className="text-base font-extrabold">
-                {isEdit ? user.isTeamMember ? "Edit Member" : "Edit Invitation" : "Add Member"}
+                {isEdit
+                  ? user.isTeamMember
+                    ? "Edit User Details"
+                    : "Edit Invitation"
+                  : "Create New User"}
               </h6>
               <button
                 type="button"
@@ -98,21 +102,14 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
               onSubmit={handleSubmit}
             >
               {(props: FormikProps<FormValues>) => {
-                const { touched, errors } = props;
+                const { touched, errors, isValid, dirty } = props;
                 return (
                   <Form>
                     <div className="mt-4">
                       <div className="field">
                         <div className="field_with_errors">
                           <label className="form__label">Name</label>
-                          <div className="tracking-wider block text-xs text-red-600 flex">
-                            {errors.firstName && touched.firstName && (
-                              <div>{errors.firstName}</div>
-                            )}
-                            {errors.lastName && touched.lastName && (
-                              <div className="ml-2">{errors.lastName}</div>
-                            )}
-                          </div>
+
                         </div>
                         <div className="flex">
                           <div className="mt-1">
@@ -124,7 +121,13 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                               } `}
                               data-cy="new-member-firstName"
                               name="firstName"
+                              placeholder="First Name"
                             />
+                            <div className="tracking-wider block text-xs text-red-600 flex">
+                              {errors.firstName && touched.firstName && (
+                                <div>{errors.firstName}</div>
+                              )}
+                            </div>
                           </div>
                           <div className="mt-1 ml-8">
                             <Field
@@ -135,7 +138,14 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                               } `}
                               data-cy="new-member-lastName"
                               name="lastName"
+                              placeholder="Last Name"
+
                             />
+                            <div className="tracking-wider block text-xs text-red-600 flex">
+                              {errors.lastName && touched.lastName && (
+                                <div className="ml-2">{errors.lastName}</div>
+                              )}
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -144,11 +154,6 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                       <div className="field">
                         <div className="field_with_errors">
                           <label className="form__label">Email</label>
-                          <div className="tracking-wider block text-xs text-red-600">
-                            {errors.email && touched.email && (
-                              <div>{errors.email}</div>
-                            )}
-                          </div>
                         </div>
                         <div className="mt-1">
                           <Field
@@ -160,7 +165,13 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                             name="email"
                             disabled={isEdit}
                             data-cy="new-member-email"
+                            placeholder="Enter email ID"
                           />
+                          <div className="tracking-wider block text-xs text-red-600">
+                            {errors.email && touched.email && (
+                              <div>{errors.email}</div>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -229,13 +240,19 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                       {apiError}
                     </p>
                     <div className="actions mt-4">
-                      <input
+                      <button
                         type="submit"
                         name="commit"
-                        value={isEdit ? "SAVE CHANGES": "SEND INVITATION"}
-                        className="form__input_submit"
                         data-cy="send-invite-button"
-                      />
+                        disabled={!(dirty && isValid)}
+                        className={
+                          !isValid || !dirty
+                            ? "tracking-widest h-10 w-full flex justify-center py-1 px-4 border border-transparent shadow-sm text-base font-sans font-medium text-miru-white-1000 bg-miru-gray-1000 focus:outline-none rounded"
+                            : "form__input_submit"
+                        }
+                      >
+                        {isEdit ? "SAVE CHANGES" : "SEND INVITE"}
+                      </button>
                     </div>
                   </Form>
                 );

--- a/app/javascript/src/components/Team/modals/DeleteMember.tsx
+++ b/app/javascript/src/components/Team/modals/DeleteMember.tsx
@@ -42,7 +42,7 @@ const DeleteMember = ({ user }) => {
               </button>
             </div>
             <p className="my-8">
-              Are you sure you want to delete user {user?.name}? This action cannot be reversed.
+              Are you sure you want to delete user <b> {user?.name}</b>? This action cannot be reversed.
             </p>
             <div className="flex justify-between">
               <button


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Teams-page-fixes-bfd703fdafaa460aa8c73cb78091dc04?d=0169e67d1500466fb37ab7b64debfc2a

## Summary
- Changed header of add/edit team member as per the Figma designs.
- Added placeholders for the text fields.
- Send Invite button is to be enabled only after the user enters a valid first name, last name, and email.
- Positioned error messages below their respective fields.
- Capitalization of roles, first name, and last name.
- Save changes button on the edit modal is to be enabled only after a user makes changes in the name or role.
- Make the user name in bold on delete user modal

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
