### PR TITLE
Fixes libffi load error in CI

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Setup Env's
         run: |
           cp .env.example .env
+      - name: ffi pristine
+        run: bundle pristine ffi
       - name: Setup test database
         env:
           RAILS_ENV: test


### PR DESCRIPTION
## Notion card

## Summary
Fixes [libffi load error](https://github.com/ffi/ffi/issues/881#issuecomment-1189739345) in CI.

```
LoadError: libffi.so.7: cannot open shared object file: No such file or directory - /home/runner/work/miru-web/miru-web/vendor/bundle/ruby/3. 1.0/gems/ffi-1.15.5/lib/ffi_c. so
```

## Preview
N/A

## Type of change

N/A

## How Has This Been Tested?

N/A

### Checklist:

N/A