### PR TITLE
Stretched logo issue resolution

### DIFF
--- a/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
+++ b/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
@@ -7,7 +7,7 @@ const CompanyInfo = ({ company, logo = "" }) => {
     <div className="flex flex-col justify-between border-b-2 border-miru-gray-400 md:h-40 md:flex-row md:p-10">
       <div className="flex flex-col md:flex-row">
         <img
-          className="m-auto md:m-0 md:mr-5"
+          className="m-auto h-20 w-20 rounded-full	md:m-0 md:mr-5"
           src={company.logo ? company.logo : logo}
         />
         <div className="mt-2 text-center md:text-left">

--- a/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
+++ b/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
@@ -7,7 +7,7 @@ const CompanyInfo = ({ company, logo = "" }) => {
     <div className="flex flex-col justify-between border-b-2 border-miru-gray-400 md:h-40 md:flex-row md:p-10">
       <div className="flex flex-col md:flex-row">
         <img
-          className="m-auto h-20 w-20 rounded-full	md:m-0 md:mr-5"
+          className="m-auto h-20 w-20 rounded-full md:m-0 md:mr-5"
           src={company.logo ? company.logo : logo}
         />
         <div className="mt-2 text-center md:text-left">

--- a/app/views/mailers/invoice_mailer/invoice.html.erb
+++ b/app/views/mailers/invoice_mailer/invoice.html.erb
@@ -9,8 +9,8 @@
         <div
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
-          <div style="padding: 10px; display: inline-block; text-align: center">
-            <%= image_tag @company_logo, height: 80 ,width: 80 %>
+          <div style="padding: 10px; display: inline-block; text-align: center;">
+            <%= image_tag @company_logo, height: 80 ,width: 80, style="border-radius: 80px;" %>
           </div>
           <div>
             <span style='font-weight:bold'><%= @invoice.company.name %></span>

--- a/app/views/mailers/invoice_mailer/invoice.html.erb
+++ b/app/views/mailers/invoice_mailer/invoice.html.erb
@@ -10,7 +10,7 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, style="border-radius: 80px;" %>
+            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
           </div>
           <div>
             <span style='font-weight:bold'><%= @invoice.company.name %></span>


### PR DESCRIPTION
Notion card
https://www.notion.so/saeloun/The-company-logo-is-stretched-on-the-client-invoice-view-eeb844bef95a4808a739962631e8c03b?pvs=4

what
- Added resolution of stretched logo by adding width and height

why
- The issue was accuring on client side due to not fixed image size

screenshots-
<img width="1742" alt="Screenshot 2023-02-15 at 2 39 42 PM" src="https://user-images.githubusercontent.com/104751221/218985841-ef2981e5-f1f4-40b9-b0b8-2975f97c7050.png">
<img width="1742" alt="Screenshot 2023-02-15 at 2 28 04 PM" src="https://user-images.githubusercontent.com/104751221/218985865-efd0378a-998a-4563-b514-b2a0e9004dd0.png">
apoo
