### PR TITLE
Reduce heroku slug size

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+/spec
+/test


### PR DESCRIPTION
## Notion card

## Summary

Right now the Heroku slug size of Miru apps is nearer to 500Mb (Maximum slug size). 
![Screenshot 2022-08-25 at 9 42 38 AM](https://user-images.githubusercontent.com/22231095/186573368-8d8b1a3c-4d24-44a3-8acb-ebf3b3b0136d.png)


## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
