### PR TITLE
Fix: can edit non billed entries

### DIFF
--- a/app/controllers/internal_api/v1/timesheet_entry_controller.rb
+++ b/app/controllers/internal_api/v1/timesheet_entry_controller.rb
@@ -30,7 +30,7 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
   def update
     authorize current_timesheet_entry
     current_timesheet_entry.project = current_project
-    current_timesheet_entry.update!(timesheet_entry_param)
+    current_timesheet_entry.update!(timesheet_entry_params)
     render json: { notice: I18n.t("timesheet_entry.update.message"), entry: current_timesheet_entry.formatted_entry },
       status: :ok
   end

--- a/app/controllers/internal_api/v1/timesheet_entry_controller.rb
+++ b/app/controllers/internal_api/v1/timesheet_entry_controller.rb
@@ -30,8 +30,9 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
   def update
     authorize current_timesheet_entry
     current_timesheet_entry.project = current_project
+    current_timesheet_entry.update!(timesheet_entry_param)
     render json: { notice: I18n.t("timesheet_entry.update.message"), entry: current_timesheet_entry.formatted_entry },
-      status: :ok if current_timesheet_entry.update(timesheet_entry_update_params)
+      status: :ok
   end
 
   def destroy
@@ -51,9 +52,5 @@ class InternalApi::V1::TimesheetEntryController < InternalApi::V1::ApplicationCo
 
     def timesheet_entry_params
       params.require(:timesheet_entry).permit(:project_id, :duration, :work_date, :note, :bill_status)
-    end
-
-    def timesheet_entry_update_params
-      params.require(:timesheet_entry).permit(:project_id, :duration, :work_date, :note)
     end
 end

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -117,15 +117,39 @@ RSpec.describe TimesheetEntry, type: :model do
           timesheet_entry.update(bill_status: "unbilled")
 
           expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.bill_status).to eq("unbilled")
           expect(timesheet_entry.errors.blank?).to be true
         end
       end
 
-      context "when time entry is not billed" do
-        it "allows owners and admins to edit the billed time entry" do
+      context "when time entry is non billable" do
+        before do
+          timesheet_entry.update!(bill_status: "non_billable")
+        end
+
+        it "allows owners and admins to edit the non billable time entry to unbilled" do
+          expect(timesheet_entry.bill_status).to eq("non_billable")
+
           timesheet_entry.update(bill_status: "unbilled")
 
           expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.bill_status).to eq("unbilled")
+          expect(timesheet_entry.errors.blank?).to be true
+        end
+      end
+
+      context "when time entry is unbilled" do
+        before do
+          timesheet_entry.update!(bill_status: "unbilled")
+        end
+
+        it "allows owners and admins to edit the unbilled time entry to non billable" do
+          expect(timesheet_entry.bill_status).to eq("unbilled")
+
+          timesheet_entry.update(bill_status: "non_billable")
+
+          expect(timesheet_entry.valid?).to be_truthy
+          expect(timesheet_entry.bill_status).to eq("non_billable")
           expect(timesheet_entry.errors.blank?).to be true
         end
       end

--- a/spec/requests/internal_api/v1/timesheet_entries/update_spec.rb
+++ b/spec/requests/internal_api/v1/timesheet_entries/update_spec.rb
@@ -46,6 +46,26 @@ RSpec.describe "InternalApi::V1::TimesheetEntry#update", type: :request do
       expect(json_response["entry"]["bill_status"]).to match("billed")
       expect(json_response["notice"]).to match("Timesheet updated")
     end
+
+    context "when time entry record is billed one" do
+      before do
+        timesheet_entry.update!(bill_status: "billed")
+      end
+
+      it "they should be able to update billed time entry record to unbiiled successfully" do
+        expect(timesheet_entry.bill_status).to eq("billed")
+
+        send_request :patch, internal_api_v1_timesheet_entry_path(timesheet_entry.id), params: {
+          project_id: project.id,
+          timesheet_entry: {
+            bill_status: :unbilled
+          }
+        }
+
+        expect(response).to be_successful
+        expect(json_response["entry"]["bill_status"]).to match("unbilled")
+      end
+    end
   end
 
   context "when user is an employee" do
@@ -73,6 +93,26 @@ RSpec.describe "InternalApi::V1::TimesheetEntry#update", type: :request do
       expect(json_response["entry"]["note"]).to match("Updated Note")
       expect(json_response["entry"]["bill_status"]).to match("billed")
       expect(json_response["notice"]).to match("Timesheet updated")
+    end
+
+    context "when time entry record is billed one" do
+      before do
+        timesheet_entry.update!(bill_status: "billed")
+      end
+
+      it "they should not be able to update billed time entry record" do
+        expect(timesheet_entry.bill_status).to eq("billed")
+
+        send_request :patch, internal_api_v1_timesheet_entry_path(timesheet_entry.id), params: {
+          project_id: project.id,
+          timesheet_entry: {
+            bill_status: :unbilled
+          }
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response["errors"]).to include("You are not authorized to perform this action.")
+      end
     end
   end
 


### PR DESCRIPTION
## Notion card
https://www.notion.so/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=6aa4a6bfa674450b8644d56720c38015&pm=s

## Summary
<!-- Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change. -->
- Employees can't edit the billed entries but can edit the billable and non-billable entries.
- Admin & owner can edit billed entries and all the entries
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
https://share.vidyard.com/watch/SRkKxsQ5yc5SzXEFDcqQby?
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have added automated tests for my code
