### PR TITLE
Fix-failing-invoice-download-test

### DIFF
--- a/cypress/e2e/invoices/invoiceDownload.spec.js
+++ b/cypress/e2e/invoices/invoiceDownload.spec.js
@@ -32,7 +32,6 @@ describe("invoices index page", () => {
     const invoice_number = fake.invoiceNumber
     const reference = fake.validReference
     cy.sendInvoice(invoice_number, reference)
-    cy.visit(invoicesPath)
     cy.get(invoicesSelector.searchBar).clear().type(invoice_number).type('{enter}')
     cy.get(invoicesSelector.viewInvoice).first().click({force:true})
     cy.get(invoicesSelector.moreOptionsView).click()


### PR DESCRIPTION
## Notion card

## Summary
Fixed the failing invoice download spec.

## Preview
All invoice download specs passing on staging
<img width="1792" alt="Screenshot 2022-12-12 at 3 00 20 PM" src="https://user-images.githubusercontent.com/18750194/207010474-77a1145f-fccc-4f23-9fa2-cfef543815a3.png">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
