### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/requests/internal_api/v1/reports/time_entry/download_spec.rb
+++ b/spec/requests/internal_api/v1/reports/time_entry/download_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "InternalApi::V1::Reports::TimeEntryController#download", type: :
     admin.add_role :admin, company
     employee.add_role :employee, company
     book_keeper.add_role :book_keeper, company
+    TimesheetEntry.search_index.refresh
   end
 
   context "when user is an admin or owner" do

--- a/spec/requests/internal_api/v1/team_members/details/update_spec.rb
+++ b/spec/requests/internal_api/v1/team_members/details/update_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "InternalApi::V1::TeamMembers::DetailsController::#update", type:
     @user_details = {
       # first name is kept the same for testing, rest all fields are updated
       first_name: user.first_name,
-      last_name: Faker::Name.last_name,
+      last_name: Faker::Alphanumeric.alpha(number: 2..10),
       phone: Faker::PhoneNumber.phone_number_with_country_code,
       date_of_birth: Faker::Date.between(from: "1990-01-01", to: "2000-01-01"),
       personal_email_id: Faker::Internet.safe_email,


### PR DESCRIPTION
## Notion card

## Summary
Fixed the following flaky specs:

1. Spec - spec/requests/internal_api/v1/team_members/details/update_spec.rb:

`InternalApi::V1::TeamMembers::DetailsController::#update when Employee wants to update his own details is successful
     Failure/Error: expect(response).to have_http_status(:ok)
       expected the response to have status code :ok (200) but it was :unprocessable_entity ([42](https://github.com/saeloun/miru-web/actions/runs/3673181224/jobs/6212369080#step:20:43)2)
     # ./spec/requests/internal_api/v1/team_members/details/update_spec.rb:83:in `block (3 levels) in <top (required)>'`

Problem was, in lastname param, we expect only alphabets and sometimes faker was adding `'` in the string while generating last name

2. Spec - spec/requests/internal_api/v1/reports/time_entry/download_spec.rb
Fix: Spec was not able to get document from the ES, added index refresh call.


## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
