### PR TITLE
Hide setting panel on page load

### DIFF
--- a/app/javascript/src/components/Invoices/Generate/index.tsx
+++ b/app/javascript/src/components/Invoices/Generate/index.tsx
@@ -34,7 +34,7 @@ const GenerateInvoices = () => {
   const [selectedOption, setSelectedOption] = useState<any>([]);
   const [showSendInvoiceModal, setShowSendInvoiceModal] = useState<boolean>(false);
   const [invoiceId, setInvoiceId] = useState<number>(null);
-  const [showInvoiceSetting, setShowInvoiceSetting] = useState<boolean>(true);
+  const [showInvoiceSetting, setShowInvoiceSetting] = useState<boolean>(false);
   const [manualEntryArr, setManualEntryArr] = useState<any>([]);
 
   const fetchGenerateInvoice = async (navigate, getInvoiceDetails) => {


### PR DESCRIPTION
## Notion card

https://www.notion.so/saeloun/The-payment-settings-panel-should-not-be-opened-automatically-on-clickin-new-invoice-button-93e7f72902e444f0b216e8ebdc07b871

## Summary
Don't show the invoice settings side panel when page loads

## Preview
https://www.loom.com/share/1d191c42b1f14647aa869699aee05d3f

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
