### PR TITLE
Default month view on /time-tracking

### DIFF
--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -32,7 +32,7 @@ dayjs.Ls.en.weekStart = 1;
 
 const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   const [dayInfo, setDayInfo] = useState<any[]>([]);
-  const [view, setView] = useState<string>("day");
+  const [view, setView] = useState<string>("month");
   const [newEntryView, setNewEntryView] = useState<boolean>(false);
   const [newRowView, setNewRowView] = useState<boolean>(false);
   const [selectDate, setSelectDate] = useState<number>(dayjs().weekday());
@@ -281,7 +281,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
       <div className="mt-6">
         <div className="flex justify-between items-center mb-6">
           <nav className="flex">
-            {["day", "week", "month"].map((item,index) => (
+            {["month", "week", "day"].map((item,index) => (
               <button
                 key={index}
                 onClick={() => setView(item)}


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Change-the-Default-Time-tracking-view-to-Month-2e6723386b1c4145b727108f473f4b5c

## Summary
- Default view set to month from the day.
- Selection of /time-tracking view from Day, Week, Month to Month, Week, Day.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
<img width="1439" alt="Screenshot 2022-11-08 at 4 58 14 PM" src="https://user-images.githubusercontent.com/33005890/200552719-10bca749-bbf5-4d3f-bb13-0ea694cfe7dd.png">

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have added automated tests for my code
