### PR TITLE
Fixed viewing timesheet entries of other members

### DIFF
--- a/app/javascript/src/components/TimeTracking/MonthCalender.tsx
+++ b/app/javascript/src/components/TimeTracking/MonthCalender.tsx
@@ -9,7 +9,18 @@ const { useState, useEffect } = React;
 // Day start from monday
 dayjs.Ls.en.weekStart = 1;
 
-const MonthCalender: React.FC<Iprops> = ({ fetchEntries, selectedEmployeeId, dayInfo, entryList, selectedFullDate, setSelectedFullDate, handleWeekTodayButton, monthsAbbr, setWeekDay, setSelectDate  }) => {
+const MonthCalender: React.FC<Iprops> = ({
+  fetchEntries,
+  selectedEmployeeId,
+  dayInfo,
+  entryList,
+  selectedFullDate,
+  setSelectedFullDate,
+  handleWeekTodayButton,
+  monthsAbbr,
+  setWeekDay,
+  setSelectDate
+}) => {
   const [currentMonthNumber, setCurrentMonthNumber] = useState<number>(dayjs().month());
   const [currentYear, setCurrentYear] = useState<number>(dayjs().year());
   const [firstDay, setFirstDay] = useState<number>(dayjs().startOf("month").weekday());
@@ -166,29 +177,34 @@ const MonthCalender: React.FC<Iprops> = ({ fetchEntries, selectedEmployeeId, day
             </div>
           ))}
           <div
-            key="8"
             className="text-center text-xs text-miru-dark-purple-1000 font-medium w-28 items-center rounded-xl"
           >
           Total
           </div>
         </div>
         {
-          monthData.map((weekInfo) => (
-            <div className="my-4 bg-miru-gray-100 flex justify-between">
+          monthData.map((weekInfo, index) => (
+            <div className="my-4 bg-miru-gray-100 flex justify-between" key={index}>
               {Array.from(Array(7).keys()).map((dayNum) => (
-                weekInfo[dayNum] ? <div onClick={() => {
-                  handleWeekday(weekInfo[dayNum].date);
-                  setSelectDate(dayNum);
-                }} className={("border-2 cursor-pointer h-14 w-24 bg-white rounded-md flex justify-end p-1 " + (weekInfo[dayNum]["date"] === selectedFullDate ? "border-miru-han-purple-1000" : "border-transparent"))}>
-                  <div>
-                    <div className="flex justify-end">
-                      <p className={"text-xs font-medium " + (weekInfo[dayNum]["date"] === today ? "text-miru-white-1000 bg-miru-han-purple-1000 rounded-xl px-2" : "text-miru-dark-purple-200")}>{weekInfo[dayNum]["day"]}</p>
+                weekInfo[dayNum] ?
+                  <div
+                    key={dayNum}
+                    onClick={() => {
+                      handleWeekday(weekInfo[dayNum].date);
+                      setSelectDate(dayNum);
+                    }}
+                    className={`border-2 cursor-pointer h-14 w-24 bg-white rounded-md flex justify-end p-1
+                    ${(weekInfo[dayNum]["date"] === selectedFullDate ? "border-miru-han-purple-1000" :
+                  "border-transparent")}`}
+                  >
+                    <div>
+                      <div className="flex justify-end">
+                        <p className={"text-xs font-medium " + (weekInfo[dayNum]["date"] === today ? "text-miru-white-1000 bg-miru-han-purple-1000 rounded-xl px-2" : "text-miru-dark-purple-200")}>{weekInfo[dayNum]["day"]}</p>
+                      </div>
+                      <p className="text-2xl mx-3 text-miru-dark-purple-1000">{weekInfo[dayNum]["totalDuration"] > 0 ? minToHHMM(weekInfo[dayNum]["totalDuration"]) : ""}</p>
                     </div>
-                    <p className="text-2xl mx-3 text-miru-dark-purple-1000">{weekInfo[dayNum]["totalDuration"] > 0 ? minToHHMM(weekInfo[dayNum]["totalDuration"]) : ""}</p>
                   </div>
-                </div>
-                  :
-                  <div className="h-14 w-24 text-miru-dark-purple-1000"></div>
+                  : <div key={dayNum} className="h-14 w-24 text-miru-dark-purple-1000"></div>
               ))}
               <div className="h-14 w-24 bg-white rounded-md font-bold relative">
                 <div className="flex p-1 justify-end bottom-0 right-0 absolute">

--- a/app/javascript/src/components/TimeTracking/MonthCalender.tsx
+++ b/app/javascript/src/components/TimeTracking/MonthCalender.tsx
@@ -19,10 +19,12 @@ const MonthCalender: React.FC<Iprops> = ({
   handleWeekTodayButton,
   monthsAbbr,
   setWeekDay,
-  setSelectDate
+  setSelectDate,
+  currentMonthNumber,
+  setCurrentMonthNumber,
+  currentYear,
+  setCurrentYear
 }) => {
-  const [currentMonthNumber, setCurrentMonthNumber] = useState<number>(dayjs().month());
-  const [currentYear, setCurrentYear] = useState<number>(dayjs().year());
   const [firstDay, setFirstDay] = useState<number>(dayjs().startOf("month").weekday());
   const [daysInMonth, setDaysInMonth] = useState<number>(dayjs().daysInMonth());
   const [totalMonthDuration, setTotalMonthDuration] = useState<number>(0);
@@ -126,13 +128,6 @@ const MonthCalender: React.FC<Iprops> = ({
     handleMonthChange();
   }, [entryList]);
 
-  useEffect(() => {
-    fetchEntries(
-      dayjs(startOfTheMonth).subtract(1, "month").format("DD-MM-YYYY"),
-      dayjs(endOfTheMonth).add(1, "month").format("DD-MM-YYYY")
-    );
-  }, [selectedEmployeeId]);
-
   return (
     <div className="mb-6">
       <div className="flex justify-between items-center bg-miru-han-purple-1000 h-10 w-full">
@@ -231,6 +226,11 @@ interface Iprops {
   monthsAbbr: string[];
   setWeekDay: React.Dispatch<React.SetStateAction<number>>;
   setSelectDate: React.Dispatch<React.SetStateAction<number>>;
+  currentMonthNumber: any;
+  setCurrentMonthNumber: any;
+  currentYear: any;
+  setCurrentYear: any
+
 }
 
 export default MonthCalender;

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unexpected-multiline */
-import React, { useState, useEffect }  from "react";
+import React, { useEffect, useState }  from "react";
 
 import { TOASTER_DURATION } from "constants/index";
 

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -114,7 +114,6 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   useEffect(() => {
     if (dayInfo.length <= 0) return;
     fetchEntriesOfThreeMonths();
-    if (allEmployeesEntries[selectedEmployeeId]) setEntryList(allEmployeesEntries[selectedEmployeeId]);
   }, [selectedEmployeeId]);
 
   const handleWeekTodayButton = () => {
@@ -146,10 +145,10 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     try {
       const res = await timesheetEntryApi.list(from, to, selectedEmployeeId);
       if (res.status >= 200 && res.status < 300) {
-        setAllEmployeesEntries(
-          (prevState) => ( { ...prevState, [selectedEmployeeId]: res.data.entries } )
-        );
-        setEntryList((prevState) => ({ ...prevState, ...res.data.entries }));
+        const allEntries = { ...allEmployeesEntries };
+        allEntries[selectedEmployeeId] = { ...allEntries[selectedEmployeeId], ...res.data.entries };
+        setAllEmployeesEntries(allEntries);
+        setEntryList(allEntries[selectedEmployeeId]);
       }
       return res;
     } catch (error) {
@@ -277,8 +276,9 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
       <div className="mt-6">
         <div className="flex justify-between items-center mb-6">
           <nav className="flex">
-            {["day", "week", "month"].map(item => (
+            {["day", "week", "month"].map((item,index) => (
               <button
+                key={index}
                 onClick={() => setView(item)}
                 className={
                   item === view
@@ -428,6 +428,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
           entryList[selectedFullDate].map((entry, weekCounter) =>
             editEntryId === entry.id ? (
               <AddEntry
+                key={entry.id}
                 selectedEmployeeId={selectedEmployeeId}
                 fetchEntries={fetchEntries}
                 setNewEntryView={setNewEntryView}

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unexpected-multiline */
-import React  from "react";
+import React, { useState, useEffect }  from "react";
 
 import { TOASTER_DURATION } from "constants/index";
 
@@ -21,7 +21,6 @@ import EntryCard from "./EntryCard";
 import MonthCalender from "./MonthCalender";
 import WeeklyEntries from "./WeeklyEntries";
 
-const { useState, useEffect } = React;
 dayjs.extend(updateLocale);
 dayjs.extend(weekday);
 

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -82,13 +82,6 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     }
   };
 
-  const fetchEntriesOfThreeMonths = () => {
-    fetchEntries(
-      dayjs(dayInfo[0]["fullDate"]).startOf("month").subtract(1, "month").format("DD-MM-YYYY"),
-      dayjs(dayInfo[0]["fullDate"]).endOf("month").add(1, "month").format("DD-MM-YYYY"),
-    );
-  };
-
   useEffect(() => {
     handleWeekInfo();
   }, [weekDay]);
@@ -110,11 +103,6 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
         .format("YYYY-MM-DD")
     );
   }, [selectDate, weekDay]);
-
-  useEffect(() => {
-    if (dayInfo.length <= 0) return;
-    fetchEntriesOfThreeMonths();
-  }, [selectedEmployeeId]);
 
   const handleWeekTodayButton = () => {
     setSelectDate(0);

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -52,6 +52,8 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   const [clients, setClients] = useState<any>({});
   const [projects, setProjects] = useState<any>({});
   const [employees, setEmployees] = useState<any>([]);
+  const [currentMonthNumber, setCurrentMonthNumber] = useState<number>(dayjs().month());
+  const [currentYear, setCurrentYear] = useState<number>(dayjs().year());
 
   const employeeOptions = employees.map(e => ({ value: `${e["id"]}`, label: e["first_name"] + " " + e["last_name"] }) );
 
@@ -82,6 +84,17 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     }
   };
 
+  const fetchEntriesOfMonths = () => {
+    const firstDateOfTheMonth = `${currentYear}-${currentMonthNumber +1}-01`;
+    const startOfTheMonth = dayjs(firstDateOfTheMonth).format("YYYY-MM-DD");
+    const endOfTheMonth = dayjs(firstDateOfTheMonth).endOf("month").format("YYYY-MM-DD");
+
+    fetchEntries(
+      dayjs(startOfTheMonth).subtract(1, "month").format("DD-MM-YYYY"),
+      dayjs(endOfTheMonth).add(1, "month").format("DD-MM-YYYY")
+    );
+  };
+
   useEffect(() => {
     handleWeekInfo();
   }, [weekDay]);
@@ -103,6 +116,11 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
         .format("YYYY-MM-DD")
     );
   }, [selectDate, weekDay]);
+
+  useEffect(() => {
+    if (dayInfo.length <= 0) return;
+    fetchEntriesOfMonths();
+  }, [selectedEmployeeId]);
 
   const handleWeekTodayButton = () => {
     setSelectDate(0);
@@ -302,6 +320,10 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
                 monthsAbbr={monthsAbbr}
                 setWeekDay={setWeekDay}
                 setSelectDate={setSelectDate}
+                currentMonthNumber={currentMonthNumber}
+                setCurrentMonthNumber={setCurrentMonthNumber}
+                currentYear={currentYear}
+                setCurrentYear={setCurrentYear}
               />
               :
               <div className="mb-6">


### PR DESCRIPTION
## Notion card
https://www.notion.so/Admin-and-Owner-are-able-to-view-the-timesheet-entries-of-previously-viewed-team-members-entries-wh-294498527a0349819ee1e0add4a943ef

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Resolved the time entries of other team members view. 
- Fixed console warnings, unnecessary useEffects, fetching data twice

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://www.loom.com/share/14e24f11fe5e45cb85c8dce1bf2cd444

Other related bugs
https://www.loom.com/share/13c62315f56543f0bdb3718d8f1c93c4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
