### PR TITLE
Hide Billing tab under settings for admin and owner user role

### DIFF
--- a/app/javascript/src/components/Profile/SubNav.tsx
+++ b/app/javascript/src/components/Profile/SubNav.tsx
@@ -53,15 +53,17 @@ const SideNav = ({ isAdmin, firstName, company, lastName, email }) => {
           PAYMENT SETTINGS
         </NavLink>
       </li>
-      <li className="border-b-2 border-miru-gray-400">
-        <NavLink
-          end
-          className={({ isActive }) => getActiveClassName(isActive)}
-          to="/profile/edit/billing"
-        >
-          BILLING
-        </NavLink>
-      </li>
+      {!isAdmin && (
+        <li className="border-b-2 border-miru-gray-400">
+          <NavLink
+            end
+            className={({ isActive }) => getActiveClassName(isActive)}
+            to="/profile/edit/billing"
+          >
+            BILLING
+          </NavLink>
+        </li>
+      )}
       <li className="border-b-2 border-miru-gray-400">
         {/* <NavLink end to="/profile/edit/import" className={({ isActive }) => getActiveClassName(isActive)}>
           IMPORT

--- a/app/javascript/src/components/Profile/SubNav.tsx
+++ b/app/javascript/src/components/Profile/SubNav.tsx
@@ -53,8 +53,7 @@ const SideNav = ({ isAdmin, firstName, company, lastName, email }) => {
           PAYMENT SETTINGS
         </NavLink>
       </li>
-      {!isAdmin && (
-        <li className="border-b-2 border-miru-gray-400">
+      {/* <li className="border-b-2 border-miru-gray-400">
           <NavLink
             end
             className={({ isActive }) => getActiveClassName(isActive)}
@@ -62,8 +61,7 @@ const SideNav = ({ isAdmin, firstName, company, lastName, email }) => {
           >
             BILLING
           </NavLink>
-        </li>
-      )}
+        </li> */}
       <li className="border-b-2 border-miru-gray-400">
         {/* <NavLink end to="/profile/edit/import" className={({ isActive }) => getActiveClassName(isActive)}>
           IMPORT


### PR DESCRIPTION
## Notion card
[https://www.notion.so/saeloun/Hide-Billing-tab-under-settings-for-admin-and-owner-user-role-3bf1fbbef94045b7a45797dc4fd2bdda](https://www.notion.so/saeloun/Hide-Billing-tab-under-settings-for-admin-and-owner-user-role-3bf1fbbef94045b7a45797dc4fd2bdda)

## Summary
Since the billing tab is currently not developed, hence hide the Billings tab for admin and owner user roles. Here inside the `SideNav` component (`app/javascript/src/components/Profile/SubNav.tsx`) if the value of `isAdmin` is `true` I'll hide the `Billing` tab.

## Preview
[https://www.loom.com/share/d262c9a7a22e42b5b98f1574b1c0dd3b](https://www.loom.com/share/d262c9a7a22e42b5b98f1574b1c0dd3b)

## Type of change
-  In the `SideNav` component (`app/javascript/src/components/Profile/SubNav.tsx`) if the value of `isAdmin` is `true` I'll hide the "Billing" tab.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Log in as an admin or owner user.
2. Click on setting from the left navigation pane.
3. It should not show the "Billing" tab under the Sidenav bar of the Settings page.

### Checklist:

- [x] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
