### PR TITLE
remember me default checkbox selected

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -42,7 +42,7 @@
                       <div class="field">
                         <div class="flex items-center justify-between">
                           <div class="flex items-center">
-                            <%= f.check_box :remember_me, class: "h-4 w-4 text-miru-dark-purple-1000 focus:ring-text-miru-han-purple-1000 border-text-miru-han-purple-600 rounded" %>
+                            <%= f.check_box :remember_me, checked: true, class: "h-4 w-4 text-miru-dark-purple-1000 focus:ring-text-miru-han-purple-1000 border-text-miru-han-purple-600 rounded" %>
                             <%= f.label t('registration.remember_me').capitalize, class: "ml-2 form__label" %>
                           </div>
                         </div>


### PR DESCRIPTION
## Notion card
https://www.notion.so/Remember-me-checkbox-should-be-selected-by-default-on-sign-up-and-login-page-2f4a4c31c0f746eb937a86c92fa08d7f

## Summary
Remember me checkbox should be selected by default on the login page 

## Preview
<img width="1781" alt="Screenshot 2022-12-28 at 4 56 49 PM" src="https://user-images.githubusercontent.com/22776061/209805557-2d3af988-346c-4d26-954c-268260494094.png">

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains the same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
while login in, remember me checkbox should be checked by default.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
