### PR TITLE
Fix refresh invoices list after sending invoice

### DIFF
--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -72,21 +72,23 @@ const SendInvoice: React.FC<any> = ({
   }, [newRecipient]);
 
   const handleSubmit = async (event: FormEvent) => {
-    try {
-      event.preventDefault();
-      setStatus(InvoiceStatus.LOADING);
+    if (invoiceEmail?.recipients.length > 0){
+      try {
+        event.preventDefault();
+        setStatus(InvoiceStatus.LOADING);
 
-      const payload = { invoice_email: invoiceEmail };
-      const {
-        data: { message }
-      } = await invoicesApi.sendInvoice(invoice.id, payload);
+        const payload = { invoice_email: invoiceEmail };
+        const {
+          data: { message }
+        } = await invoicesApi.sendInvoice(invoice.id, payload);
 
-      Toastr.success(message);
-      setStatus(InvoiceStatus.SUCCESS);
-      setIsSending(false);
-      setTimeout(fetchInvoices, 6000);
-    } catch (error) {
-      setStatus(InvoiceStatus.ERROR);
+        Toastr.success(message);
+        setStatus(InvoiceStatus.SUCCESS);
+        setIsSending(false);
+        setTimeout(fetchInvoices, 6000);
+      } catch (error) {
+        setStatus(InvoiceStatus.ERROR);
+      }
     }
   };
 
@@ -228,13 +230,21 @@ const SendInvoice: React.FC<any> = ({
                   type="button"
                   onClick={handleSubmit}
                   className={cn(
-                    "flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border border-transparent rounded-md shadow-sm bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-miru-han-purple-600",
+                    `flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border
+                    border-transparent rounded-md shadow-sm
+                    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-miru-han-purple-600
+                    ${invoiceEmail?.recipients.length > 0 ?
+      "bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 cursor-pointer":
+      "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
+    }
+                    `,
                     {
                       "hover:bg-miru-chart-green-400 bg-miru-chart-green-600":
                         status === InvoiceStatus.SUCCESS
                     }
+
                   )}
-                  disabled={isDisabled(status)}
+                  disabled={invoiceEmail?.recipients.length > 0 || isDisabled(status)}
                 >
                   {buttonText(status)}
                 </button>

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -232,9 +232,9 @@ const SendInvoice: React.FC<any> = ({
                   className={cn(
                     `flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border
                     border-transparent rounded-md shadow-sm
-                    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-miru-han-purple-600
                     ${invoiceEmail?.recipients.length > 0 ?
-      "bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 cursor-pointer":
+      `bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 cursor-pointer focus:outline-none focus:ring-2
+                        focus:ring-offset-2 focus:ring-miru-han-purple-600`:
       "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
     }
                     `,
@@ -242,7 +242,6 @@ const SendInvoice: React.FC<any> = ({
                       "hover:bg-miru-chart-green-400 bg-miru-chart-green-600":
                         status === InvoiceStatus.SUCCESS
                     }
-
                   )}
                   disabled={invoiceEmail?.recipients.length > 0 || isDisabled(status)}
                 >

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -243,7 +243,7 @@ const SendInvoice: React.FC<any> = ({
                         status === InvoiceStatus.SUCCESS
                     }
                   )}
-                  disabled={invoiceEmail?.recipients.length > 0 || isDisabled(status)}
+                  disabled={invoiceEmail?.recipients.length <= 0 || isDisabled(status)}
                 >
                   {buttonText(status)}
                 </button>

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -46,7 +46,12 @@ const Recipient: React.FC<{ email: string; handleClick: any }> = ({
   </div>
 );
 
-const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending }) => {
+const SendInvoice: React.FC<any> = ({
+  invoice,
+  setIsSending,
+  isSending,
+  fetchInvoices
+}) => {
   const [status, setStatus] = useState<InvoiceStatus>(InvoiceStatus.IDLE);
   const [invoiceEmail, setInvoiceEmail] = useState<InvoiceEmail>({
     subject: emailSubject(invoice),
@@ -79,6 +84,7 @@ const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending }) => {
       Toastr.success(message);
       setStatus(InvoiceStatus.SUCCESS);
       setIsSending(false);
+      setTimeout(fetchInvoices, 6000);
     } catch (error) {
       setStatus(InvoiceStatus.ERROR);
     }

--- a/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
@@ -23,7 +23,8 @@ const TableRow = ({
   selectInvoices,
   deselectInvoices,
   setShowDeleteDialog,
-  setInvoiceToDelete
+  setInvoiceToDelete,
+  fetchInvoices
 }) => {
   const [isSending, setIsSending] = useState<boolean>(false);
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
@@ -136,7 +137,12 @@ const TableRow = ({
         />
       </td>
       {isSending && (
-        <SendInvoice invoice={invoice} setIsSending={setIsSending} isSending />
+        <SendInvoice
+          invoice={invoice}
+          setIsSending={setIsSending}
+          fetchInvoices={fetchInvoices}
+          isSending
+        />
       )}
     </tr>
   );

--- a/app/javascript/src/components/Invoices/List/Table/index.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/index.tsx
@@ -9,7 +9,8 @@ const Table = ({
   deselectInvoices,
   selectedInvoices,
   setShowDeleteDialog,
-  setInvoiceToDelete
+  setInvoiceToDelete,
+  fetchInvoices
 }) => (
 
   <table className="min-w-full mt-4 divide-y divide-gray-200 overflow-x-scroll">
@@ -32,6 +33,7 @@ const Table = ({
           deselectInvoices={deselectInvoices}
           setShowDeleteDialog={setShowDeleteDialog}
           setInvoiceToDelete={setInvoiceToDelete}
+          fetchInvoices={fetchInvoices}
         />
       ))}
     </tbody>

--- a/app/javascript/src/components/Invoices/List/container.tsx
+++ b/app/javascript/src/components/Invoices/List/container.tsx
@@ -19,7 +19,8 @@ const Container = ({
   filterParams,
   setFilterParams,
   filterIntialValues,
-  filterParamsStr
+  filterParamsStr,
+  fetchInvoices
 }) => {
   const [isDesktop, setIsDesktop] = useState(innerWidth > 650);
   let appliedFilterCount = (filterParamsStr.match(/&/g) || []).length;
@@ -120,6 +121,7 @@ const Container = ({
           deselectInvoices={deselectInvoices}
           setShowDeleteDialog={setShowDeleteDialog}
           setInvoiceToDelete={setInvoiceToDelete}
+          fetchInvoices={fetchInvoices}
         />
       </>
     </div>

--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -159,6 +159,7 @@ const Invoices: React.FC = () => {
             setFilterParams={setFilterParams}
             filterIntialValues={filterIntialValues}
             filterParamsStr={filterParamsStr}
+            fetchInvoices={fetchInvoices}
           />
 
           {isFilterVisible && (

--- a/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/index.tsx
@@ -238,14 +238,21 @@ const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending, handleSa
                   type="button"
                   onClick={handleSubmit}
                   className={cn(
-                    "flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border border-transparent rounded-md shadow-sm bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-miru-han-purple-600",
+                    `flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border
+                    border-transparent rounded-md shadow-sm
+                    ${invoiceEmail?.recipients.length > 0 ?
+      `bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 cursor-pointer focus:outline-none focus:ring-2
+                        focus:ring-offset-2 focus:ring-miru-han-purple-600`:
+      "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
+    }
+                    `,
                     {
                       "hover:bg-miru-chart-green-400 bg-miru-chart-green-600":
                         status === InvoiceStatus.SUCCESS
                     }
                   )}
                   data-cy ="send-email"
-                  disabled={isDisabled(status)}
+                  disabled={invoiceEmail?.recipients.length <= 0 || isDisabled(status)}
                 >
                   {buttonText(status)}
                 </button>

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -243,7 +243,7 @@ const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending }) => {
                     }
                   )}
                   data-cy ="send-email"
-                  disabled={invoiceEmail?.recipients.length > 0 || isDisabled(status)}
+                  disabled={invoiceEmail?.recipients.length <= 0 || isDisabled(status)}
                 >
                   {buttonText(status)}
                 </button>

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -69,17 +69,19 @@ const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending }) => {
   }, [newRecipient]);
 
   const handleSubmit = async (event: FormEvent) => {
-    try {
-      event.preventDefault();
-      setStatus(InvoiceStatus.LOADING);
+    if (invoiceEmail?.recipients.length > 0){
+      try {
+        event.preventDefault();
+        setStatus(InvoiceStatus.LOADING);
 
-      const payload = { invoice_email: invoiceEmail };
-      const resp = await invoicesApi.sendInvoice(invoice.id, payload);
+        const payload = { invoice_email: invoiceEmail };
+        const resp = await invoicesApi.sendInvoice(invoice.id, payload);
 
-      Toastr.success(resp.data.message);
-      setStatus(InvoiceStatus.SUCCESS);
-    } catch (error) {
-      setStatus(InvoiceStatus.ERROR);
+        Toastr.success(resp.data.message);
+        setStatus(InvoiceStatus.SUCCESS);
+      } catch (error) {
+        setStatus(InvoiceStatus.ERROR);
+      }
     }
   };
 
@@ -227,14 +229,21 @@ const SendInvoice: React.FC<any> = ({ invoice, setIsSending, isSending }) => {
                   type="button"
                   onClick={handleSubmit}
                   className={cn(
-                    "flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border border-transparent rounded-md shadow-sm bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-miru-han-purple-600",
+                    `flex justify-center w-full p-3 mt-6 text-lg font-bold text-white uppercase border
+                    border-transparent rounded-md shadow-sm
+                    ${invoiceEmail?.recipients.length > 0 ?
+      `bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 cursor-pointer focus:outline-none focus:ring-2
+                        focus:ring-offset-2 focus:ring-miru-han-purple-600`:
+      "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
+    }
+                    `,
                     {
                       "hover:bg-miru-chart-green-400 bg-miru-chart-green-600":
                         status === InvoiceStatus.SUCCESS
                     }
                   )}
                   data-cy ="send-email"
-                  disabled={isDisabled(status)}
+                  disabled={invoiceEmail?.recipients.length > 0 || isDisabled(status)}
                 >
                   {buttonText(status)}
                 </button>


### PR DESCRIPTION
## Notion card
https://www.notion.so/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=d07557a0b1244a49b31b13627e059d9e&pm=s

https://sentry.io/organizations/saeloun-inc/issues/3679710947/?project=4504002776662016&query=is%3Aunresolved&referrer=issue-stream

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Auto refresh once we send the invoice from invoices list page.
- Auto refresh will only happen once. If the invoice status still not changes in the mean time as it is asynchoronus action & sendgrid handles the mail delivery. User has to manual refresh the screen. 
- Can't send invoice if mail recipients are not present. 
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://share.vidyard.com/watch/o8WSeWb6kyqvZgCRKsLvp4?
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
