### PR TITLE
Fixed: can add new manual line items on the generate & edit invoice

### DIFF
--- a/app/javascript/src/components/Invoices/common/utils.js
+++ b/app/javascript/src/components/Invoices/common/utils.js
@@ -24,7 +24,7 @@ export const generateInvoiceLineItems = (selectedLineItems, manualEntryArr) => {
 
   invoiceLineItems = invoiceLineItems.concat(
     manualEntryArr.map(item => ({
-      id: item.id,
+      idx: item.id,
       name: item.name,
       description: item.description,
       date: dayjs(item.date).format("DD/MM/YYYY"),


### PR DESCRIPTION
## Notion card
Closes #900 
## Summary
<!-- Please include a summary of the change and which issue is fixed — ensure you answer 
what and why. Please also include relevant motivation and context. List any dependencies 
that are required for this change. -->
Fixed: After adding new manual line items on the generate & edit invoices page, If we click on save either it throws the error or it misses existing added entries on the invoice.
## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
**Before:**

https://share.vidyard.com/watch/WCWo3SKVwF6hzWna1jHEpQ

**After**

https://user-images.githubusercontent.com/52771571/211322308-97dbc74c-a662-473f-a8bf-c27799d952c0.mov


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
