### PR TITLE
Invoice filter bugs

### DIFF
--- a/app/javascript/src/StyledComponents/SidePanel/index.tsx
+++ b/app/javascript/src/StyledComponents/SidePanel/index.tsx
@@ -26,7 +26,7 @@ const SidePanel = ({
     <div
       ref={wrapperRef}
       className={classnames(
-        "sidebar__container flex w-full flex-col lg:w-1/5",
+        "sidebar__container flex w-full flex-col lg:w-1/4",
         WrapperClassname
       )}
     >

--- a/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
+++ b/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
@@ -41,6 +41,7 @@ const FilterSideBar = ({
   const [isStatusOpen, setIsStatusOpen] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [dateRangeList, setDateRangeList] = useState<any>(dateRangeOptions);
+  const [disableApplyBtn, setDisableApplyBtn] = useState(false);
 
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
   const wrapperRef = useRef(null);
@@ -199,7 +200,24 @@ const FilterSideBar = ({
     hideCustomFilter();
   };
 
+  useEffect(() => {
+    if (
+      filters.dateRange.value == "custom" &&
+      !filters.dateRange.from &&
+      !filters.dateRange.to &&
+      disableDateBtn
+    ) {
+      setDisableApplyBtn(true);
+    } else {
+      setDisableApplyBtn(false);
+    }
+  }, [filters, disableDateBtn]);
+
   const handleApply = () => {
+    if (disableApplyBtn) {
+      return;
+    }
+
     defaultDateRange()
       ? setFilterParams(setDefaultDateRange())
       : setFilterParams(filters);
@@ -475,8 +493,12 @@ const FilterSideBar = ({
           RESET
         </Button>
         <Button
-          className="px-10 py-2.5 text-base font-bold leading-5"
+          disabled={disableApplyBtn}
           style="primary"
+          className={`${
+            disableApplyBtn &&
+            "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
+          } px-10 py-2.5 text-base font-bold leading-5`}
           onClick={handleApply}
         >
           APPLY

--- a/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
+++ b/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
@@ -254,7 +254,7 @@ const FilterSideBar = ({
         </SidePanel.Header>
         <SidePanel.Body className="sidebar__filters max-h-80v min-h-80v overflow-y-auto">
           <ul>
-            <li className="cursor-pointer border-b border-miru-gray-200 pb-5 pt-6 text-miru-dark-purple-1000 hover:text-miru-han-purple-1000">
+            <li className="relative cursor-pointer border-b border-miru-gray-200 pb-5 pt-6 text-miru-dark-purple-1000 hover:text-miru-han-purple-1000">
               <div
                 className="flex items-center justify-between px-5"
                 onClick={() => {
@@ -299,7 +299,7 @@ const FilterSideBar = ({
               )}
               {showCustomFilter && (
                 <div
-                  className="absolute z-20 mt-1 flex flex-col rounded-lg bg-miru-white-1000 shadow-c1"
+                  className="absolute z-20 mt-1 ml-4 flex flex-col overflow-y-auto rounded-lg bg-miru-white-1000 shadow-c1"
                   ref={wrapperRef}
                 >
                   <CustomDateRangePicker

--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -201,7 +201,6 @@ const Invoices = ({ isDesktop }) => {
   const handleReset = () => {
     window.localStorage.removeItem(LocalStorageKeys.INVOICE_FILTERS);
     setFilterParams(filterIntialValues);
-    setIsFilterVisible(false);
   };
 
   return (


### PR DESCRIPTION
Notion -
https://www.notion.so/saeloun/Invoice-list-page-Filter-panel-bugs-87116f47416f451b81f71bc2f074bbae?pvs=4

What- 
1. This PR includes changes that lead to increase in the width of the filter side panel.(Updated it as per the design)
2. Whenever there will be an error on custom date range the filter apply button will be disabled and reset button will add the default filters but won't close the filter sidepanel.

Why-
1. I noticed that the filter side panel requires more width so that it won't break in responsive screen sizes.
2. Disable Apply button on filter was the requirement by Apoorv and confirmed by Supriya.(Mentioned in notion card)

Note:- I have verified the disabling Apply filter button with errors and best-case scenarios.

Loom Video -
https://www.loom.com/share/b972c729099c4411bd9fd55d3804fbb6
