### PR TITLE
Init Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -220,3 +220,7 @@ end
 
 # https://github.com/ankane/strong_migrations
 gem "strong_migrations"
+
+# Error tracking: https://docs.sentry.io/platforms/ruby/guides/rails/
+gem "sentry-rails"
+gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,6 +481,11 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sentry-rails (5.7.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.7.0)
+    sentry-ruby (5.7.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
     shoulda-matchers (5.3.0)
@@ -619,6 +624,8 @@ DEPENDENCIES
   sass-rails
   searchkick
   selenium-webdriver (>= 4.0.0)
+  sentry-rails
+  sentry-ruby
   shoulda-callback-matchers (~> 1.1.1)
   shoulda-matchers (~> 5.1)
   sidekiq (< 7)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sentry.init do |config|
+  config.dsn = "https://c4c00a5cc17647ac83f27f48af7d5e4f@o744686.ingest.sentry.io/4504649746087936"
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  # Set traces_sample_rate to 1.0 to capture 100%
+  # of transactions for performance monitoring.
+  # We recommend adjusting this value in production.
+  config.traces_sample_rate = 1.0
+  # or
+  config.traces_sampler = lambda do |context|
+    true
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,8 +8,6 @@ Sentry.init do |config|
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
   config.traces_sample_rate = 1.0
-  # or
-  config.traces_sampler = lambda do |context|
-    true
-  end
+
+  config.environment = Rails.env
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,10 +9,11 @@ production:
   - action_mailbox_incineration
   - active_storage_analysis
   - active_storage_purge
-:schedule:
-  weekly_reminder:
-    cron: '0 14 * * 1 Asia/Kolkata'   # Runs every monday at  14:00
-    class: WeeklyReminderToUserJob
-  update_invoice_status:
-    cron: '0 0 * * *'   # Runs every day at 12AM UTC
-    class: UpdateInvoiceStatusToOverdueJob
+:scheduler:
+  schedule:
+    weekly_reminder:
+      cron: '0 14 * * 1 Asia/Kolkata'   # Runs every monday at  14:00
+      class: WeeklyReminderToUserJob
+    update_invoice_status:
+      cron: '0 0 * * *'   # Runs every day at 12AM UTC
+      class: UpdateInvoiceStatusToOverdueJob


### PR DESCRIPTION
What:
- Init Sentry config

Why:
- We moved away from ENV based config
- Adding back config on App level instead. 

Todo:
- Move project keys keys to ENV