### PR TITLE
Fixed "Invoice page is not getting Automatically refreshed after creating an invoice

### DIFF
--- a/app/controllers/internal_api/v1/invoices_controller.rb
+++ b/app/controllers/internal_api/v1/invoices_controller.rb
@@ -17,10 +17,8 @@ class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationControll
 
   def create
     authorize Invoice
-    invoice = current_company.invoices.create!(invoice_params)
-    refresh_index
     render :create, locals: {
-      invoice: invoice,
+      invoice: current_company.invoices.create!(invoice_params),
       client: @client
     }
   end
@@ -96,11 +94,5 @@ class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationControll
 
     def ensure_time_entries_billed
       invoice.update_timesheet_entry_status!
-    end
-
-    # Elasticsearch can take up to a second for a change to reflect in search.
-    # We can use the refresh method to have it show up immediately.
-    def refresh_index
-      Invoice.search_index.refresh
     end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,7 +67,7 @@ class Invoice < ApplicationRecord
   store_accessor :payment_infos, :stripe_payment_intent
 
   before_validation :set_external_view_key, on: :create
-  after_commit :reindex_invoices
+  after_commit :reindex_invoice
 
   validates :issue_date, :due_date, :invoice_number, presence: true
   validates :due_date, comparison: { greater_than_or_equal_to: :issue_date }
@@ -159,8 +159,8 @@ class Invoice < ApplicationRecord
     CompanyDateFormattingService.new(issue_date, company:).process
   end
 
-  def reindex_invoices
-    Invoice.reindex
+  def reindex_invoice
+    Invoice.search_index.refresh
   end
 
   private

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,7 +67,7 @@ class Invoice < ApplicationRecord
   store_accessor :payment_infos, :stripe_payment_intent
 
   before_validation :set_external_view_key, on: :create
-  after_commit :reindex_invoice
+  after_commit :refresh_invoice
 
   validates :issue_date, :due_date, :invoice_number, presence: true
   validates :due_date, comparison: { greater_than_or_equal_to: :issue_date }
@@ -159,7 +159,7 @@ class Invoice < ApplicationRecord
     CompanyDateFormattingService.new(issue_date, company:).process
   end
 
-  def reindex_invoice
+  def refresh_invoice
     Invoice.search_index.refresh
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,7 +67,7 @@ class Invoice < ApplicationRecord
   store_accessor :payment_infos, :stripe_payment_intent
 
   before_validation :set_external_view_key, on: :create
-  after_commit :refresh_invoice
+  after_commit :refresh_invoice_index
 
   validates :issue_date, :due_date, :invoice_number, presence: true
   validates :due_date, comparison: { greater_than_or_equal_to: :issue_date }
@@ -159,7 +159,7 @@ class Invoice < ApplicationRecord
     CompanyDateFormattingService.new(issue_date, company:).process
   end
 
-  def refresh_invoice
+  def refresh_invoice_index
     Invoice.search_index.refresh
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -67,6 +67,7 @@ class Invoice < ApplicationRecord
   store_accessor :payment_infos, :stripe_payment_intent
 
   before_validation :set_external_view_key, on: :create
+  after_commit :reindex_invoices
 
   validates :issue_date, :due_date, :invoice_number, presence: true
   validates :due_date, comparison: { greater_than_or_equal_to: :issue_date }
@@ -156,6 +157,10 @@ class Invoice < ApplicationRecord
 
   def formatted_issue_date
     CompanyDateFormattingService.new(issue_date, company:).process
+  end
+
+  def reindex_invoices
+    Invoice.reindex
   end
 
   private

--- a/spec/requests/internal_api/v1/invoices/create_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/create_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
                           "invoiceLineItems", "invoiceNumber", "issueDate",
                           "outstandingAmount", "reference", "status", "tax"]
         expect(json_response.keys.sort).to match(expected_attrs)
+        Invoice.reindex
         assert_equal ["SAI-C1-03"], Invoice.search("SAI-C1-03").map(&:invoice_number)
       end
 

--- a/spec/requests/internal_api/v1/invoices/create_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/create_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
       let(:invoice) {
         attributes_for(
           :invoice,
+          invoice_number: "SAI-C1-03",
           client: company.clients.first,
           client_id: company.clients.first.id,
           status: :draft,
@@ -33,7 +34,7 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
         )
       }
 
-      it "creates invoice successfully" do
+      it "creates invoice successfully & reindex it" do
         send_request :post, internal_api_v1_invoices_path(invoice:), headers: auth_headers(user)
         expect(response).to have_http_status(:ok)
         expected_attrs = ["amount", "amountDue", "amountPaid",
@@ -41,6 +42,7 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
                           "invoiceLineItems", "invoiceNumber", "issueDate",
                           "outstandingAmount", "reference", "status", "tax"]
         expect(json_response.keys.sort).to match(expected_attrs)
+        assert_equal ["SAI-C1-03"], Invoice.search("SAI-C1-03").map(&:invoice_number)
       end
 
       context "when client doesn't exist" do


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=b572ac81385d4325a3b770f085256b50&pm=s

**What:** 

The invoice page was not getting Automatically refreshed after creating an invoice for a client.

**Why:**
Elasticsearch can take up to a few seconds for a change to reflect in the search.

We used the refresh method to have it show up immediately.