### PR TITLE
Invoice summury click actions

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
@@ -2,7 +2,12 @@ import React from "react";
 
 import { currencyNotationFormat } from "helpers";
 
-const InvoiceSummary = ({ summary, baseCurrency, filterParams, setFilterParams }) => {
+const InvoiceSummary = ({
+  summary,
+  baseCurrency,
+  filterParams,
+  setFilterParams
+}) => {
   const formattedAmount = (amount) =>
     currencyNotationFormat({ baseCurrency: baseCurrency, amount });
 
@@ -16,7 +21,8 @@ const InvoiceSummary = ({ summary, baseCurrency, filterParams, setFilterParams }
               ["status"]: [{ value: "overdue", label: "OVERDUE" }]
             })
           }
-          className="page-display__box flex items-center md:items-start">
+          className="page-display__box flex items-center md:items-start cursor-pointer"
+        >
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Overdue
           </p>
@@ -29,11 +35,14 @@ const InvoiceSummary = ({ summary, baseCurrency, filterParams, setFilterParams }
           onClick={() =>
             setFilterParams({
               ...filterParams,
-              ["status"]: [{ value: "sent", label: "SENT" },
-                { value: "viewed", label: "VIEWED" }]
+              ["status"]: [
+                { value: "sent", label: "SENT" },
+                { value: "viewed", label: "VIEWED" }
+              ]
             })
           }
-          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
+          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start cursor-pointer"
+        >
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Outstanding
           </p>
@@ -49,7 +58,8 @@ const InvoiceSummary = ({ summary, baseCurrency, filterParams, setFilterParams }
               ["status"]: [{ value: "draft", label: "DRAFT" }]
             })
           }
-          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
+          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start cursor-pointer"
+        >
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Amount in draft
           </p>

--- a/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
@@ -2,14 +2,21 @@ import React from "react";
 
 import { currencyNotationFormat } from "helpers";
 
-const InvoiceSummary = ({ summary, baseCurrency }) => {
+const InvoiceSummary = ({ summary, baseCurrency, filterParams, setFilterParams }) => {
   const formattedAmount = (amount) =>
     currencyNotationFormat({ baseCurrency: baseCurrency, amount });
 
   return (
     <div className="px-10 py-10 mt-6 bg-miru-han-purple-1000 text-white rounded-2xl overflow-x-auto">
       <ul className="mt-0 border-t-0 page-display__wrap">
-        <li className="page-display__box flex items-center md:items-start">
+        <li
+          onClick={() =>
+            setFilterParams({
+              ...filterParams,
+              ["status"]: [{ value: "overdue", label: "OVERDUE" }]
+            })
+          }
+          className="page-display__box flex items-center md:items-start">
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Overdue
           </p>
@@ -18,7 +25,15 @@ const InvoiceSummary = ({ summary, baseCurrency }) => {
           </p>
         </li>
 
-        <li className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
+        <li
+          onClick={() =>
+            setFilterParams({
+              ...filterParams,
+              ["status"]: [{ value: "sent", label: "SENT" },
+                { value: "viewed", label: "VIEWED" }]
+            })
+          }
+          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Outstanding
           </p>
@@ -27,7 +42,14 @@ const InvoiceSummary = ({ summary, baseCurrency }) => {
           </p>
         </li>
 
-        <li className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
+        <li
+          onClick={() =>
+            setFilterParams({
+              ...filterParams,
+              ["status"]: [{ value: "draft", label: "DRAFT" }]
+            })
+          }
+          className="page-display__box mt-8 md:mt-0 flex items-center md:items-start">
           <p className="text-sm text-white font-normal tracking-widest uppercase">
             Amount in draft
           </p>

--- a/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
@@ -11,16 +11,18 @@ const InvoiceSummary = ({
   const formattedAmount = (amount) =>
     currencyNotationFormat({ baseCurrency: baseCurrency, amount });
 
+  const applyFilter = (status) => {
+    setFilterParams({
+      ...filterParams,
+      ["status"]: status
+    });
+  };
+
   return (
     <div className="px-10 py-10 mt-6 bg-miru-han-purple-1000 text-white rounded-2xl overflow-x-auto">
       <ul className="mt-0 border-t-0 page-display__wrap">
         <li
-          onClick={() =>
-            setFilterParams({
-              ...filterParams,
-              ["status"]: [{ value: "overdue", label: "OVERDUE" }]
-            })
-          }
+          onClick={() => applyFilter([{ value: "overdue", label: "OVERDUE" }])}
           className="page-display__box flex items-center md:items-start cursor-pointer"
         >
           <p className="text-sm text-white font-normal tracking-widest uppercase">
@@ -33,14 +35,11 @@ const InvoiceSummary = ({
 
         <li
           onClick={() =>
-            setFilterParams({
-              ...filterParams,
-              ["status"]: [
-                { value: "sent", label: "SENT" },
-                { value: "viewed", label: "VIEWED" },
-                { value: "overdue", label: "OVERDUE" }
-              ]
-            })
+            applyFilter([
+              { value: "sent", label: "SENT" },
+              { value: "viewed", label: "VIEWED" },
+              { value: "overdue", label: "OVERDUE" }
+            ])
           }
           className="page-display__box mt-8 md:mt-0 flex items-center md:items-start cursor-pointer"
         >
@@ -53,12 +52,7 @@ const InvoiceSummary = ({
         </li>
 
         <li
-          onClick={() =>
-            setFilterParams({
-              ...filterParams,
-              ["status"]: [{ value: "draft", label: "DRAFT" }]
-            })
-          }
+          onClick={() => applyFilter([{ value: "draft", label: "DRAFT" }])}
           className="page-display__box mt-8 md:mt-0 flex items-center md:items-start cursor-pointer"
         >
           <p className="text-sm text-white font-normal tracking-widest uppercase">

--- a/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceSummary/index.tsx
@@ -37,7 +37,8 @@ const InvoiceSummary = ({
               ...filterParams,
               ["status"]: [
                 { value: "sent", label: "SENT" },
-                { value: "viewed", label: "VIEWED" }
+                { value: "viewed", label: "VIEWED" },
+                { value: "overdue", label: "OVERDUE" }
               ]
             })
           }

--- a/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
+++ b/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
@@ -410,7 +410,9 @@ const FilterSideBar = ({
                       }
                       name="status"
                       checkboxValue={status.value}
-                      isChecked={filters.status.includes(status)}
+                      isChecked={filters.status.some(
+                        (e) => e.value === status.value
+                      )}
                       handleCheck={(event) =>
                         handleSelectFilter(status, event.target)
                       }

--- a/app/javascript/src/components/Invoices/List/RecentlyUpdated/index.tsx
+++ b/app/javascript/src/components/Invoices/List/RecentlyUpdated/index.tsx
@@ -23,9 +23,9 @@ const RecentlyUpdated = ({ invoice }) => {
       <div className="flex justify-center md:my-3 my-1">
         <Avatar />
       </div>
-      <p className="mt-1 mb-2.5 font-semibold md:text-base text-sm text-center capitalize text-miru-dark-purple-1000 leading-5 h-11 flex justify-center items-center">
+      <div className="mt-1 mb-2.5 font-semibold md:text-base text-sm text-center capitalize text-miru-dark-purple-1000 leading-5 h-11 flex justify-center items-center">
         <p className="truncateOverflowText">{invoice.client.name}</p>
-      </p>
+      </div>
       <h1 className="mt-2.5 mb-1 md:text-xl text-base font-bold text-miru-dark-purple-1000 truncate">
         {" "}
         {formattedAmount(invoice.amount, invoice.company.baseCurrency)}{" "}

--- a/app/javascript/src/components/Invoices/List/container.tsx
+++ b/app/javascript/src/components/Invoices/List/container.tsx
@@ -13,13 +13,17 @@ const Container = ({
   selectInvoices,
   deselectInvoices,
   setShowDeleteDialog,
-  setInvoiceToDelete
+  setInvoiceToDelete,
+  filterParams,
+  setFilterParams
 }) =>
   invoices.length > 0 ? (
     <div className="overflow-x-scroll flex flex-col items-stretch">
       <InvoiceSummary
         summary={summary}
         baseCurrency={invoices[0].company.baseCurrency}
+        filterParams={filterParams}
+        setFilterParams={setFilterParams}
       />
 
       <div className="my-20">

--- a/app/javascript/src/components/Invoices/List/container.tsx
+++ b/app/javascript/src/components/Invoices/List/container.tsx
@@ -86,7 +86,7 @@ const Container = ({
               (param) =>
                 Array.isArray(param) ?
                   param.map((val) => (
-                    <span className="mx-2 px-2 h-6 font-normal text-xs text-miru-dark-purple-1000 bg-miru-gray-400 rounded-xl flex items-center justify-between capitalize">
+                    <span key={val.value} className="mx-2 px-2 h-6 font-normal text-xs text-miru-dark-purple-1000 bg-miru-gray-400 rounded-xl flex items-center justify-between capitalize">
                       {val.label}
                       <X
                         size={12}

--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -155,6 +155,8 @@ const Invoices: React.FC = () => {
             deselectInvoices={deselectInvoices}
             setShowDeleteDialog={setShowDeleteDialog}
             setInvoiceToDelete={setInvoiceToDelete}
+            filterParams= {filterParams}
+            setFilterParams={setFilterParams}
           />
 
           {isFilterVisible && (


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/clicking-on-oustanding-overdue-and-draft-amount-section-the-respective-invoices-should-be-displaye-a95e2e433aab41859721be01aaf542d3
## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- The invoices are getting filtered as per the selected invoice status on clicking invoice summary dashboard.
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

https://www.loom.com/share/fca1af602e734ea9a83994906e883b27
## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
