### PR TITLE
Bug in the line items list when editing a line item

### DIFF
--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/EditLineItems.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/EditLineItems.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
-import { minFromHHMM, minToHHMM, lineTotalCalc } from "helpers";
+import { minFromHHMM, minToHHMM, lineTotalCalc, useOutsideClick } from "helpers";
 import { Trash } from "phosphor-react";
 import DatePicker from "react-datepicker";
 
@@ -19,6 +19,7 @@ const EditLineItems = ({
   const [rate, setRate] = useState<number>(item.rate);
   const [quantity, setQuantity] = useState<any>(minToHHMM(item.quantity));
   const [lineTotal, setLineTotal] = useState<string>(item.lineTotal);
+  const wrapperRef = useRef(null);
 
   useEffect(() => {
     const names = name.split(" ");
@@ -46,6 +47,10 @@ const EditLineItems = ({
     setSelectedOption(selectedOptionArr);
   }, [name, lineItemDate, description, quantity, rate, lineTotal]);
 
+  useOutsideClick(wrapperRef, () => {
+    setEdit(false);
+  });
+
   const closeEditField = (event) => {
     if (event.key === "Enter") setEdit(false);
   };
@@ -63,7 +68,7 @@ const EditLineItems = ({
   };
 
   return (
-    <tr className="w-full my-1">
+    <tr className="w-full my-1" ref={wrapperRef}>
       <td className="p-1 w-full">
         <input
           type="text"


### PR DESCRIPTION
## Fix Bug in the line items list when editing a line item on create new invoice

## Summary
This fixes bug on create new invoice page when you editing an invoice entry and press create new item button. Date used to persist over the modal which is now resolved.

## Preview 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
