### PR TITLE
moreoptions button removed from generate invoice page

### DIFF
--- a/app/javascript/src/components/Invoices/Edit/index.tsx
+++ b/app/javascript/src/components/Invoices/Edit/index.tsx
@@ -139,6 +139,7 @@ const EditInvoice = () => {
     return (
       <Fragment>
         <Header
+          showMoreButton
           formType="edit"
           handleSaveInvoice={handleSaveInvoice}
           handleSendInvoice={handleSendInvoice}

--- a/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
@@ -23,6 +23,7 @@ const Header = ({
   invoiceNumber = null,
   id = null,
   deleteInvoice = null,
+  showMoreButton = false,
 }) => {
   const [isMoreOptionsVisible, setIsMoreOptionsVisible] =
     useState<boolean>(false);
@@ -82,17 +83,19 @@ const Header = ({
               SEND TO
             </span>
           </button>
-          <div ref={wrapperRef}>
-            <MoreButton
-              onClick={() => setIsMoreOptionsVisible(!isMoreOptionsVisible)}
-            />
-            {isMoreOptionsVisible && (
-              <MoreOptions
-                deleteInvoice={deleteInvoice}
-                downloadInvoice={null}
+          {showMoreButton && (
+            <div ref={wrapperRef}>
+              <MoreButton
+                onClick={() => setIsMoreOptionsVisible(!isMoreOptionsVisible)}
               />
-            )}
-          </div>
+              {isMoreOptionsVisible && (
+                <MoreOptions
+                  deleteInvoice={deleteInvoice}
+                  downloadInvoice={null}
+                />
+              )}
+            </div>
+          )}
         </div>
       </div>
     </Fragment>


### PR DESCRIPTION
## Notion card
NA
## Summary
<!-- Please include a summary of the change and which issue is fixed — ensure you answer 
what and why. Please also include relevant motivation and context. List any dependencies 
that are required for this change. -->
- More options button removed from generate invoice page.
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
Before:
<img width="1430" alt="Screenshot 2022-12-22 at 11 53 27 AM" src="https://user-images.githubusercontent.com/72149587/209070748-50938748-f935-45cd-88cf-9dc5e36cff70.png">

After:
<img width="1400" alt="Screenshot 2022-12-22 at 11 52 31 AM" src="https://user-images.githubusercontent.com/72149587/209070619-ca7bde13-90be-45f8-8e16-ff81bae04c20.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->
- Checked if button is removed from generate invoice page but visible on view invoice and edit invoice page with required actions.
### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code

