### PR TITLE
Fixed devise translation error on signup

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -69,6 +69,10 @@ en:
       updated_but_not_signed_in:
         "Your account has been updated successfully, but since your password was
         changed, you need to sign in again."
+      user:
+        "signed_up_but_Your access has been disabled":
+          "Please check your email and follow the confirmation link to confirm
+          your email address."
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."


### PR DESCRIPTION
## Notion card
https://www.notion.so/6afc9500b2cc42af86be55f37894fb09?v=b4528f26f4424af7beaf036262796cb3&p=97355a9ade9a4afc93dbc8077a44ca26&pm=s

## Summary
<!-- Please include a summary of the change and which issue is fixed — ensure you answer 
what and why. Please also include relevant motivation and context. List any dependencies 
that are required for this change. -->
On signup, the devise is throwing translation error `en.devise.registrations.user.signed_up_but_Your access has been disabled`
With this PR we fixed the toast message `Please check your email and follow the confirmation link to confirm your email address.`


## Preview
<!-- Please include a short loom video previewing the changes made in the PR. This will help
the reviewers visualize and get context at a glance -->
<img width="1470" alt="Screenshot 2023-02-02 at 7 48 09 PM" src="https://user-images.githubusercontent.com/52771571/216350039-b8470ac0-36dd-418c-863e-8a52f22708cc.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking and retains same functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration -->

### Checklist:

- [ ] I have manually tested all workflows
- [ ] I have performed a self-review of my own code
- [ ] I have annotated changes in the PR that are relevant to the reviewer
- [ ] I have added automated tests for my code
