### PR TITLE
Fixed download on above 24 hour

### DIFF
--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -87,8 +87,10 @@ class TimesheetEntry < ApplicationRecord
   end
 
   def formatted_duration
-    minutes = duration.to_i
-    Time.parse("#{minutes / 60}:#{minutes % 60}").strftime("%H:%M")
+    total_minutes = duration.to_i
+    hours = total_minutes / 60
+    minutes = total_minutes % 60
+    format("%02d:%02d", hours, minutes)
   end
 
   private


### PR DESCRIPTION
## Notion card
https://www.notion.so/saeloun/Internal-server-error-on-time-entry-download-if-a-single-entry-has-more-than-24-hours-logged-in-it-98a47feff1bb4cb9aea7048770235ca0

## Summary
- If there is an entry with more than 24 hours in duration, downloading a PDF report was resulting in a server-side error.
- In this PR this issue has been Fixed. Now downloading reports where entry is more than 24 hours.
- The changes have been done in the TimesheetEntry model's formatted_duration method which takes total minutes input and returns duration in HH:MM format.

## Preview
https://www.loom.com/share/365304dacb88490eb0317f3e108b48f8

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [x] I have performed a self-review of my own code
- [x] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
