### PR TITLE
Revert "Autosize timesheet notes textarea only on focus to avoid incorrect height and scroll issue"

### DIFF
--- a/app/javascript/src/components/time-tracking/AddEntry.tsx
+++ b/app/javascript/src/components/time-tracking/AddEntry.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React, { useState, useEffect } from "react";
 
+import autosize from "autosize";
 import { getNumberWithOrdinal, minFromHHMM, minToHHMM, validateTimesheetEntry } from "helpers";
 
 import timesheetEntryApi from "apis/timesheet-entry";
@@ -45,7 +46,10 @@ const AddEntry: React.FC<Iprops> = ({
   };
 
   useEffect(() => {
+    const textArea = document.querySelector("textarea");
+    autosize(textArea);
     handleFillData();
+    textArea.click();
   }, []);
 
   useEffect(() => {
@@ -170,7 +174,7 @@ const AddEntry: React.FC<Iprops> = ({
           cols={60}
           name="notes"
           placeholder=" Notes"
-          className={("w-129 px-1 rounded-sm bg-miru-gray-100 focus:miru-han-purple-1000 outline-none resize-none mt-2 overflow-y-auto " + (editEntryId ? "h-32" : "h-8") )}
+          className={("w-129 px-1 rounded-sm bg-miru-gray-100 focus:miru-han-purple-1000 outline-none resize-none mt-2 " + (editEntryId ? "h-32" : "h-8") )}
         ></textarea>
       </div>
       <div className="w-60">


### PR DESCRIPTION
Reverts saeloun/miru-web#695

This change is breaking the new time entry description height. 
https://www.loom.com/share/eba00fa605784e4f86849112f0889b89

cc: @apoorv1316 @aaj013 