### PR TITLE
Manual line item entry with 0 quantity

### DIFF
--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -32,7 +32,7 @@ class InvoiceLineItem < ApplicationRecord
 
   validates :name, :date, :rate, :quantity, presence: true
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
-  validates :quantity, numericality: { greater_than: 0 }
+  validates :quantity, numericality: { greater_than_or_equal_to: 0 }
 
   def self.total_cost
     (self.sum("quantity * rate") / 60).round(3)

--- a/spec/models/invoice_line_item_spec.rb
+++ b/spec/models/invoice_line_item_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InvoiceLineItem, type: :model do
     end
 
     describe "validate numericality of" do
-      it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
+      it { is_expected.to validate_numericality_of(:quantity).is_greater_than_or_equal_to(0) }
       it { is_expected.to validate_numericality_of(:rate).is_greater_than_or_equal_to(0) }
     end
   end


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/Refactor-the-validations-added-to-invoice-page-while-adding-line-items-1-47988406ad394094b63c0581bda92dcd

What: We needed a functionality to add manual line item entry without any quantity

Why: Our code had validation to check if quantity is greater than 0, removed that check