### PR TITLE
Removed entries from generate invoice won't be visible on the saved invoice

### DIFF
--- a/app/javascript/src/mapper/generateInvoice.mapper.ts
+++ b/app/javascript/src/mapper/generateInvoice.mapper.ts
@@ -56,6 +56,7 @@ const mapGenerateInvoice = input => ({
     rate: ilt.rate,
     quantity: ilt.quantity,
     timesheet_entry_id: ilt.timesheet_entry_id,
+    _destroy: ilt._destroy,
   })),
 });
 


### PR DESCRIPTION
## Notion card
Closes #864 

## Summary
<!-- Please include a summary of the change and which issue is fixed — ensure you answer 
what and why. Please also include relevant motivation and context. List any dependencies 
that are required for this change. -->
- Currently When we create an invoice, on the generate invoice page we add entries. After adding line items if we remove any line item from the generate invoice it will be removed there, but it appears once the invoice is saved.
- With this PR removed entries from generate invoice won't be visible on the saved invoice.

## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->

**Before**

https://user-images.githubusercontent.com/52771571/208568332-0af6d0e2-ec07-4b4f-b84e-fae2ccff5fc7.mov


**After**

https://user-images.githubusercontent.com/52771571/208568131-5d9374f3-e02b-4638-877d-7546285a8a4b.mov



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
