### PR TITLE
Restrict timesheet entries to be added to only one invoice

### DIFF
--- a/app/controllers/internal_api/v1/generate_invoice_controller.rb
+++ b/app/controllers/internal_api/v1/generate_invoice_controller.rb
@@ -34,9 +34,11 @@ class InternalApi::V1::GenerateInvoiceController < InternalApi::V1::ApplicationC
 
     # merging selected_entries from params with ids already present in other invoice line items
     def filtered_ids
-      invoice_line_item_ts_ids = InvoiceLineItem.pluck(:timesheet_entry_id).uniq
+      invoice_line_item_timesheet_entry_ids = InvoiceLineItem.joins(:timesheet_entry)
+        .where(timesheet_entries: { bill_status: "unbilled" })
+        .pluck(:timesheet_entry_id).uniq
       selected_entries = (params[:selected_entries].present?) ? params[:selected_entries] : []
-      filtered_ids = (selected_entries + invoice_line_item_ts_ids).uniq
+      filtered_ids = (selected_entries + invoice_line_item_timesheet_entry_ids).uniq
     end
 
     def unselected_time_entries_filter

--- a/app/controllers/internal_api/v1/generate_invoice_controller.rb
+++ b/app/controllers/internal_api/v1/generate_invoice_controller.rb
@@ -32,8 +32,15 @@ class InternalApi::V1::GenerateInvoiceController < InternalApi::V1::ApplicationC
       @search_term ||= (params[:search_term].present?) ? params[:search_term] : "*"
     end
 
+    # merging selected_entries from params with ids already present in other invoice line items
+    def filtered_ids
+      invoice_line_item_ts_ids = InvoiceLineItem.pluck(:timesheet_entry_id).uniq
+      selected_entries = (params[:selected_entries].present?) ? params[:selected_entries] : []
+      filtered_ids = (selected_entries + invoice_line_item_ts_ids).uniq
+    end
+
     def unselected_time_entries_filter
-      { id: { not: params[:selected_entries] } }
+      { id: { not: filtered_ids } }
     end
 
     def project_filter

--- a/spec/requests/internal_api/v1/generate_invoice/index_spec.rb
+++ b/spec/requests/internal_api/v1/generate_invoice/index_spec.rb
@@ -126,5 +126,17 @@ RSpec.describe "InternalApi::V1::GeneratInvoice#index", type: :request do
        expect(json_response["new_line_item_entries"]).to eq(JSON.parse(expected_invoice_line_items.to_json))
      end
    end
+
+    context "when the timesheet entry is already added to another draft invoice" do
+     it "returns empty new_line_item_entries result" do
+       create(:invoice_line_item, timesheet_entry_id: timesheet_entry.id)
+       send_request :get, internal_api_v1_generate_invoice_index_path(client_id: client.id), params: {
+         params: @search_params
+       }
+       expect(response).to have_http_status(:ok)
+       expect(json_response["filter_options"]).to eq(JSON.parse(filter_options.to_json))
+       expect(json_response["new_line_item_entries"]).to be_empty
+     end
+   end
   end
 end


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Bug-If-a-timesheet-entry-has-been-added-to-an-invoice-in-draft-status-and-if-I-create-new-invoice--6255fd6ba598482eaa30e0363afcd093

## Summary
If a timesheet entry was added to an invoice in draft status and if we create a new invoice then those entries were still available to be added to the new invoice. This pr fixes this bug and restrict entries to be displayed only if they are not a part of any other invoice.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
On local

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
