### PR TITLE
Enable token authentication with JWT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,10 @@ gem "redis", "~> 4.0"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
+
+# A ruby implementation of the RFC 7519 OAuth JSON Web Token (JWT) standard.
+gem "jwt"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,6 +525,7 @@ DEPENDENCIES
   activerecord-import
   annotate
   aws-sdk-s3
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   bullet
   bundler-audit
@@ -545,6 +546,7 @@ DEPENDENCIES
   honeybadger
   image_processing (>= 1.2)
   jbuilder (~> 2.11)
+  jwt
   letter_opener
   letter_opener_web
   money

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   include CurrentCompanyConcern
   include Pagy::Backend
 
-  before_action :authenticate_user!, :validate_company!
+  before_action :process_token, :validate_company!
 
   private
 
@@ -15,5 +15,34 @@ class ApplicationController < ActionController::Base
       return if current_user.nil? || devise_controller?
 
       authorize current_company, :company_present?, policy_class: CompanyPolicy
+    end
+
+    # Check for auth headers - if present, decode or send unauthorized response (called always to allow current_user)
+    def process_token
+      if request.headers["Authorization"].present?
+        begin
+          jwt_payload = JWT.decode(
+            request.headers["Authorization"].split(" ")[1],
+            Rails.application.secrets.secret_key_base).first
+          @current_user_id = jwt_payload["id"]
+        rescue JWT::ExpiredSignature, JWT::VerificationError, JWT::DecodeError
+          head :unauthorized
+        end
+      end
+    end
+
+    # If user has not signed in, return unauthorized response (called only when auth is needed)
+    def authenticate_user!(options = {})
+      head :unauthorized unless signed_in?
+    end
+
+    # set Devise's current_user using decoded JWT instead of session
+    def current_user
+      @current_user ||= super || User.find(@current_user_id)
+    end
+
+    # check that authenticate_user has successfully returned @current_user_id (user is authenticated)
+    def signed_in?
+      @current_user_id.present?
     end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    respond_to do |format|
+       format.json do
+         user = User.find_by_email(params[:email])
+         if user && user.valid_password?(params[:password])
+           token = user.generate_jwt
+           render json: token.to_json
+         else
+           render json: { errors: { "email or password" => ["is invalid"] } }, status: :unprocessable_entity
+         end
+       end
+       format.html { super }
+     end
+  end
+
   def after_sign_in_path_for(user)
     if user.has_role?(:owner) && user.companies.empty?
       new_company_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,6 +130,10 @@ class User < ApplicationRecord
     employments.exists?(company_id:)
   end
 
+  def generate_jwt
+    JWT.encode({ id:, exp: 60.days.from_now.to_i }, Rails.application.secrets.secret_key_base)
+  end
+
   private
 
     def discard_project_members


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Enable-token-authorization-25ddc196e549443ca637563ded292ad4

## Summary
 Feature request for Miru. Need to enable token authentication to be able to access some APIs programmatically (for eg. JWT) to submit timesheets directly to Miru.
 
 Slack conversation- https://saeloun.slack.com/archives/CFKNQ9H52/p1663582267924919

## Preview

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
**Via curl request from console -** curl -X POST http://localhost:3000/users/sign_in -H 'Content-Type: application/json' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZXhwIjoxNjcxMzQ2MzYxfQ.lFA8IYIbKfHjg301bYNxprLEE7DeUOZ-SZP4T7G7aLI' -d '{"email":"vipul@example.com","password":"password"}'

**Postman**
In progress

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
