### PR TITLE
Removed employee access for team member's tab

### DIFF
--- a/app/javascript/src/components/Navbar/utils.tsx
+++ b/app/javascript/src/components/Navbar/utils.tsx
@@ -21,12 +21,6 @@ const navEmployeeOptions = [
     path: Paths.TIME_TRACKING,
   },
   {
-    logo: <TeamsIcon className="mr-0 md:mr-4" size={26} />,
-    label: "Team",
-    dataCy: "team-tab",
-    path: Paths.TEAM,
-  },
-  {
     logo: <ClientsIcon className="mr-0 md:mr-4" size={26} />,
     label: "Clients",
     dataCy: "clients-tab",
@@ -42,6 +36,12 @@ const navEmployeeOptions = [
 
 const navAdminOptions = [
   ...navEmployeeOptions,
+  {
+    logo: <TeamsIcon className="mr-0 md:mr-4" size={26} />,
+    label: "Team",
+    dataCy: "team-tab",
+    path: Paths.TEAM,
+  },
   {
     logo: <InvoicesIcon className="mr-0 md:mr-4" size={26} />,
     label: "Invoices",


### PR DESCRIPTION
Notion -
https://www.notion.so/saeloun/Employee-user-role-should-not-be-able-to-view-the-Team-page-2859fcd057cd4065a09755698f6aa70b

Screenshots-
1) With Admin Credential
<img width="1702" alt="Screenshot 2023-02-07 at 6 38 28 PM" src="https://user-images.githubusercontent.com/104751221/217284818-aae22684-5317-4000-bb3b-27a577815b89.png">

2) With Employee Credential
<img width="1702" alt="Screenshot 2023-02-07 at 6 35 22 PM" src="https://user-images.githubusercontent.com/104751221/217284869-13f71da1-5e19-4b31-8c85-7a33849a1aff.png">

This PR contains the removal of employee access for team member's tab.
Tested on local Machine
