### PR TITLE
Close filter panel on rest button click

### DIFF
--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -204,6 +204,7 @@ const Invoices = () => {
 
   const handleReset = () => {
     window.localStorage.removeItem(LocalStorageKeys.INVOICE_FILTERS);
+    setIsFilterVisible(false);
     setFilterParams(filterIntialValues);
   };
 


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/The-filter-panel-should-not-open-after-clicking-on-reset-button-1f320185fe7041048854926cc93a9d30

Why: On clicking on the reset button on the filter panel it was not closing.

What: Set the isFilterVisible state to false onclick event of the reset button.

Loom: https://www.loom.com/share/fa99c17b8ddb4ae7b59a9675db50eab0