### PR TITLE
Only index kept records in ES

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -106,6 +106,10 @@ class Invoice < ApplicationRecord
     }
   end
 
+  def should_index?
+    kept?
+  end
+
   def update_timesheet_entry_status!
     timesheet_entry_ids = invoice_line_items.pluck(:timesheet_entry_id)
     TimesheetEntry.where(id: timesheet_entry_ids).update!(bill_status: :billed)


### PR DESCRIPTION
What:
- Only index kept Invoice records in ES

Why:
- So that discarded once don't show up accidentally

