### PR TITLE
Fixed invoice time entries hourly value along with invoice pdf

### DIFF
--- a/app/javascript/src/components/Clients/Details/index.tsx
+++ b/app/javascript/src/components/Clients/Details/index.tsx
@@ -14,6 +14,7 @@ import AddEditProject from "components/Projects/Modals/AddEditProject";
 import DeleteProject from "components/Projects/Modals/DeleteProject";
 import { cashFormatter } from "helpers/cashFormater";
 import { currencySymbol } from "helpers/currencySymbol";
+import { minutesToHHMM } from "helpers/hhmm-parser";
 import { sendGAPageView } from "utils/googleAnalytics";
 
 import Header from "./Header";
@@ -22,15 +23,12 @@ import { unmapClientDetails } from "../../../mapper/client.mapper";
 
 const getTableData = (clients) => {
   if (clients) {
-    return clients.map((client) => {
-      const hours = (client.minutes/60).toFixed(2);
-      return {
-        col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
-        col2: <div className="text-base text-miru-dark-purple-1000">{client.team.map(member => <span>{member},&nbsp;</span>)}</div>,
-        col3: <div className="text-base text-miru-dark-purple-1000 text-right">{hours}</div>,
-        rowId: client.id
-      };
-    });
+    return clients.map((client) => ({
+      col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
+      col2: <div className="text-base text-miru-dark-purple-1000">{client.team.map(member => <span>{member},&nbsp;</span>)}</div>,
+      col3: <div className="text-base text-miru-dark-purple-1000 text-right">{minutesToHHMM(client.minutes)}</div>,
+      rowId: client.id
+    }));
   }
   return [{}];
 };

--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -12,6 +12,7 @@ import ChartBar from "common/ChartBar";
 import Table from "common/Table";
 import { cashFormatter } from "helpers/cashFormater";
 import { currencySymbol } from "helpers/currencySymbol";
+import { minutesToHHMM } from "helpers/hhmm-parser";
 import { sendGAPageView } from "utils/googleAnalytics";
 
 import Header from "./Header";
@@ -23,16 +24,12 @@ import NewClient from "../Modals/NewClient";
 
 const getTableData = (clients) => {
   if (clients) {
-    return clients.map((client) => {
-      const hours = `${Math.floor(client.minutes / 60)}:${client.minutes % 60}`;
-
-      return {
-        col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
-        col2: <div className="text-base text-miru-dark-purple-1000 text-right">{client.email}</div>,
-        col3: <div className="text-base text-miru-dark-purple-1000 text-right">{hours}</div>,
-        rowId: client.id
-      };
-    });
+    return clients.map((client) => ({
+      col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
+      col2: <div className="text-base text-miru-dark-purple-1000 text-right">{client.email}</div>,
+      col3: <div className="text-base text-miru-dark-purple-1000 text-right">{minutesToHHMM(client.minutes)}</div>,
+      rowId: client.id
+    }));
   }
   return [{}];
 };

--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -24,7 +24,8 @@ import NewClient from "../Modals/NewClient";
 const getTableData = (clients) => {
   if (clients) {
     return clients.map((client) => {
-      const hours = (client.minutes / 60).toFixed(2);
+      const hours = `${Math.floor(client.minutes / 60)}:${client.minutes % 60}`;
+
       return {
         col1: <div className="text-base text-miru-dark-purple-1000">{client.name}</div>,
         col2: <div className="text-base text-miru-dark-purple-1000 text-right">{client.email}</div>,

--- a/app/javascript/src/components/InvoiceEmail/InvoiceTotalSummary.tsx
+++ b/app/javascript/src/components/InvoiceEmail/InvoiceTotalSummary.tsx
@@ -16,7 +16,7 @@ const InvoiceTotalSummary = ({ invoice, company, lineItems }) => {
               Sub total
             </td>
             <td className="font-bold text-base text-miru-dark-purple-1000 text-right ">
-              {parseFloat(subTotal).toFixed(2)}
+              {currencyFormat({ baseCurrency: company.base_currency, amount: parseFloat(subTotal).toFixed(2) })}
             </td>
           </tr>
           <tr
@@ -24,7 +24,9 @@ const InvoiceTotalSummary = ({ invoice, company, lineItems }) => {
             <td className="py-2 pr-10 font-normal text-base text-miru-dark-purple-1000 text-right pr-10">
               Discount
             </td>
-            <td className="font-bold text-base text-miru-dark-purple-1000 text-right ">{parseFloat(discount).toFixed(2)}</td>
+            <td className="font-bold text-base text-miru-dark-purple-1000 text-right ">
+              {currencyFormat({ baseCurrency: company.base_currency, amount: parseFloat(discount).toFixed(2) })}
+            </td>
           </tr>
           <tr>
             <td className="pt-4 font-normal text-base text-miru-dark-purple-1000 text-right pr-10">

--- a/app/javascript/src/components/Invoices/Edit/Header.tsx
+++ b/app/javascript/src/components/Invoices/Edit/Header.tsx
@@ -21,7 +21,7 @@ const Header = ({ invoiceNumber, id, updateInvoice }) => (
         <button
           type="button"
           className="header__button bg-miru-han-purple-1000 text-white w-1/3 p-0 hover:text-white"
-          onClick={() => { updateInvoice();}}
+          onClick={updateInvoice}
           data-cy='save-invoice-edit'
         >
           <FloppyDisk size={18} color="white" />

--- a/app/javascript/src/components/Invoices/Edit/NewLineItemTable.tsx
+++ b/app/javascript/src/components/Invoices/Edit/NewLineItemTable.tsx
@@ -9,7 +9,7 @@ const NewLineItemTable = ({
 }) => {
 
   const selectRowId = (item) => {
-    const option = { ...item, lineTotal: (Number(item.qty)/60 * Number(item.rate)) };
+    const option = { ...item, lineTotal: (Number(item.quantity)/60 * Number(item.rate)).toFixed(2) };
     const newLineItems = [...lineItems];
     newLineItems.splice(item.key, 1);
 

--- a/app/javascript/src/components/Invoices/Edit/index.tsx
+++ b/app/javascript/src/components/Invoices/Edit/index.tsx
@@ -37,7 +37,7 @@ const EditInvoice = () => {
   const [dueDate, setDueDate] = useState();
 
   const addKeyToLineItems = items => (
-    items.map((item, index) => {
+    items?.map((item, index) => {
       item["key"] = index;
       return item;
     })

--- a/app/javascript/src/components/Invoices/Generate/ManualEntry.tsx
+++ b/app/javascript/src/components/Invoices/Generate/ManualEntry.tsx
@@ -12,7 +12,7 @@ const ManualEntry = ({
   const [date, setDate] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [rate, setRate] = useState<any>("");
-  const [qty, setQty] = useState<any>("");
+  const [quantity, setQuantity] = useState<any>("");
   const [lineTotal, setLineTotal] = useState<any>(entry.lineTotal ? entry.lineTotal : 0);
   const [lineItem, setLineItem] = useState<any>({});
   const ref = useRef();
@@ -25,11 +25,11 @@ const ManualEntry = ({
         date,
         description,
         rate,
-        qty: qty,
-        lineTotal: (Number(qty) * Number(rate)).toFixed(2)
+        quantity,
+        lineTotal: (Number(quantity) * Number(rate)).toFixed(2)
       });
     }
-  }, [name, date, description, rate, qty, lineTotal]);
+  }, [name, date, description, rate, quantity, lineTotal]);
 
   useEffect(() => {
     const newManualEntryArr = manualEntryArr.map((option) => {
@@ -95,19 +95,19 @@ const ManualEntry = ({
           value={entry.rate}
           onChange={e => {
             setRate(e.target.value);
-            setLineTotal(Number(e.target.value) * Number(qty));
+            setLineTotal(Number(e.target.value) * Number(quantity));
           }}
         />
       </td>
       <td className="p-1 w-full">
         <input
           type="text"
-          placeholder="Qty"
+          placeholder="quantity"
           className=" p-1 px-2 bg-white rounded w-full font-medium text-sm text-miru-dark-purple-1000 text-right focus:outline-none focus:border-miru-gray-1000 focus:ring-1 focus:ring-miru-gray-1000"
-          defaultValue={entry.qty}
-          value={entry.qty}
+          defaultValue={entry.quantity}
+          value={entry.quantity}
           onChange={e => {
-            setQty(e.target.value);
+            setQuantity(e.target.value);
             setLineTotal(Number(rate) * Number(e.target.value));
           }}
         />

--- a/app/javascript/src/components/Invoices/Generate/NewLineItemTable.tsx
+++ b/app/javascript/src/components/Invoices/Generate/NewLineItemTable.tsx
@@ -26,7 +26,7 @@ const NewLineItemTable = ({
 
   const hasMoreItems = lineItems.length === totalLineItems;
   const selectRowId = (items) => {
-    const option = { ...items, lineTotal: (Number(items.qty) / 60 * Number(items.rate)) };
+    const option = { ...items, lineTotal: (Number(items.quantity) / 60 * Number(items.rate)).toFixed(2) };
     setAddNew(false);
     setSelectedOption([...selectedOption, option]);
     setLineItems([]);
@@ -62,7 +62,7 @@ const NewLineItemTable = ({
           }
         >
           {lineItems.map((item, index) => {
-            const hoursLogged = minutesToHHMM(item.qty);
+            const hoursLogged = minutesToHHMM(item.quantity);
             const date = dayjs(item.date).format("DD.MM.YYYY");
             return (
               <div key={index} onClick={() => { selectRowId(item); }} className="py-2 px-3 flex justify-between cursor-pointer hover:bg-miru-gray-100" data-cy="entries-list">

--- a/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import dayjs from "dayjs";
 
 import { currencyFormat } from "helpers/currency";
+import { minutesToHHMM } from "helpers/hhmm-parser";
 
 const LineItem = ({ currency, item }) => {
   const date = dayjs(item.date).format("DD-MM-YYYY");
@@ -22,7 +23,7 @@ const LineItem = ({ currency, item }) => {
         {currencyFormat({ baseCurrency: currency, amount: item.rate })}
       </td>
       <td className="border-b-2 border-miru-gray-200 px-1 py-3 font-normal text-base text-miru-dark-purple-1000 text-right ">
-        {(item.quantity / 60).toFixed(2)}
+        {minutesToHHMM(item.quantity)}
       </td>
       <td className="border-b-2 border-miru-gray-200 px-1 py-3 font-normal text-base text-miru-dark-purple-1000 text-right ">
         {currencyFormat({ baseCurrency: currency, amount: ((item.quantity / 60) * item.rate).toFixed(2) })}

--- a/app/javascript/src/components/Invoices/MultipleEntriesModal/Table.tsx
+++ b/app/javascript/src/components/Invoices/MultipleEntriesModal/Table.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import dayjs from "dayjs";
 import InfiniteScroll from "react-infinite-scroll-component";
 
+import { minutesToHHMM } from "helpers/hhmm-parser";
+
 const CheckboxIcon = () => <div className="bg-white border-2 border-miru-han-purple-1000 w-5 h-5 flex flex-shrink-0 justify-center items-center mr-2 focus-within:border-blue-500">
   <svg className="custom__checkbox-tick fill-current hidden w-2 h-2 text-miru-han-purple-1000 pointer-events-none" version="1.1" viewBox="0 0 17 12" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">
@@ -52,7 +54,7 @@ const Table = ({
               <table className="w-full">
                 <tbody>
                   {lineItems.map((item, index) => {
-                    const hoursLogged = (item.qty / 60).toFixed(2);
+                    const hoursLogged = minutesToHHMM(item.quantity);
                     const date = dayjs(item.date).format("DD.MM.YYYY");
                     return (
                       <tr key={index}>

--- a/app/javascript/src/components/Invoices/MultipleEntriesModal/index.tsx
+++ b/app/javascript/src/components/Invoices/MultipleEntriesModal/index.tsx
@@ -59,7 +59,7 @@ const MultipleEntriesModal = ({
       setPageNumber(pageNumber + 1);
       const items = res.data.new_line_item_entries.map(item => ({
         ...item, checked: allCheckboxSelected,
-        lineTotal: (Number(item.qty) / 60 * Number(item.rate))
+        lineTotal: ((Number(item.quantity) / 60 * Number(item.rate)).toFixed(2))
       }));
       const mergedItems = [...items, ...lineItems];
       const sortedData = mergedItems.sort((item1, item2) => dayjs(item1.date).isAfter(dayjs(item2.date)) ? 1 : -1);
@@ -74,7 +74,7 @@ const MultipleEntriesModal = ({
       const items = res.data.new_line_item_entries.map(item => ({
         ...item,
         checked: allCheckboxSelected,
-        lineTotal: (Number(item.qty) / 60 * Number(item.rate))
+        lineTotal: ((Number(item.quantity) / 60 * Number(item.rate)).toFixed(2))
       }));
       const mergedItems = [...items, ...lineItems];
       const sortedData = mergedItems.sort((item1, item2) => dayjs(item1.date).isAfter(dayjs(item2.date)) ? 1 : -1);

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/EditLineItems.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/EditLineItems.tsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from "react";
 import { Trash } from "phosphor-react";
 import DatePicker from "react-datepicker";
 
+import { minutesFromHHMM, minutesToHHMM } from "helpers/hhmm-parser";
+
 const EditLineItems = ({
   item,
   setSelectedOption,
@@ -12,14 +14,13 @@ const EditLineItems = ({
 }) => {
 
   const strName = item.name || `${item.first_name} ${item.last_name}`;
-  const actualQuantity = ((item.qty / 60) || (item.quantity / 60)).toFixed(2);
   const [name, setName] = useState<string>(strName);
   const formatedDate = new Date(item.date);
   const [lineItemDate, setLineItemDate] = useState(formatedDate);
   const [description, setDescription] = useState<string>(item.description);
   const [rate, setRate] = useState<number>(item.rate);
-  const [quantity, setQuantity] = useState<number>(Number(actualQuantity));
-  const lineTotal = quantity * rate;
+  const [quantity, setQuantity] = useState<string>(minutesToHHMM(item.quantity));
+  const [lineTotal, setLineTotal] = useState<string>(item.lineTotal);
 
   useEffect(() => {
     const names = name.split(" ");
@@ -31,8 +32,8 @@ const EditLineItems = ({
       date: lineItemDate,
       description,
       rate,
-      qty: Number(quantity) * 60,
-      lineTotal: Number(quantity) * Number(rate)
+      quantity: minutesFromHHMM(quantity),
+      lineTotal
     };
 
     const selectedOptionArr = selectedOption.map((option) => {
@@ -45,10 +46,16 @@ const EditLineItems = ({
     });
 
     setSelectedOption(selectedOptionArr);
-  }, [name, lineItemDate, description, quantity, rate]);
+  }, [name, lineItemDate, description, quantity, rate, lineTotal]);
 
   const closeEditField = (event) => {
     if (event.key === "Enter") setEdit(false);
+  };
+
+  const handleSetQuantity = (e) => {
+    const quantityInMin = Number(minutesFromHHMM(e.target.value));
+    setQuantity(e.target.value);
+    setLineTotal((Number(quantityInMin / 60) * Number(rate)).toFixed(2));
   };
 
   return (
@@ -95,14 +102,14 @@ const EditLineItems = ({
       <td className="p-1 w-full">
         <input
           type="text"
-          placeholder="Qty"
+          placeholder="Quantity"
           className=" p-1 px-2 bg-white rounded w-full font-medium text-sm text-miru-dark-purple-1000 text-right focus:outline-none focus:border-miru-gray-1000 focus:ring-1 focus:ring-miru-gray-1000"
           value={quantity}
-          onChange={e => setQuantity(Number(e.target.value))}
+          onChange={handleSetQuantity}
         />
       </td>
       <td className="text-right font-normal text-base text-miru-dark-purple-1000 focus:outline-none focus:border-miru-gray-1000 focus:ring-1 focus:ring-miru-gray-1000">
-        {lineTotal.toFixed(2)}
+        {lineTotal}
       </td>
       <td>
         <button onClick={() => handleDelete(item)} className="w-full flex items-center px-2.5 text-left py-4 hover:bg-miru-gray-100">

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/NewLineItemStatic.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/NewLineItemStatic.tsx
@@ -14,10 +14,9 @@ const NewLineItemStatic = ({
 }) => {
   const [isSideMenuVisible, setSideMenuVisible] = useState(false);
   const [showEditMenu, setShowEditMenu] = useState(false);
-  const quantity = item.qty || item.quantity;
-  const hoursLogged = minutesToHHMM(quantity).split(":").join(".");
+  const hoursLogged = minutesToHHMM(item.quantity);
   const date = dayjs(item.date).format("DD.MM.YYYY");
-  const totalRate = (quantity / 60) * item.rate;
+  const totalRate = Number(Number(item.quantity / 60) * Number(item.rate)).toFixed(2);
   const name = item.name || `${item.first_name} ${item.last_name}`;
   return (
     <tr className="invoice-items-row"
@@ -44,7 +43,7 @@ const NewLineItemStatic = ({
         {hoursLogged}
       </td>
       <td className="border-b-2 border-miru-gray-200 px-1 py-3 font-normal text-base text-miru-dark-purple-1000 text-right ">
-        {currencyFormat({ baseCurrency: currency, amount: totalRate.toFixed(2) })}
+        {currencyFormat({ baseCurrency: currency, amount: totalRate })}
       </td>
       <td className="w-10">
         {

--- a/app/javascript/src/components/Invoices/common/utils.js
+++ b/app/javascript/src/components/Invoices/common/utils.js
@@ -9,8 +9,10 @@ export const generateInvoiceLineItems = (selectedLineItems, manualEntryArr) => {
       description: item.description,
       date: dayjs(item.date).format("DD/MM/YYYY"),
       rate: item.rate,
-      quantity: item.qty,
-      timesheet_entry_id: item.time_sheet_entry ? item.time_sheet_entry : item.timesheet_entry_id,
+      quantity: Number(item.quantity),
+      timesheet_entry_id: item.time_sheet_entry
+        ? item.time_sheet_entry
+        : item.timesheet_entry_id,
       _destroy: !!item._destroy
     }))
   );
@@ -22,7 +24,7 @@ export const generateInvoiceLineItems = (selectedLineItems, manualEntryArr) => {
       description: item.description,
       date: dayjs(item.date).format("DD/MM/YYYY"),
       rate: item.rate,
-      quantity: Number(item.qty) * 60,
+      quantity: Number(item.quantity),
       timesheet_entry_id: item.time_sheet_entry,
       _destroy: !!item._destroy
     }))
@@ -32,7 +34,7 @@ export const generateInvoiceLineItems = (selectedLineItems, manualEntryArr) => {
 };
 
 export const getMaxIdx = (arr) => {
-  const ids = arr.map(object => object.idx);
+  const ids = arr.map((object) => object.idx);
 
   if (ids.length > 0) {
     return Math.max(...ids);

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -18,6 +18,7 @@ import ChartBar from "common/ChartBar";
 import Table from "common/Table";
 import { cashFormatter } from "helpers/cashFormater";
 import { currencySymbol } from "helpers/currencySymbol";
+import { minutesToHHMM } from "helpers/hhmm-parser";
 import { sendGAPageView } from "utils/googleAnalytics";
 
 import EditMembersList from "./EditMembersList";
@@ -60,32 +61,28 @@ const ProjectDetails = () => {
 
   const getTableData = (project) => {
     if (project) {
-      return project.members.map((member) => {
-        const hours = member.minutes / 60;
-        const hour = hours.toFixed(2);
-        return {
-          col1: (
-            <div className="text-base text-miru-dark-purple-1000">
-              {member.name}
-            </div>
-          ),
-          col2: (
-            <div className="text-base text-miru-dark-purple-1000 text-right">
-              {currencySymb}{member.hourlyRate}
-            </div>
-          ),
-          col3: (
-            <div className="text-base text-miru-dark-purple-1000 text-right">
-              {hour}
-            </div>
-          ),
-          col4: (
-            <div className="text-lg font-bold text-miru-dark-purple-1000 text-right">
-              {currencySymb}{member.cost}
-            </div>
-          )
-        };
-      });
+      return project.members.map((member) => ({
+        col1: (
+          <div className="text-base text-miru-dark-purple-1000">
+            {member.name}
+          </div>
+        ),
+        col2: (
+          <div className="text-base text-miru-dark-purple-1000 text-right">
+            {currencySymb}{member.hourlyRate}
+          </div>
+        ),
+        col3: (
+          <div className="text-base text-miru-dark-purple-1000 text-right">
+            {minutesToHHMM(member.minutes)}
+          </div>
+        ),
+        col4: (
+          <div className="text-lg font-bold text-miru-dark-purple-1000 text-right">
+            {currencySymb}{member.cost}
+          </div>
+        )
+      }));
     }
   };
 

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -79,7 +79,7 @@ const ProjectDetails = () => {
         ),
         col4: (
           <div className="text-lg font-bold text-miru-dark-purple-1000 text-right">
-            {currencySymb}{member.cost}
+            {currencySymb}{(Number(member.cost)).toFixed(2)}
           </div>
         )
       }));

--- a/app/javascript/src/mapper/editInvoice.mapper.ts
+++ b/app/javascript/src/mapper/editInvoice.mapper.ts
@@ -1,5 +1,5 @@
 export const unmapLineItems = (input) => input.map(item => ({
   ...item,
-  lineTotal: ((Number(item.quantity) / 60) * Number(item.rate)),
+  lineTotal: ((Number(item.quantity) / 60) * Number(item.rate)).toFixed(2),
   timesheet_entry_id: item.timesheetEntryId
 }));

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -58,7 +58,7 @@ class Client < ApplicationRecord
          timesheet_entries.work_date as date,
          timesheet_entries.note as description,
          project_members.hourly_rate as rate,
-         timesheet_entries.duration as qty"
+         timesheet_entries.duration as quantity"
       ).where.not(id: selected_entries).order("timesheet_entries.work_date").distinct
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,7 +49,7 @@ class Project < ApplicationRecord
 
     project_members.map do |member|
       entry = entries.find { |entry| entry.user_id == member.user_id }
-      cost = ((entry&.duration.presence || 0) / 60) * member.hourly_rate
+      cost = calculate_cost(entry&.duration.presence || 0, member.hourly_rate)
       {
         id: member.user_id,
         name: member.full_name,
@@ -120,5 +120,10 @@ class Project < ApplicationRecord
 
     def discard_project_members
       project_members.discard_all
+    end
+
+    def calculate_cost(duration, hourly_rate)
+      time = (duration.to_f / 60).round(2)
+      ((duration.to_f / 60) * hourly_rate).round(2)
     end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -123,6 +123,6 @@ class Project < ApplicationRecord
     end
 
     def calculate_cost(duration, hourly_rate)
-      "%.2f" % ((duration.to_f / 60) * hourly_rate)
+      (duration.to_f / 60) * hourly_rate
     end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -123,7 +123,6 @@ class Project < ApplicationRecord
     end
 
     def calculate_cost(duration, hourly_rate)
-      time = (duration.to_f / 60).round(2)
-      ((duration.to_f / 60) * hourly_rate).round(2)
+      "%.2f" % ((duration.to_f / 60) * hourly_rate)
     end
 end

--- a/app/services/invoice_payment/pdf_generation.rb
+++ b/app/services/invoice_payment/pdf_generation.rb
@@ -42,16 +42,29 @@ module InvoicePayment
 
         new_invoice_line_items = []
         invoice_line_items.each do |line_item|
+          if line_item.quantity <= 0
+            quantity = "00:00"
+          else
+            hours = line_item.quantity / 60
+            minutes = line_item.quantity % 60
+            hours = "0#{hours}" if hours.digits.count == 1
+            minutes = "0#{minutes}" if minutes.digits.count == 1
+            quantity = "#{hours}:#{minutes}"
+          end
+
+          total_rate = ((line_item.quantity.to_f / 60) * line_item.rate)
+          line_total_val = "%.2f" % total_rate
+
           new_line_item = {}
           new_line_item[:name] = line_item.name
           new_line_item[:date] = line_item.date
           new_line_item[:description] = line_item.description
           new_line_item[:rate] = line_item.rate
-          new_line_item[:quantity] = (line_item.quantity.to_f / 60).round(2)
-          new_line_item[:line_total] = (line_item.quantity.to_f / 60 * line_item.rate).round(2)
+          new_line_item[:quantity] = quantity
+          new_line_item[:line_total] = line_total_val
           new_invoice_line_items << new_line_item
 
-          sub_total += new_line_item[:line_total]
+          sub_total += total_rate
         end
 
         {

--- a/app/services/invoice_payment/pdf_generation.rb
+++ b/app/services/invoice_payment/pdf_generation.rb
@@ -47,8 +47,8 @@ module InvoicePayment
           new_line_item[:date] = line_item.date
           new_line_item[:description] = line_item.description
           new_line_item[:rate] = line_item.rate
-          new_line_item[:quantity] = line_item.quantity / 60
-          new_line_item[:line_total] = new_line_item[:quantity] * line_item.rate.to_i
+          new_line_item[:quantity] = (line_item.quantity.to_f / 60).round(2)
+          new_line_item[:line_total] = (line_item.quantity.to_f / 60 * line_item.rate).round(2)
           new_invoice_line_items << new_line_item
 
           sub_total += new_line_item[:line_total]

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Client, type: :model do
                  timesheet_entries.work_date as date,
                  timesheet_entries.note as description,
                  project_members.hourly_rate as rate,
-                 timesheet_entries.duration as qty"
+                 timesheet_entries.duration as quantity"
               ).where.not(id: selected_entries).order("timesheet_entries.work_date").distinct
           expect(client.new_line_item_entries(selected_entries)).to eq(result)
         end
@@ -204,7 +204,7 @@ RSpec.describe Client, type: :model do
                  timesheet_entries.work_date as date,
                  timesheet_entries.note as description,
                  project_members.hourly_rate as rate,
-                 timesheet_entries.duration as qty"
+                 timesheet_entries.duration as quantity"
               ).where.not(id: selected_entries).order("timesheet_entries.work_date").distinct
           expect(client.new_line_item_entries(selected_entries)).to eq(result)
         end


### PR DESCRIPTION
## Notion card
https://www.notion.so/The-qty-in-Invoice-PDF-generated-is-rounded-off-because-of-which-the-invoice-amount-in-miru-and-PDF--d4915e1c12ff4b4b9cac547526f24e06

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
Fixed total hours value in clients page, projects page and team members' total hours and total cost for that particular project. Fixed pdf attachment when client receives the invoice in the mail, hours by the team members getting rounded and because of that, mail view and attached pdf are not matching and the total value is wrong. Fixed this bug.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
Video: https://www.loom.com/share/c986903b9cf74f179075f28392fd7a73
Video continuation: https://www.loom.com/share/94e125e7387d4de081beb637ee59d540

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
