### PR TITLE
Apply bill_status filter as "unbilled" on fetching new line items

### DIFF
--- a/app/controllers/internal_api/v1/generate_invoice_controller.rb
+++ b/app/controllers/internal_api/v1/generate_invoice_controller.rb
@@ -40,9 +40,14 @@ class InternalApi::V1::GenerateInvoiceController < InternalApi::V1::ApplicationC
       { project_id: project }
     end
 
+    def unbilled_status_filter
+      { bill_status: "unbilled" }
+    end
+
     def new_line_item_entries
       default_filter = project_filter.merge(unselected_time_entries_filter)
-      where_clause = default_filter.merge(TimeEntries::Filters.process(params))
+      bill_status_filter = default_filter.merge(unbilled_status_filter)
+      where_clause = bill_status_filter.merge(TimeEntries::Filters.process(params))
       search_result = TimesheetEntry.search(
         search_term,
         fields: [:note, :user_name],

--- a/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
+++ b/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
@@ -10,9 +10,8 @@ end
 
 # new line items data according to filters and search term
 json.new_line_item_entries new_line_item_entries do |line_item|
-  # TODO:-Temporarily checking for project member relation. To be fixed in TimeTracking.
-  hourly_rate = ProjectMember.find_by(user_id: line_item.user_id, project_id: line_item.project_id)&.hourly_rate
-  next unless hourly_rate
+  # TODO:-Temporarily sending data for all unbilled timesheet entries even if user is not a part of the project.
+  # To be fixed in a separate TimeTracking PR on priority.
 
   json.timesheet_entry_id line_item.id
   json.user_id line_item.user_id
@@ -22,7 +21,7 @@ json.new_line_item_entries new_line_item_entries do |line_item|
   json.description line_item.note
   json.date line_item.work_date
   json.quantity line_item.duration
-  json.rate hourly_rate
+  json.rate ProjectMember.find_by(user_id: line_item.user_id, project_id: line_item.project_id)&.hourly_rate
 end
 
 # sends total number of new line item entry count

--- a/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
+++ b/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
@@ -10,6 +10,10 @@ end
 
 # new line items data according to filters and search term
 json.new_line_item_entries new_line_item_entries do |line_item|
+  # TODO:-Temporarily checking for project member relation. To be fixed in TimeTracking.
+  hourly_rate = ProjectMember.find_by(user_id: line_item.user_id, project_id: line_item.project_id)&.hourly_rate
+  next unless hourly_rate
+
   json.timesheet_entry_id line_item.id
   json.user_id line_item.user_id
   json.project_id line_item.project_id
@@ -18,7 +22,7 @@ json.new_line_item_entries new_line_item_entries do |line_item|
   json.description line_item.note
   json.date line_item.work_date
   json.quantity line_item.duration
-  json.rate ProjectMember.find_by(user_id: line_item.user_id, project_id: line_item.project_id).hourly_rate
+  json.rate hourly_rate
 end
 
 # sends total number of new line item entry count

--- a/spec/requests/internal_api/v1/generate_invoice/index_spec.rb
+++ b/spec/requests/internal_api/v1/generate_invoice/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "InternalApi::V1::GeneratInvoice#index", type: :request do
   let(:client) { create(:client, company:) }
   let!(:project) { create(:project, client:) }
   let!(:project_member) { create(:project_member, user:, project:) }
-  let!(:timesheet_entry) { create(:timesheet_entry, user:, project:) }
+  let!(:timesheet_entry) { create(:timesheet_entry, user:, project:, bill_status: "unbilled") }
 
   let(:expected_invoice_line_items) do [{
     "timesheet_entry_id": timesheet_entry.id,


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Admin-and-owner-is-able-to-view-all-non-billable-and-previously-billes-entries-on-add-line-item-wind-8193240df1804991a75538aaeed5d0c4

## Summary

- Added Unbilled status filter to timesheet entry.
- Added temporary check in index.json.jbuilder to avoid error 500 to avoid showing entries for users who are not associated to a project for which they have created the entry.

## Preview


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Local.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
