### PR TITLE
Remove empty specs

### DIFF
--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -55,10 +55,6 @@ RSpec.describe TimesheetEntry, type: :model do
     end
   end
 
-  describe ".during" do
-    pending("Will work on this")
-  end
-
   describe "#snippet" do
     it "returns proper data" do
       expect(timesheet_entry.snippet).to eq(

--- a/spec/requests/company_spec.rb
+++ b/spec/requests/company_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-RSpec.describe "Companies", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/requests/invoices/payments_spec.rb
+++ b/spec/requests/invoices/payments_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-RSpec.describe "Invoices::Payments", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end


### PR DESCRIPTION
What:

- Remove empty specs


Why:

- We can add later, but these are a code smell