### PR TITLE
settings button removed

### DIFF
--- a/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
@@ -1,12 +1,7 @@
 import React, { Fragment, useState, useRef } from "react";
 
 import { useOutsideClick } from "helpers";
-import {
-  XIcon,
-  FloppyDiskIcon,
-  PaperPlaneTiltIcon,
-  SettingIcon,
-} from "miruIcons";
+import { XIcon, FloppyDiskIcon, PaperPlaneTiltIcon } from "miruIcons";
 import { Link } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
@@ -19,7 +14,7 @@ const Header = ({
   formType = "generate",
   handleSaveInvoice,
   handleSendInvoice,
-  setShowInvoiceSetting,
+  setShowInvoiceSetting, //eslint-disable-line
   invoiceNumber = null,
   id = null,
   deleteInvoice = null,
@@ -45,15 +40,6 @@ const Header = ({
               ? `Edit Invoice #${invoiceNumber}`
               : "Generate Invoice"}
           </h2>
-          {formType == "generate" && (
-            <button
-              className="ml-5 flex items-center text-xs font-bold leading-4 tracking-widest text-miru-han-purple-1000"
-              onClick={() => setShowInvoiceSetting(true)}
-            >
-              <SettingIcon className="mr-2.5" color="#5B34EA" size={15} />
-              SETTINGS
-            </button>
-          )}
         </div>
         <div className="flex flex-col md:w-2/5 md:flex-row">
           <Link


### PR DESCRIPTION
### **What :**
2nd task from this ticket (https://www.notion.so/saeloun/Invoice-page-UX-feedback-c94100068cbf41708986ccccfdb92f08)
Settings button removed from generate invoice header.

### **Why :**
Currently when the button is clicked, a blank page is getting displayed.

### **Preview :**
**Screenshots:**
Before:
<img width="1417" alt="Screenshot 2023-02-07 at 2 23 07 PM" src="https://user-images.githubusercontent.com/72149587/217197539-145d59ff-8b21-495a-86da-b2da89ed823b.png">

After:
<img width="1367" alt="Screenshot 2023-02-07 at 2 22 34 PM" src="https://user-images.githubusercontent.com/72149587/217197600-0934eaa3-1298-44e4-8a2a-f81d5faa52fa.png">


### **Todos** (for testing):
Check if button is removed on all pages. 


 