### PR TITLE
Upgraded the ruby version in docker to 3.1.3

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.1.3
 
 FROM ruby:$RUBY_VERSION-slim AS base
 

--- a/deployment/fly/Dockerfile.production
+++ b/deployment/fly/Dockerfile.production
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.1.3
 ARG VARIANT=jemalloc-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 

--- a/deployment/fly/Dockerfile.staging
+++ b/deployment/fly/Dockerfile.staging
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.1.3
 ARG VARIANT=jemalloc-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 


### PR DESCRIPTION
## Notion card

## Summary
Recent ruby upgrade to 3.1.3 caused a staging deployment failure on the fly. This is because we missed to updated the ruby version in the docker container.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
