### PR TITLE
Team page font

### DIFF
--- a/app/javascript/src/components/Team/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Team/List/Table/TableRow.tsx
@@ -29,8 +29,12 @@ const TableRow = ({ item }) => {
       }}
     >
       <td className="table__data p-6 capitalize">{item.name}</td>
-      <td className="table__data table__text p-6">{item.email}</td>
-      <td className="table__data table__text p-6 capitalize">{item.role}</td>
+      <td className="table__data table__text p-6 text-sm font-medium">
+        {item.email}
+      </td>
+      <td className="table__data table__text p-6 text-sm font-medium capitalize">
+        {item.role}
+      </td>
       {isAdminUser && (
         <Fragment>
           <td className="w-48 py-6 pr-6 text-right">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -42,7 +42,7 @@
                       <div class="field">
                         <div class="flex items-center justify-between">
                           <div class="flex items-center">
-                            <%= f.check_box :remember_me, class: "h-4 w-4 text-miru-dark-purple-1000 focus:ring-text-miru-han-purple-1000 border-text-miru-han-purple-600 rounded" %>
+                            <%= f.check_box :remember_me, checked: true, class: "h-4 w-4 text-miru-dark-purple-1000 focus:ring-text-miru-han-purple-1000 border-text-miru-han-purple-600 rounded" %>
                             <%= f.label t('registration.remember_me').capitalize, class: "ml-2 form__label" %>
                           </div>
                         </div>


### PR DESCRIPTION
## Notion card
https://www.notion.so/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=fdf63eea1c86445182eb27dba458e74e&pm=s
## Summary
On Team page: For ‘Email ID’ & ‘Role’ columns update font size from 12px to 14px, font weight from ‘Regular’ to ‘Medium’

## Preview
<img width="1792" alt="Screenshot 2023-01-02 at 2 54 27 PM" src="https://user-images.githubusercontent.com/22776061/210213357-b9702856-aea5-4d24-b724-c8d13d884e86.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains the same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
On team page, For the ‘Email ID’ & ‘Role’ columns font size is 14px, font-weight ‘Medium’

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
