### PR TITLE
Restricted team page access for Employee role. Updated team policy.

### DIFF
--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -2,7 +2,7 @@
 
 class TeamPolicy < ApplicationPolicy
   def index?
-    user_owner_role? || user_admin_role? || user_employee_role?
+    user_owner_role? || user_admin_role?
   end
 
   def update?

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe TeamPolicy, type: :policy, test_ploi: true do
       it "grants permission" do
         expect(described_class).to permit(admin, :team)
         expect(described_class).to permit(owner, :team)
-        expect(described_class).to permit(employee, :team)
       end
 
-      context "when user is book_keeper" do
+      context "when user is book_keeper or employee" do
         it "does not grants permission" do
           expect(described_class).not_to permit(book_keeper, :team)
+          expect(described_class).not_to permit(employee, :team)
         end
       end
     end

--- a/spec/requests/internal_api/v1/team/index_spec.rb
+++ b/spec/requests/internal_api/v1/team/index_spec.rb
@@ -59,29 +59,8 @@ RSpec.describe "InternalApi::V1::Team#index", type: :request do
       send_request :get, internal_api_v1_team_index_path
     end
 
-    it "is permitted to access Team#index page" do
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "checks if correct team members data is returned" do
-      actual_members_data = json_response["team"].map do |member|
-                              member.slice("name", "email", "role", "status")
-                            end
-      actual_invited_user_data = json_response["invitation"].map do |member|
-                                      member.slice("name", "email", "role", "status")
-                                    end
-
-      expected_members_data = [{
-        "name" => user.full_name, "email" => user.email, "role" => "admin", "status" => nil
-      }, {
-        "name" => user3.full_name, "email" => user3.email, "role" => "employee", "status" => nil
-      }]
-
-      expected_invited_user_data = [{
-        "name" => invitation.full_name, "email" => invitation.recipient_email, "role" => "employee", "status" => nil
-      }]
-      expect(actual_members_data).to eq(expected_members_data)
-      expect(actual_invited_user_data).to eq(expected_invited_user_data)
+    it "is not permitted to access Team#index page" do
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=2cc38eb0f24d4e6c8752e1ec592d30de&pm=s

**Description:**
User with an Employee role, should not be able to view the Team page when they login into Miru. 


**What Fixed:**

For the employee role, we have already restricted team page access from navigation. But we were able to access it through the URL. To fix this issue we modified the Team policy(index action) for employee role.

Now when an employee accesses the team page from the URL it will throw an unauthorized error.

**Screenshot:**

<img width="1697" alt="Screenshot 2023-02-14 at 1 40 24 PM" src="https://user-images.githubusercontent.com/2971017/218689896-33a58bb7-ba64-4739-b018-658a16b22168.png">
