### PR TITLE
Fix bug datepicker on add manual entry

### DIFF
--- a/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
+++ b/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
@@ -204,13 +204,14 @@ const AddManualEntry = ({ setShowManualEntryModal, invoiceList, fetchPaymentList
                     className="absolute top-0 right-0 m-2"
                     color="#5B34EA"
                   />
-                  {showDatePicker && (
-                    <CustomDatePicker
-                      handleChange={handleDatePicker}
-                      date={transactionDate}
-                    />
-                  )}
                 </div>
+                {showDatePicker && (
+                  <CustomDatePicker
+                    handleChange={handleDatePicker}
+                    date={transactionDate}
+                  />
+                )}
+
               </div>
             </div>
 


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Bug-in-date-picker-on-add-manual-entry-24394e1cfac1439fa97f2de51db82a61

## Summary
Fix the bug on the date-picker on add manual entry where on clicking the previous month or next month arrow the calender was getting closed.

## Preview
https://www.loom.com/share/f8cde31d58994063a2feade66ca71b04
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
