### PR TITLE
Fixed invoice pdf attachment font family

### DIFF
--- a/app/views/invoices/pdf.html.erb
+++ b/app/views/invoices/pdf.html.erb
@@ -2,6 +2,9 @@
 html {
   -webkit-print-color-adjust: exact;
 }
+body{
+  font-family: 'Manrope', 'liberation sans', 'arial', 'verdana', 'sans-serif' !important;
+}
 </style>
 <div class="main">
   <div class="flex justify-between border-b-2 border-miru-gray-400 p-10 h-50">

--- a/app/views/invoices/pdf.html.erb
+++ b/app/views/invoices/pdf.html.erb
@@ -3,7 +3,8 @@ html {
   -webkit-print-color-adjust: exact;
 }
 body{
-  font-family: 'Manrope', 'liberation sans', 'arial', 'verdana', 'sans-serif' !important;
+  font-family: system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
+  font-size: 14px !important;
 }
 </style>
 <div class="main">
@@ -29,18 +30,18 @@ body{
   </div>
 
   <div class="flex justify-between border-b-2 border-miru-gray-400 px-10 py-5 h-36">
-    <div class="group">
+    <div class="w-1/3">
       <p class="font-normal text-xs text-miru-dark-purple-1000 flex">Billed to</p>
       <div>
         <p class="font-bold text-base text-miru-dark-purple-1000">
           <%=client.name%>
         </p>
-        <p class="font-normal text-xs text-miru-dark-purple-400 w-52">
+        <p class="font-normal text-xs text-miru-dark-purple-400 truncate">
           <%=client.address%><br><%=client.phone%>
         </p>
       </div>
     </div>
-    <div class="group">
+    <div class="w-1/4">
       <p class="font-normal text-xs text-miru-dark-purple-1000 flex">Date of Issue</p>
       <p class="font-normal text-base text-miru-dark-purple-1000">
         <%=invoice["issue_date"].strftime('%d-%m-%Y')%>
@@ -50,19 +51,19 @@ body{
         <%=invoice["due_date"].strftime('%d-%m-%Y')%>
       </p>
     </div>
-    <div class="group">
+    <div class="w-1/3">
       <p class="font-normal text-xs text-miru-dark-purple-1000">Invoice Number</p>
       <p class="font-normal text-base text-miru-dark-purple-1000">
         <%=invoice["invoice_number"]%>
       </p>
       <p class="font-normal text-xs text-miru-dark-purple-1000 mt-4">Reference</p>
-      <p class="font-normal text-base text-miru-dark-purple-1000">
+      <p class="font-normal text-base text-miru-dark-purple-1000 truncate">
         <%=invoice["reference"]%>
       </p>
     </div>
-    <div>
+    <div class="w-1/5 text-right">
       <p class="font-normal text-xs text-miru-dark-purple-1000 text-right">Amount</p>
-      <p class="font-normal text-4xl text-miru-dark-purple-1000 mt-1">
+      <p class="font-normal text-2xl text-miru-dark-purple-1000 mt-1">
         <%=invoice_amount%>
       </p>
     </div>


### PR DESCRIPTION
## Notion card
https://www.notion.so/Configure-Font-Family-support-to-PDF-attachment-in-Fly-io-5ec07a824711465cbe3bc359acdfbbcd

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
Now by default it checks Manrope font if system does not have it then it checks for other fonts 
```
font-family: system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
  font-size: 14px !important;

```
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
<img width="794" alt="Screenshot 2022-10-20 at 4 43 29 PM" src="https://user-images.githubusercontent.com/52771571/196933892-a0e8ca0c-3e63-4542-a348-55f29a595b36.png">


## Type of change


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code