### PR TITLE
Fix bug in removing member from a project

### DIFF
--- a/app/models/concerns/project_sql_queries.rb
+++ b/app/models/concerns/project_sql_queries.rb
@@ -20,7 +20,7 @@ module ProjectSqlQueries
         RIGHT JOIN (
           SELECT user_id, hourly_rate
           FROM project_members
-          WHERE project_id = #{id}
+          WHERE project_id = #{id} AND discarded_at IS NULL
         ) pm ON pm.user_id = te.user_id
         LEFT JOIN users u ON u.id = pm.user_id;
       """

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -24,9 +24,11 @@ RSpec.describe Project, type: :model do
 
     let(:company) { create(:company) }
     let(:user) { create(:user) }
+    let(:user_2) { create(:user) }
     let(:client) { create(:client, company:) }
     let(:project) { create(:project, client:) }
     let!(:member) { create(:project_member, project:, user:, hourly_rate: 5000) }
+    let!(:member_2) { create(:project_member, project:, user:, hourly_rate: 5000) }
     let(:hourly_rate) { member.hourly_rate }
     let(:result) do
       [{
@@ -37,10 +39,14 @@ RSpec.describe Project, type: :model do
       }]
     end
 
+    before do
+      member_2.discard!
+    end
+
     context "when entries are missing" do
       let(:time_frame) { "last_week" }
 
-      it "returns data with 0 values" do
+      it "returns only kept members with 0 values" do
         expect(subject).to eq(
           [{
             id: member.user_id,


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/Unable-to-remove-a-team-member-from-a-project-345c86358a1c443da44369814ace6ef5

What: Fixes the list of project members to not show soft deleted members
https://www.loom.com/share/c8d216b6c5ed47908f256f405da7df02

Why: There was a bug while removing a member, where that removed member was still showing up because we were showing all the projects members even when they were soft deleted.
https://www.loom.com/share/c24891617ae04ca2974d67ef53d856b7