### PR TITLE
Add client side validations for team and client name

### DIFF
--- a/app/javascript/src/components/Team/modals/AddEditMember.tsx
+++ b/app/javascript/src/components/Team/modals/AddEditMember.tsx
@@ -9,8 +9,12 @@ import { TeamModalType } from "constants/index";
 import { useList } from "context/TeamContext";
 
 const TeamMemberSchema = Yup.object().shape({
-  firstName: Yup.string().required("First Name cannot be blank"),
-  lastName: Yup.string().required("Last Name cannot be blank"),
+  firstName: Yup.string()
+    .matches(/^[a-zA-Z]+$/, "First Name must contain only letters")
+    .required("First Name cannot be blank"),
+  lastName: Yup.string()
+    .matches(/^[a-zA-Z]+$/, "Last Name must contain only letters")
+    .required("Last Name cannot be blank"),
   email: Yup.string()
     .email("Invalid email ID")
     .required("Email ID cannot be blank"),
@@ -235,9 +239,6 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                         </div>
                       </div>
                     </div>
-                    <p className="mt-7 block text-xs tracking-wider text-red-600">
-                      {apiError}
-                    </p>
                     <div className="actions mt-4">
                       <button
                         data-cy="send-invite-button"

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -36,8 +36,8 @@ class Client < ApplicationRecord
   has_one_attached :logo
   belongs_to :company
 
-  validates :name, :email, presence: true
-  validates :email, uniqueness: { scope: :company_id }, format: { with: Devise.email_regexp }
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, uniqueness: { scope: :company_id }, format: { with: Devise.email_regexp }
   after_discard :discard_projects
   after_commit :reindex_projects
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Client, type: :model do
     it { is_expected.to validate_uniqueness_of(:email).scoped_to(:company_id) }
     it { is_expected.to allow_value("valid@email.com").for(:email) }
     it { is_expected.not_to allow_value("invalid@email").for(:email) }
+    it { is_expected.to validate_length_of(:name).is_at_most(50) }
   end
 
   describe "Associations" do


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/Client-Team-module-validations-9364b78f8c574b90aef618b0f1616921

What: 
- Add client-side validation for invalid first name and last name on create team modal.
- Removed the API error that was displayed on the modal.
- Add length validation for client name

Why:
- Every time a user entered an invalid first name and last name a backend request was sent and then the error message was 
displayed one at a time.
- API error was shown on the modal and in toast too.
- No length validation was present on the client name.

Loom:  https://www.loom.com/share/92266e6e4bce437a9db2ca04f3dc943c