### PR TITLE
711-Added logic to only update non billed time entries

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   include ErrorHandler
   include CurrentCompanyConcern
   include Pagy::Backend
+  include SetCurrentDetails
 
   before_action :authenticate_user!, :validate_company!
 

--- a/app/controllers/concerns/set_current_details.rb
+++ b/app/controllers/concerns/set_current_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SetCurrentDetails
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.user = current_user
+      Current.company = current_company
+    end
+  end
+end

--- a/app/controllers/internal_api/v1/application_controller.rb
+++ b/app/controllers/internal_api/v1/application_controller.rb
@@ -6,6 +6,7 @@ class InternalApi::V1::ApplicationController < ActionController::API
   include ErrorHandler
   include CurrentCompanyConcern
   include Pagy::Backend
+  include SetCurrentDetails
 
   before_action :authenticate_user!
 end

--- a/app/controllers/internal_api/v1/time_tracking_controller.rb
+++ b/app/controllers/internal_api/v1/time_tracking_controller.rb
@@ -22,6 +22,7 @@ class InternalApi::V1::TimeTrackingController < InternalApi::V1::ApplicationCont
         1.month.since.end_of_month
         )
     entries = formatted_entries_by_date(timesheet_entries)
+    entries[:currentUserRole] = current_user.primary_role current_company
     render json: { clients:, projects:, entries:, employees: }, status: :ok
   end
 

--- a/app/controllers/internal_api/v1/timesheet_entry_controller.rb
+++ b/app/controllers/internal_api/v1/timesheet_entry_controller.rb
@@ -31,7 +31,7 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
     authorize current_timesheet_entry
     current_timesheet_entry.project = current_project
     render json: { notice: I18n.t("timesheet_entry.update.message"), entry: current_timesheet_entry.formatted_entry },
-      status: :ok if current_timesheet_entry.update(timesheet_entry_params)
+      status: :ok if current_timesheet_entry.update(timesheet_entry_update_params)
   end
 
   def destroy
@@ -51,5 +51,9 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
 
     def timesheet_entry_params
       params.require(:timesheet_entry).permit(:project_id, :duration, :work_date, :note, :bill_status)
+    end
+
+    def timesheet_entry_update_params
+      params.require(:timesheet_entry).permit(:project_id, :duration, :work_date, :note)
     end
 end

--- a/app/controllers/internal_api/v1/timesheet_entry_controller.rb
+++ b/app/controllers/internal_api/v1/timesheet_entry_controller.rb
@@ -13,6 +13,7 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
       params[:to]
     )
     entries = formatted_entries_by_date(timesheet_entries)
+    entries[:currentUserRole] = current_user.primary_role current_company
     render json: { entries: }, status: :ok
   end
 

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -18,6 +18,42 @@ interface props {
   bill_status: string;
 }
 
+const showUpdateAction = (billStatus, id, setEditEntryId) => {
+  if (billStatus != "billed") {
+    return (
+      <button onClick={() => setEditEntryId(id)} className="mx-10">
+        <img
+          src={editIcon}
+          alt="edit"
+          className="icon-hover text-miru-han-purple-600 hover:text-miru-han-purple-1000 w-4 h-4"
+        />
+      </button>
+    );
+  } else {
+    return (
+      <div className="mx-10 w-4 h-4"></div>
+    );
+  }
+};
+
+const showDeleteAction = (billStatus, id, handleDeleteEntry) => {
+  if (billStatus != "billed") {
+    return (
+      <button onClick={() => handleDeleteEntry(id)} className="mr-10">
+        <img
+          src={deleteIcon}
+          alt="delete"
+          className="icon-hover fill-blue text-miru-han-purple-1000 hover:text-miru-han-purple-1000 w-4 h-4"
+        />
+      </button>
+    );
+  } else {
+    return (
+      <div className="mr-10 w-4 h-4"></div>
+    );
+  }
+};
+
 const EntryCard: React.FC<props> = ({
   id,
   client,
@@ -63,20 +99,8 @@ const EntryCard: React.FC<props> = ({
         />
       )}
       <p className="text-4xl ml-6">{minToHHMM(duration)}</p>
-      <button onClick={() => setEditEntryId(id)} className="mx-10">
-        <img
-          src={editIcon}
-          alt="edit"
-          className="icon-hover text-miru-han-purple-600 hover:text-miru-han-purple-1000 w-4 h-4"
-        />
-      </button>
-      <button onClick={() => handleDeleteEntry(id)} className="mr-10">
-        <img
-          src={deleteIcon}
-          alt="delete"
-          className="icon-hover fill-blue text-miru-han-purple-1000 hover:text-miru-han-purple-1000 w-4 h-4"
-        />
-      </button>
+      { showUpdateAction(bill_status, id, setEditEntryId) }
+      { showDeleteAction(bill_status, id, handleDeleteEntry) }
     </div>
   </div>
 );

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { minToHHMM } from "helpers";
 import { Badge } from "StyledComponents";
 
+import { Roles } from "../../constants";
+
 const deleteIcon = require("../../../../assets/images/delete.svg");
 const editIcon = require("../../../../assets/images/edit.svg");
 
@@ -16,10 +18,13 @@ interface props {
   handleDeleteEntry: (id: number) => void;
   setEditEntryId: React.Dispatch<React.SetStateAction<number>>;
   bill_status: string;
+  current_user_role: string;
 }
 
-const showUpdateAction = (billStatus, id, setEditEntryId) => {
-  if (billStatus != "billed") {
+const canEditTimeEntry = (billStatus, role) => (billStatus != "billed" || role == Roles["OWNER"] || role == Roles["ADMIN"]);
+
+const showUpdateAction = (billStatus, role, id, setEditEntryId) => {
+  if (canEditTimeEntry(billStatus, role)) {
     return (
       <button onClick={() => setEditEntryId(id)} className="mx-10">
         <img
@@ -36,8 +41,8 @@ const showUpdateAction = (billStatus, id, setEditEntryId) => {
   }
 };
 
-const showDeleteAction = (billStatus, id, handleDeleteEntry) => {
-  if (billStatus != "billed") {
+const showDeleteAction = (billStatus, role, id, handleDeleteEntry) => {
+  if (canEditTimeEntry(billStatus, role)) {
     return (
       <button onClick={() => handleDeleteEntry(id)} className="mr-10">
         <img
@@ -62,7 +67,8 @@ const EntryCard: React.FC<props> = ({
   duration,
   handleDeleteEntry,
   setEditEntryId,
-  bill_status
+  bill_status,
+  current_user_role
 }) => (
   <div className="week-card flex justify-between items-center shadow-2xl w-full p-4 mt-10 rounded-lg">
     <div className="flex-auto">
@@ -99,8 +105,8 @@ const EntryCard: React.FC<props> = ({
         />
       )}
       <p className="text-4xl ml-6">{minToHHMM(duration)}</p>
-      { showUpdateAction(bill_status, id, setEditEntryId) }
-      { showDeleteAction(bill_status, id, handleDeleteEntry) }
+      { showUpdateAction(bill_status, current_user_role, id, setEditEntryId) }
+      { showDeleteAction(bill_status, current_user_role, id, handleDeleteEntry) }
     </div>
   </div>
 );

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -18,7 +18,7 @@ interface props {
   handleDeleteEntry: (id: number) => void;
   setEditEntryId: React.Dispatch<React.SetStateAction<number>>;
   bill_status: string;
-  current_user_role: string;
+  currentUserRole: string;
 }
 
 const canEditTimeEntry = (billStatus, role) => (billStatus != "billed" || role == Roles["OWNER"] || role == Roles["ADMIN"]);
@@ -68,7 +68,7 @@ const EntryCard: React.FC<props> = ({
   handleDeleteEntry,
   setEditEntryId,
   bill_status,
-  current_user_role
+  currentUserRole
 }) => (
   <div className="week-card flex justify-between items-center shadow-2xl w-full p-4 mt-10 rounded-lg">
     <div className="flex-auto">
@@ -105,8 +105,8 @@ const EntryCard: React.FC<props> = ({
         />
       )}
       <p className="text-4xl ml-6">{minToHHMM(duration)}</p>
-      { showUpdateAction(bill_status, current_user_role, id, setEditEntryId) }
-      { showDeleteAction(bill_status, current_user_role, id, handleDeleteEntry) }
+      { showUpdateAction(bill_status, currentUserRole, id, setEditEntryId) }
+      { showDeleteAction(bill_status, currentUserRole, id, handleDeleteEntry) }
     </div>
   </div>
 );

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -458,6 +458,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
                 key={weekCounter}
                 handleDeleteEntry={handleDeleteEntry}
                 setEditEntryId={setEditEntryId}
+                currentUserRole={ entryList["currentUserRole"] }
                 {...entry}
               />
             )

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user, :company
+end

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -74,7 +74,8 @@ class TimesheetEntry < ApplicationRecord
       note:,
       work_date:,
       bill_status:,
-      team_member: user.full_name
+      team_member: user.full_name,
+      current_user_role: user.primary_role(project.client.company)
     }
   end
 

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -96,8 +96,7 @@ class TimesheetEntry < ApplicationRecord
     end
 
     def ensure_bill_status_is_not_billed
-      errors.add(:timesheet_entry, I18n.t(:errors)[:create_billed_entry]) if
-      self.bill_status == "billed"
+      errors.add(:timesheet_entry, I18n.t(:errors)[:create_billed_entry]) if billed?
     end
 
     def ensure_billed_status_should_not_be_changed

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -100,7 +100,9 @@ class TimesheetEntry < ApplicationRecord
     end
 
     def ensure_billed_status_should_not_be_changed
+      return if Current.user.nil?
+
       errors.add(:timesheet_entry, I18n.t(:errors)[:bill_status_billed]) if
-      self.bill_status_changed? && self.bill_status_was == "billed"
+      self.bill_status_changed? && self.bill_status_was == "billed" && Current.user.primary_role(Current.company) == "employee"
     end
 end

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -74,8 +74,7 @@ class TimesheetEntry < ApplicationRecord
       note:,
       work_date:,
       bill_status:,
-      team_member: user.full_name,
-      current_user_role: user.primary_role(project.client.company)
+      team_member: user.full_name
     }
   end
 

--- a/app/policies/timesheet_entry_policy.rb
+++ b/app/policies/timesheet_entry_policy.rb
@@ -14,7 +14,7 @@ class TimesheetEntryPolicy < ApplicationPolicy
   end
 
   def update?
-    record.user_id == user.id ||
+    (record.user_id == user.id && !record.billed?) ||
       user.has_role?(:owner, record.project.client.company) || user.has_role?(:admin, record.project.client.company)
   end
 

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -101,14 +101,65 @@ RSpec.describe TimesheetEntry, type: :model do
   end
 
   describe "#ensure_billed_status_should_not_be_changed" do
-    let(:error_message) { "You can't bill an entry that has already been billed" }
+    context "when admin or owner is updating the time entry" do
+      before do
+        admin.add_role([:owner, :admin].sample, company)
+        Current.user = admin
+        Current.company = company
+      end
 
-    it "returns an error if status is changed for a billed entry" do
-      timesheet_entry.update!(bill_status: "billed")
-      timesheet_entry.update(bill_status: "unbilled")
+      let(:admin) { create(:user) }
+      let(:timesheet_entry) { create(:timesheet_entry, project:) }
 
-      expect(timesheet_entry.valid?).to be_falsey
-      expect(timesheet_entry.errors.messages[:timesheet_entry]).to eq([error_message])
+      context "when time entry is billed" do
+        it "allows owners and admins to edit the billed time entry" do
+          timesheet_entry.update!(bill_status: "billed")
+          timesheet_entry.update(bill_status: "unbilled")
+
+          expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.errors.blank?).to be true
+        end
+      end
+
+      context "when time entry is not billed" do
+        it "allows owners and admins to edit the billed time entry" do
+          timesheet_entry.update(bill_status: "unbilled")
+
+          expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.errors.blank?).to be true
+        end
+      end
+    end
+
+    context "when employee is editing time entry" do
+      before do
+        user.add_role(:employee, company)
+        Current.user = user
+        Current.company = company
+      end
+
+      let(:user) { create(:user) }
+      let(:timesheet_entry) { create(:timesheet_entry, project:) }
+      let(:error_message) { "You can't bill an entry that has already been billed" }
+
+      context "when time entry is billed" do
+        it "does not allow to update billed time entry to employee" do
+          timesheet_entry.update!(bill_status: "billed")
+          timesheet_entry.update(bill_status: "unbilled")
+
+          expect(timesheet_entry.valid?).to be_falsy
+          expect(timesheet_entry.errors.messages[:timesheet_entry]).to eq([error_message])
+        end
+      end
+
+      context "when time entry is not billed" do
+        it "allows employee to change non billed time entries" do
+          timesheet_entry.update(bill_status: "unbilled")
+
+          expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.errors.blank?).to be true
+        end
+      end
     end
   end
 end

--- a/spec/policies/timesheet_entry_policy_spec.rb
+++ b/spec/policies/timesheet_entry_policy_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
     end
 
     permissions :update? do
+      context "when entry belongs to same user" do
+        let(:timesheet_entry) { create(:timesheet_entry, user:, project:) }
+
+        context "when entry is not billed" do
+          it "is permitted to update the entry" do
+            expect(subject).to permit(user, timesheet_entry)
+          end
+        end
+
+        context "when entry is billed" do
+          before { timesheet_entry.update(bill_status: :billed) }
+
+          it "is not permitted to update the entry" do
+            expect(subject).not_to permit(user, timesheet_entry)
+          end
+        end
+      end
+
       it "is not permitted to update" do
         expect(subject).not_to permit(user, timesheet_entry)
       end

--- a/spec/requests/internal_api/v1/timesheet_entries/index_spec.rb
+++ b/spec/requests/internal_api/v1/timesheet_entries/index_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "InternalApi::V1::TimesheetEntry#index", type: :request do
     end
 
     it "returns the timesheet entry" do
-      expect(json_response["entries"].size).to eq(2)
+      expect(json_response["entries"].size).to eq(3)
+      expect(json_response["entries"]["currentUserRole"]).to eq(user.primary_role company)
 
       expect(json_response["entries"].keys)
         .to include(timesheet_entry1.work_date.strftime("%F"), timesheet_entry2.work_date.strftime("%F"))
@@ -60,7 +61,8 @@ RSpec.describe "InternalApi::V1::TimesheetEntry#index", type: :request do
     end
 
     it "returns the timesheet entry" do
-      expect(json_response["entries"].size).to eq(2)
+      expect(json_response["entries"].size).to eq(3)
+      expect(json_response["entries"]["currentUserRole"]).to eq(user.primary_role company)
 
       expect(json_response["entries"].keys)
         .to include(timesheet_entry1.work_date.strftime("%F"), timesheet_entry2.work_date.strftime("%F"))


### PR DESCRIPTION
Signed-off-by: sudeeptarlekar <sudeeptarlekar@gmail.com>

Fixes #711 

## Summary
Dis-allowed user to update entry after it is billed.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Tested on local on UI.
Tested using test cases.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
