### PR TITLE
Send error to sentry only if the environment is production or staging

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,4 +10,5 @@ Sentry.init do |config|
   config.traces_sample_rate = 1.0
 
   config.environment = Rails.env
+  config.enabled_environments = %w[production staging]
 end


### PR DESCRIPTION
What changed:

Send error to sentry only if the environment is production or staging.

Why:

Previously error from development environment were sent to sentry.

Ref: [enabled_environments](https://docs.sentry.io/platforms/ruby/configuration/options/)