### PR TITLE
Fix allowed_urls value

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -3,8 +3,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.allow_remote_database_url = true
-    DatabaseCleaner.url_allowlist = ["postgres://postgres:postgres@database:5432/",
-                                     "postgres://root:password@localhost/miru_web?encoding=utf8&pool=5&timeout=5000"]
+    DatabaseCleaner.url_allowlist = [ENV["DATABASE_URL"]]
 
     DatabaseCleaner.clean_with :truncation, except: %w(ar_internal_metadata)
   end


### PR DESCRIPTION
What: Sets the allowed urls to ENV["DATABASE_URL"]

Why: Specs were failing locally as database cleaning was failing due to hardcoded sets of database urls. Set that to value from ENV