### PR TITLE
Upgrade React Tooltip

### DIFF
--- a/app/javascript/src/common/ChartBar/index.tsx
+++ b/app/javascript/src/common/ChartBar/index.tsx
@@ -1,7 +1,8 @@
 import React, { Fragment } from "react";
 
 import { minToHHMM } from "helpers";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "react-tooltip";
+import "react-tooltip/dist/react-tooltip.css";
 
 import { IChartBarGraph, ISingleClient } from "./interface";
 
@@ -22,16 +23,10 @@ const Client = ({ element, totalMinutes, index }: ISingleClient) => {
 
   return (
     <div style={divStyle}>
-      <ReactTooltip
-        backgroundColor="#1D1A31"
-        effect="solid"
-        id={`registerTip-${index}`}
-        place="top"
-        textColor="#FFF"
-      >
+      <Tooltip className="tooltip" id={`registerTip-${index}`} place="top">
         <p className="text-xs">{element.name}</p>
         <p className="text-center text-2xl">{minToHHMM(element.minutes)}</p>
-      </ReactTooltip>
+      </Tooltip>
       <button
         data-tip
         className={`bg-${randomColor}-600 block h-4 w-full border-b border-t hover:border-transparent`}

--- a/app/javascript/src/common/ChartBar/index.tsx
+++ b/app/javascript/src/common/ChartBar/index.tsx
@@ -23,14 +23,18 @@ const Client = ({ element, totalMinutes, index }: ISingleClient) => {
 
   return (
     <div style={divStyle}>
-      <Tooltip className="tooltip" id={`registerTip-${index}`} place="top">
+      <Tooltip
+        anchorId={`registerTip-${index}`}
+        className="tooltip"
+        place="top"
+      >
         <p className="text-xs">{element.name}</p>
         <p className="text-center text-2xl">{minToHHMM(element.minutes)}</p>
       </Tooltip>
       <button
         data-tip
         className={`bg-${randomColor}-600 block h-4 w-full border-b border-t hover:border-transparent`}
-        data-for={`registerTip-${index}`}
+        id={`registerTip-${index}`}
         type="button"
       />
     </div>

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -558,3 +558,8 @@ body {
   padding-left: 8px;
   padding-right: 4px;
 }
+
+.tooltip{
+  background-color: #1D1A31;
+  text-color: #FFF
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "^5.2.2",
     "react-table": "^7.7.0",
     "react-toastify": "^8.1.0",
-    "react-tooltip": "^4.2.21",
+    "react-tooltip": "^5.7.5",
     "react-transition-group": "1.x",
     "react_ujs": "^2.6.1",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,6 +952,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.16.7", "@babel/runtime@^7.18.3":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1119,6 +1126,18 @@
     js-yaml "^4.1.0"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@floating-ui/core@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.0.tgz#ae7ae7923d41f3d84cb2fd88740a89436610bbec"
+  integrity sha512-GHUXPEhMEmTpnpIfesFA2KAoMJPb1SPQw964tToQwt+BbGXdhqTCWT1rOb0VURGylsxsYxiGMnseJ3IlclVpVA==
+
+"@floating-ui/dom@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.1.tgz#66aa747e15894910869bf9144fc54fc7d6e9f975"
+  integrity sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==
+  dependencies:
+    "@floating-ui/core" "^1.1.0"
 
 "@fontsource/plus-jakarta-sans@^4.5.0":
   version "4.5.4"
@@ -2594,6 +2613,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.3, classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
@@ -7909,6 +7933,23 @@ raw-body@2.4.3:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+rc-steps@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rc-steps/-/rc-steps-6.0.0.tgz#f7148f8097d5d135f19b96c1b4f4b50ad6093753"
+  integrity sha512-+KfMZIty40mYCQSDvYbZ1jwnuObLauTiIskT1hL4FFOBHP6ZOr8LK0m143yD3kEN5XKHSEX1DIwCj3AYZpoeNQ==
+  dependencies:
+    "@babel/runtime" "^7.16.7"
+    classnames "^2.2.3"
+    rc-util "^5.16.1"
+
+rc-util@^5.16.1:
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.27.2.tgz#472a7bab26a62856c2c016d18dc6356e46d01012"
+  integrity sha512-8XHRbeJOWlTR2Hk1K2xLaPOf7lZu+3taskAGuqOPccA676vB3ygrz3ZgdrA3wml40CzR9RlIEHDWwI7FZT3wBQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    react-is "^16.12.0"
+
 react-autosize-textarea@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz#902c84fc395a689ca3a484dfb6bc2be9ba3694d1"
@@ -7976,7 +8017,7 @@ react-infinite-scroll-component@^6.1.0:
   dependencies:
     throttle-debounce "^2.1.0"
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8044,13 +8085,13 @@ react-toastify@^8.1.0:
   dependencies:
     clsx "^1.1.1"
 
-react-tooltip@^4.2.21:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
-  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+react-tooltip@^5.7.5:
+  version "5.7.5"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.7.5.tgz#f3487e000a24b6ff84c8181064809a57b43c2e99"
+  integrity sha512-hAr3AMSF47AuycEnI+ShwloYHTtVrftocXCfEjWAFvvAVpNGE9wredZs6NlUE1JtpOXIOe/oJUpoYj925v5hLQ==
   dependencies:
-    prop-types "^15.7.2"
-    uuid "^7.0.3"
+    "@floating-ui/dom" "1.1.1"
+    classnames "^2.3.2"
 
 react-transition-group@1.x:
   version "1.2.1"
@@ -8152,6 +8193,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
@@ -9674,11 +9720,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
What:
- Upgrade react-tooltip to v5
- Fix props
- Fix yarn install


Why:
- yarn.lock deviated from main install
- On upgraded versions, react-tooltip would fail as it was incompatible JSX code

Location Verification:

![Miru | Time tracking and invoicing 2023-02-11 19-21-34](https://user-images.githubusercontent.com/567626/218261610-34ba2a3d-135d-4fb1-a24c-abf5abe8ce0a.png)

