### PR TITLE
Bulk Downloads Invoices 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,8 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "sentry-sidekiq"
 
+gem "rubyzip"
+
 group :development, :test do
   # See https://edgeguides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", ">= 1.0.0", platforms: %i[mri mingw x64_mingw]
@@ -206,6 +208,7 @@ group :test do
   # Strategies for cleaning databases in Ruby.
   gem "database_cleaner", "~> 2.0"
   gem "hash_dot"
+  gem "rspec-sidekiq"
 
   gem "rspec-buildkite"
   gem "rspec-retry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,9 @@ GEM
       rspec-support (~> 3.10)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
+    rspec-sidekiq (3.1.0)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.12.0)
     rubocop (1.40.0)
       json (~> 2.3)
@@ -586,8 +589,8 @@ DEPENDENCIES
   rolify (~> 6.0)
   rspec-buildkite
   rspec-rails (~> 5.0, >= 5.0.2)
-  rspec-sidekiq
   rspec-retry
+  rspec-sidekiq
   rubocop
   rubocop-performance
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,12 +586,14 @@ DEPENDENCIES
   rolify (~> 6.0)
   rspec-buildkite
   rspec-rails (~> 5.0, >= 5.0.2)
+  rspec-sidekiq
   rspec-retry
   rubocop
   rubocop-performance
   rubocop-rails
   rubocop-rspec
   ruby_audit
+  rubyzip
   sass-rails
   searchkick
   selenium-webdriver (>= 4.0.0)

--- a/app/channels/bulk_invoice_download_channel.rb
+++ b/app/channels/bulk_invoice_download_channel.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BulkInvoiceDownloadChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "bulk_invoice_download_channel_#{params[:download_id]}"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/internal_api/v1/invoices/bulk_download_controller.rb
+++ b/app/controllers/internal_api/v1/invoices/bulk_download_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::Invoices::BulkDownloadController < InternalApi::V1::ApplicationController
+  def index
+    authorize :index, policy_class: Invoices::BulkDownloadPolicy
+
+    BulkInvoiceDownloadJob.perform_later(
+      bulk_download_params[:invoice_ids],
+      current_company.company_logo,
+      bulk_download_params[:download_id],
+      root_url,
+      current_url_options
+    )
+
+    head :accepted
+  end
+
+  private
+
+    def current_url_options
+      { protocol: request.protocol, host: request.host, port: request.port }
+    end
+
+    def bulk_download_params
+      params.require(:bulk_invoices).permit(:download_id, invoice_ids: [])
+    end
+end

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable";
+
+export default createConsumer();

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,1 @@
+// Import all the channels to be used by Action Cable

--- a/app/jobs/bulk_invoice_download_job.rb
+++ b/app/jobs/bulk_invoice_download_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class BulkInvoiceDownloadJob < ApplicationJob
+  queue_as :default
+
+  def perform(invoice_ids, company_logo, download_id, root_url, current_url_options)
+    ActiveStorage::Current.url_options = current_url_options
+    file_url = BulkInvoiceDownloadService.new(invoice_ids, company_logo, root_url).process
+    ActionCable.server.broadcast(
+      "bulk_invoice_download_channel_#{download_id}",
+      {
+        file_url:
+      }
+    )
+  end
+end

--- a/app/jobs/delete_active_storage_blob_job.rb
+++ b/app/jobs/delete_active_storage_blob_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DeleteActiveStorageBlobJob < ApplicationJob
+  def perform(blob)
+    blob.destroy
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -103,6 +103,24 @@ class Invoice < ApplicationRecord
     (amount * Money::Currency.new(base_currency).subunit_to_unit).to_i
   end
 
+  def pdf_content(company_logo, root_url)
+    InvoicePayment::PdfGeneration.process(
+      self,
+      company_logo,
+      root_url
+    )
+  end
+
+  def temp_pdf(company_logo, root_url)
+    file = Tempfile.new()
+    InvoicePayment::PdfGeneration.process(
+      self,
+      company_logo,
+      root_url,
+      file.path)
+    file
+  end
+
   private
 
     def set_external_view_key

--- a/app/policies/invoices/bulk_download_policy.rb
+++ b/app/policies/invoices/bulk_download_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Invoices::BulkDownloadPolicy < ApplicationPolicy
+  def index?
+    user_owner_role? || user_admin_role?
+  end
+end

--- a/app/services/bulk_invoice_download_service.rb
+++ b/app/services/bulk_invoice_download_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class BulkInvoiceDownloadService
+  attr_reader :invoices, :company_logo, :root_url
+
+  def initialize(invoice_ids, company_logo, root_url)
+    @invoices = Invoice.includes(:client, :invoice_line_items).where(id: invoice_ids)
+    @company_logo = company_logo
+    @root_url = root_url
+  end
+
+  def process
+    zip_invoices
+  end
+
+  private
+
+    def zip_invoices
+      zipper = Zipper.new(invoices_temp_pdf_data)
+      zipper.zip
+      file_uploader = FileUploader.new(zipper.file, "Invoices_" + Time.now.to_i.to_s + ".zip")
+      file_uploader.upload
+      file_uploader.delete_after(1.hours)
+      zipper.cleanup!
+      file_uploader.url
+    end
+
+    def invoices_temp_pdf_data
+      invoices.map do |invoice|
+        { name: "#{invoice.invoice_number}.pdf", file: invoice.temp_pdf(company_logo, root_url) }
+      end
+    end
+end

--- a/app/services/invoice_payment/pdf_generation.rb
+++ b/app/services/invoice_payment/pdf_generation.rb
@@ -2,11 +2,12 @@
 
 module InvoicePayment
   class PdfGeneration < ApplicationService
-    def initialize(invoice, company_logo, root_url)
+    def initialize(invoice, company_logo, root_url, filepath = nil)
       @invoice = invoice
       @company_logo = company_logo || ""
       @base_currency = invoice.company.base_currency
       @root_url = root_url
+      @filepath = filepath
     end
 
     def process
@@ -31,7 +32,8 @@ module InvoicePayment
       )
 
       options = {
-        wait_until: ["networkidle0", "load", "domcontentloaded", "networkidle2"]
+        wait_until: ["networkidle0", "load", "domcontentloaded", "networkidle2"],
+        path: @filepath
       }
 
       absolute_html = Grover::HTMLPreprocessor.process html, "#{@root_url}/", "http"

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -28,15 +28,17 @@ namespace :internal_api, defaults: { format: "json" } do
     end
 
     resources :workspaces, only: [:index, :update]
+    namespace :invoices do
+      resources :bulk_deletion, only: [:create]
+      resources :bulk_download, only: [:index]
+    end
     resources :invoices, only: [:index, :create, :update, :show, :destroy, :edit] do
       member do
         post :send_invoice
         get :download
       end
     end
-    namespace :invoices do
-      resources :bulk_deletion, only: [:create]
-    end
+
     resources :generate_invoice, only: [:index, :show]
     resources :project_members, only: [:update]
     resources :employments, only: [:index]

--- a/lib/file_uploader.rb
+++ b/lib/file_uploader.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class FileUploader
+  attr_accessor :file, :filename, :blob
+
+  def initialize(file, filename)
+    @file = file
+    @filename = filename
+    @blob = nil
+  end
+
+  def upload
+    @blob = ActiveStorage::Blob.create_and_upload!(io: File.open(file), filename:)
+  end
+
+  def url
+    @blob.url if blob
+  end
+
+  def delete_after(duration)
+    DeleteActiveStorageBlobJob.set(wait: duration).perform_later(blob)
+  end
+end

--- a/lib/zipper.rb
+++ b/lib/zipper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Zipper
+  require "zip"
+
+  attr_accessor :tempfile, :files_hash
+
+  def initialize(files_hash)
+    @tempfile = Tempfile.new(randomized_name)
+    @files_hash = files_hash
+  end
+
+  def zip
+    Zip::File.open(tempfile.path, create: true) do |zipfile|
+      files_hash.each do |file_hash|
+        zipfile.add(file_hash[:name], file_hash[:file])
+      end
+    end
+  end
+
+  def file
+    tempfile
+  end
+
+  def read
+    zip_data = File.read(tempfile.path)
+    tempfile.close
+    zip_data
+  end
+
+  def cleanup!
+    files_hash.each do |file_hash|
+      file_hash[:file].unlink
+    end
+    tempfile.unlink
+  end
+
+  def upload(filename)
+    file = File.open(tempfile)
+    ActiveStorage::Blob.create_and_upload!(io: file, filename:)
+  end
+
+  private
+
+    def randomized_name
+      "#{Time.now.to_i}_#{SecureRandom.alphanumeric(10)}.zip"
+    end
+end

--- a/spec/channels/bulk_invoice_download_channel_spec.rb
+++ b/spec/channels/bulk_invoice_download_channel_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkInvoiceDownloadChannel, type: :channel do
+  before do
+    stub_connection
+  end
+
+  it "subscribes to a stream when room id is provided" do
+    subscribe(download_id: 42)
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for("bulk_invoice_download_channel_42")
+  end
+end

--- a/spec/jobs/bulk_invoice_download_job_spec.rb
+++ b/spec/jobs/bulk_invoice_download_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkInvoiceDownloadJob, type: :job do
+  describe "#perform_later" do
+    it "enqueues the job" do
+      ActiveJob::Base.queue_adapter = :test
+      expect {
+        BulkInvoiceDownloadJob.perform_later([6], nil, "abc", "")
+      }.to enqueue_job
+    end
+  end
+
+  describe "executed job" do
+    before do
+      allow_any_instance_of(BulkInvoiceDownloadService).to receive(:process).and_return("file_url")
+    end
+
+    it "broadcast the data on the expected channel" do
+      expect {
+        BulkInvoiceDownloadJob.perform_now([6], nil, "abc", "", { host: "localhost", port: 3000 })
+      }.to have_broadcasted_to("bulk_invoice_download_channel_abc").with(file_url: "file_url")
+    end
+  end
+end

--- a/spec/requests/internal_api/v1/invoices/bulk_download/index_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/bulk_download/index_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Invoices::BulkDownbload#index", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let!(:client) { create(:client, company:) }
+  let!(:invoice) { create(:invoice, client:, status: "sent") }
+  let(:download_id) { Faker::Alphanumeric.unique.alpha(number: 10) }
+
+  subject { send_request :get, internal_api_v1_invoices_bulk_download_index_path, params: {
+    bulk_invoices: {
+      invoice_ids: [invoice.id],
+      download_id:
+    }
+  }
+}
+
+  context "when authenticated" do
+    before do
+      create(:employment, company:, user:)
+      user.add_role role, company
+      sign_in user
+    end
+
+    context "when user is admin" do
+      let(:role) { :admin }
+
+      before do
+        subject
+      end
+
+      it "send the download request successfully" do
+        subject
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it "check if bulk invoice download job is queued" do
+        expect(BulkInvoiceDownloadJob).to be_processed_in :default
+      end
+    end
+
+    context "when user is employee" do
+      let(:role) { :employee }
+
+      it "returns 403 status" do
+        subject
+        expect(json_response["errors"]).to eq "You are not authorized to perform this action."
+      end
+    end
+
+    context "when user is book_keeper" do
+      let(:role) { :book_keeper }
+
+      it "returns 403 status" do
+        subject
+        expect(json_response["errors"]).to eq "You are not authorized to perform this action."
+      end
+    end
+  end
+
+  context "when unauthenticated" do
+    context "when request is made to download the Invoice" do
+      it "returns 403 status" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+        expect(json_response["error"]).to eq("You need to sign in or sign up before continuing.")
+      end
+    end
+  end
+end

--- a/spec/services/bulk_invoice_download_service_spec.rb
+++ b/spec/services/bulk_invoice_download_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "zip"
+
+RSpec.describe BulkInvoiceDownloadService do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let!(:client) { create(:client, company:, name: "bob") }
+  let!(:invoice1) { create(:invoice, client:) }
+  let!(:invoice2) { create(:invoice, client:) }
+  let(:invoice3) { create(:invoice, client:) }
+
+  describe "#process" do
+    before do
+      # While running specs, we don't want url and to access url, we need to set ActiveStorage url
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:url).and_return("")
+
+      described_class.new([invoice1.id, invoice2.id], nil, "").process
+
+      @added_pdf_files = []
+      # Service
+      Zip::File.open(ActiveStorage::Blob.service.path_for(ActiveStorage::Blob.last.key)) do |zipfile|
+        zipfile.each do |entry|
+          @added_pdf_files.push(entry.name)
+        end
+      end
+    end
+
+    it "checks if requested invoice pdfs are added to the zipfile stored against created blob" do
+      expect(@added_pdf_files).to eq(["#{invoice1.invoice_number}.pdf", "#{invoice2.invoice_number}.pdf"])
+    end
+  end
+end


### PR DESCRIPTION
Moved from https://github.com/saeloun/miru-web/pull/769

## Notion card
https://www.notion.so/saeloun/Backend-Bulk-Invoice-download-da485b6db7d64df1b4fefeb88740e3e0

## Summary
- Added API for bulk invoice download. 
- This API accepts a download id and the invoice ids. 
- It starts a background job for creating zip of asked invoice ids and also creates a channel with given download id.
- Once the invoices zip is ready, it publishes that zip on the download id channel.
