### PR TITLE
Redirected user if 403 error received

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -64,7 +64,7 @@ module ErrorHandler
       respond_to do |format|
         format.json {
           render json: {
-            error: exception.record.errors.full_messages.first,
+            errors: exception.record.errors.full_messages.first,
             notice: I18n.t("client.update.failure.message")
           },
             status: :unprocessable_entity

--- a/app/javascript/src/apis/axios.ts
+++ b/app/javascript/src/apis/axios.ts
@@ -33,7 +33,7 @@ const handleSuccessResponse = response => {
 
 const handleErrorResponse = error => {
   Toastr.error(
-    error.response?.data?.error ||
+    error.response?.data?.errors ||
     error.response?.data?.notice ||
     error.message ||
     error.notice ||

--- a/app/javascript/src/components/Clients/Details/index.tsx
+++ b/app/javascript/src/components/Clients/Details/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { TOASTER_DURATION } from "constants/index";
 
+import Logger from "js-logger";
 import { useParams, useNavigate } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
@@ -79,7 +80,7 @@ const ClientList = ({ isAdminUser }) => {
         setOverDueOutstandingAmt(sanitized.overdueOutstandingAmount);
       })
       .catch((e) => {
-        console.log(e); // eslint-disable-line
+        Logger.error(e);
         navigate("/clients");
       });
   };

--- a/app/javascript/src/components/Clients/Details/index.tsx
+++ b/app/javascript/src/components/Clients/Details/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { TOASTER_DURATION } from "constants/index";
 
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
 import { setAuthHeaders, registerIntercepts } from "apis/axios";
@@ -44,6 +44,7 @@ const ClientList = ({ isAdminUser }) => {
   const [overdueOutstandingAmount, setOverDueOutstandingAmt]= useState<any>(null);
 
   const params = useParams();
+  const navigate = useNavigate();
 
   const handleEditClick = (id) => {
     setShowEditDialog(true);
@@ -76,6 +77,10 @@ const ClientList = ({ isAdminUser }) => {
         setProjectDetails(sanitized.projectDetails);
         setTotalMinutes(sanitized.totalMinutes);
         setOverDueOutstandingAmt(sanitized.overdueOutstandingAmount);
+      })
+      .catch((e) => {
+        console.log(e); // eslint-disable-line
+        navigate("/clients");
       });
   };
 

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -50,6 +50,7 @@ const ProjectDetails = () => {
       setOverDueOutstandingAmt(sanitized.overdueOutstandingAmount);
     } catch (e) {
       console.log(e); // eslint-disable-line
+      navigate("/projects");
     }
   };
 

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 
+import Logger from "js-logger";
 import {
   ArrowLeft,
   DotsThreeVertical,
@@ -49,7 +50,7 @@ const ProjectDetails = () => {
       setProject(sanitized);
       setOverDueOutstandingAmt(sanitized.overdueOutstandingAmount);
     } catch (e) {
-      console.log(e); // eslint-disable-line
+      Logger.error(e);
       navigate("/projects");
     }
   };

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
     client_policy:
       create?: You are not authorized to create client.
       update?: You are not authorized to update client.
+      show?: You are not authorized to access the page. Please reach out to your administrator for help.
     company_policy:
       new?: You are not authorized to create new company.
       create?: You are not authorized to create company.
@@ -234,6 +235,7 @@ en:
       index?: You are not authorized to view dashboard.
     project_policy:
       create?: You are not authorized to create project.
+      show?: You are not authorized to access the page. Please reach out to your administrator for help.
     team_policy:
       edit?: You are not authorized to edit team.
       update?: You are not authorized to update team.

--- a/spec/requests/internal_api/v1/clients/create_spec.rb
+++ b/spec/requests/internal_api/v1/clients/create_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "InternalApi::V1::Client#create", type: :request do
             address: "Somewhere on Earth"
           })
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(json_response["error"]).to eq("Name can't be blank")
+        expect(json_response["errors"]).to eq("Name can't be blank")
       end
     end
   end

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
       end
 
       it "will fail" do
-        expect(json_response["error"]).to eq("Name can't be blank")
+        expect(json_response["errors"]).to eq("Name can't be blank")
       end
 
       it "will not be created" do
@@ -106,7 +106,7 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
         end
 
         it "will fail" do
-          expect(json_response["error"]).to eq("Name can't be blank")
+          expect(json_response["errors"]).to eq("Name can't be blank")
         end
 
         it "will not be created" do

--- a/spec/requests/internal_api/v1/companies/update_spec.rb
+++ b/spec/requests/internal_api/v1/companies/update_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "InternalApi::V1::Companies::update", type: :request do
       end
 
       it "will fail" do
-        expect(json_response["error"]).to eq("Standard price can't be blank")
+        expect(json_response["errors"]).to eq("Standard price can't be blank")
       end
 
       it "will not be created" do

--- a/spec/requests/internal_api/v1/invitations/create_spec.rb
+++ b/spec/requests/internal_api/v1/invitations/create_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "InternalApi::V1::Invitations#create", type: :request do
 
       it "return error message" do
         expect(json_response["notice"]).to eq("Failed to saved changes")
-        expect(json_response["error"]).to eq("First name is invalid")
+        expect(json_response["errors"]).to eq("First name is invalid")
       end
 
       it "doesn't create invitation record" do
@@ -85,7 +85,7 @@ RSpec.describe "InternalApi::V1::Invitations#create", type: :request do
 
       it "return error message" do
         expect(json_response["notice"]).to eq("Failed to saved changes")
-        expect(json_response["error"]).to eq("Recipient email is invalid")
+        expect(json_response["errors"]).to eq("Recipient email is invalid")
       end
 
       it "doesn't create invitation record" do
@@ -146,7 +146,7 @@ RSpec.describe "InternalApi::V1::Invitations#create", type: :request do
 
       it "return error message" do
         expect(json_response["notice"]).to eq("Failed to saved changes")
-        expect(json_response["error"]).to eq("First name is invalid")
+        expect(json_response["errors"]).to eq("First name is invalid")
       end
 
       it "doesn't create invitation record" do
@@ -176,7 +176,7 @@ RSpec.describe "InternalApi::V1::Invitations#create", type: :request do
 
       it "return error message" do
         expect(json_response["notice"]).to eq("Failed to saved changes")
-        expect(json_response["error"]).to eq("Recipient email is invalid")
+        expect(json_response["errors"]).to eq("Recipient email is invalid")
       end
 
       it "doesn't create invitation record" do
@@ -206,7 +206,7 @@ RSpec.describe "InternalApi::V1::Invitations#create", type: :request do
 
       it "return error message" do
         expect(json_response["notice"]).to eq("Failed to saved changes")
-        expect(json_response["error"]).to eq("Role can't be blank")
+        expect(json_response["errors"]).to eq("Role can't be blank")
       end
 
       it "doesn't create invitation record" do

--- a/spec/requests/internal_api/v1/projects/create_spec.rb
+++ b/spec/requests/internal_api/v1/projects/create_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# config/database.ymo frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Project#create", type: :request do
@@ -31,7 +33,7 @@ RSpec.describe "InternalApi::V1::Project#create", type: :request do
             billable: false
           })
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(json_response["error"]).to eq("Client must exist")
+        expect(json_response["errors"]).to eq("Client must exist")
       end
     end
   end

--- a/spec/requests/internal_api/v1/projects/show_spec.rb
+++ b/spec/requests/internal_api/v1/projects/show_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "InternalApi::V1::Projects#show", type: :request do
       create(:employment, company:, user:)
       user.add_role :admin, company
       sign_in user
-      create_list(:timesheet_entry, 5, user:, project:)
       send_request :get, internal_api_v1_project_path(project)
     end
 
@@ -45,13 +44,13 @@ RSpec.describe "InternalApi::V1::Projects#show", type: :request do
       create(:employment, company:, user:)
       user.add_role :employee, company
       sign_in user
-      create_list(:timesheet_entry, 5, user:, project:)
       send_request :get, internal_api_v1_project_path(project)
     end
 
     it "is not permitted to view project details" do
       send_request :get, internal_api_v1_project_path(project)
       expect(response).to have_http_status(:forbidden)
+      expect(json_response["errors"]).to eq I18n.t("pundit.project_policy.show?")
     end
   end
 
@@ -60,13 +59,13 @@ RSpec.describe "InternalApi::V1::Projects#show", type: :request do
       create(:employment, company:, user:)
       user.add_role :book_keeper, company
       sign_in user
-      create_list(:timesheet_entry, 5, user:, project:)
       send_request :get, internal_api_v1_project_path(project)
     end
 
     it "is not permitted to view project details" do
       send_request :get, internal_api_v1_project_path(project)
       expect(response).to have_http_status(:forbidden)
+      expect(json_response["errors"]).to eq I18n.t("pundit.project_policy.show?")
     end
   end
 

--- a/spec/requests/internal_api/v1/projects/update_spec.rb
+++ b/spec/requests/internal_api/v1/projects/update_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "InternalApi::V1::Project#update", type: :request do
             }
           })
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(json_response["error"]).to eq("Client must exist")
+        expect(json_response["errors"]).to eq("Client must exist")
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: sudeeptarlekar <sudeeptarlekar@gmail.com>

## Notion card
https://www.notion.so/saeloun/Employees-shouldn-t-be-able-to-access-the-project-detail-page-ced94d36a30644edb7a0108aa24ab845


## Summary
Redirect user back to index pages if error returned by Apis.

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on local setup, with employee record in database

### Checklist:

- [ x ] I have manually tested all workflows
- [ x ] I have performed a self-review of my own code