### PR TITLE
Add Rspec Retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,4 +209,6 @@ group :test do
   # Strategies for cleaning databases in Ruby.
   gem "database_cleaner", "~> 2.0"
   gem "hash_dot"
+
+  gem "rspec-retry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,6 @@ GEM
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
-    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
@@ -406,6 +405,8 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.12.0)
     rubocop (1.40.0)
       json (~> 2.3)
@@ -535,7 +536,6 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
-  ruby
   arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
@@ -584,6 +584,7 @@ DEPENDENCIES
   redis (~> 4.0)
   rolify (~> 6.0)
   rspec-rails (~> 5.0, >= 5.0.2)
+  rspec-retry
   rubocop
   rubocop-performance
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "simplecov"
 require "pundit/rspec"
 require "sidekiq/testing"
 require "webmock/rspec"
+require "rspec/retry"
 
 if ENV.fetch("COVERAGE", false)
   SimpleCov.start "rails" do
@@ -114,4 +115,25 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+end
+
+https :/ / github.com / NoRedInk / rspec - retry # installation
+RSpec.configure do |config|
+  # show retry status in spec process
+  config.verbose_retry = true
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
+
+  # run retry only on features
+  config.around do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  # callback to be run between retries
+  # config.retry_callback = proc do |ex|
+  #   # run some additional clean up task - can be filtered by example metadata
+  #   if ex.metadata[:js]
+  #     Capybara.reset!
+  #   end
+  # end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,7 +117,6 @@ RSpec.configure do |config|
 =end
 end
 
-- retry 
 RSpec.configure do |config|
   # show retry status in spec process
   config.verbose_retry = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,7 +117,7 @@ RSpec.configure do |config|
 =end
 end
 
-https :/ / github.com / NoRedInk / rspec - retry # installation
+# https :/ / github.com / NoRedInk / rspec - retry 
 RSpec.configure do |config|
   # show retry status in spec process
   config.verbose_retry = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,7 +117,7 @@ RSpec.configure do |config|
 =end
 end
 
-# https :/ / github.com / NoRedInk / rspec - retry 
+- retry 
 RSpec.configure do |config|
   # show retry status in spec process
   config.verbose_retry = true


### PR DESCRIPTION
What:
- Add Rspec Retry

Why:
- Allow specs to retry once on network failures