### PR TITLE
Elastic search reindexing issue fixed

### DIFF
--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -56,7 +56,7 @@ class TimesheetEntry < ApplicationRecord
       id: id.to_i,
       bill_status:,
       project_id:,
-      client_id: self.project.client_id,
+      client_id: self.project&.client_id,
       user_id:,
       work_date: work_date.to_time,
       note:,

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -10,7 +10,7 @@ namespace :fly do
   #  - changes to the filesystem made here are DISCARDED
   #  - full access to secrets, databases
   #  - failures here prevent deployment
-  task :release => 'db:migrate:with_data'
+  task :release => 'db:migrate'
 
   # SERVER step:
   #  - changes to the filesystem made here are deployed


### PR DESCRIPTION
## Notion card

## Summary

In production, we are facing an issue with elastic search reindexing. While backtracing the error, if had found that the issue is because of https://github.com/saeloun/miru-web/blob/df23ba375133e7074acc60695267468cd17bce55/app/models/timesheet_entry.rb#L72 this line. 

Cause of issue: 
This happens only for deleted project timesheet entry reindexing. while fetching the project from the timesheet entry it returns nil and give `undefined client_id for nil class error`

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
