### PR TITLE
Change color of paid status

### DIFF
--- a/app/javascript/src/utils/getStatusTag.ts
+++ b/app/javascript/src/utils/getStatusTag.ts
@@ -7,7 +7,7 @@ const getStatusCssClass = (status) => {
     billed: "bg-miru-alert-green-400 text-miru-alert-green-800",
     unbilled: "bg-miru-alert-yellow-400 text-miru-alert-green-1000",
     nonbilled: "bg-miru-dark-purple-100 text-miru-dark-purple-600",
-    paid: "bg-miru-alert-green-400 text-miru-alert-green-800"
+    paid: "bg-miru-han-purple-100 text-miru-han-purple-1000"
   };
   const lowerCaseStatus = status.toLowerCase();
   return `rounded-xl text-xs tracking-widest font-semibold px-1 ${STATUS_LIST[lowerCaseStatus]}`;


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Change-the-color-code-of-the-paid-status-on-invoice-page-08816e8defc54eaeb7cb239e17687049
## Summary
Changed background and text color of paid invoice status

## Preview

<img width="1792" alt="Screenshot 2022-08-31 at 5 08 52 PM" src="https://user-images.githubusercontent.com/18750194/187670065-6b1a2a08-7758-4fae-abb3-d41cf414ff49.png">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
