### PR TITLE
NoInvoices height fixed

### DIFF
--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -209,7 +209,7 @@ const Invoices = () => {
   };
 
   const InvoicesLayout = () => (
-    <div className="p-4 lg:p-0">
+    <div className="h-full p-4 lg:p-0">
       <ToastContainer autoClose={TOASTER_DURATION} />
       <Header
         filterParamsStr={filterParamsStr}


### PR DESCRIPTION
No Invoices component's  height fixed.
Before:
<img width="1792" alt="Screenshot 2023-02-15 at 6 57 32 PM" src="https://user-images.githubusercontent.com/72149587/219562522-a6b4ed83-bd04-4001-bd88-b8132db3d6f1.png">

After:
<img width="1792" alt="Screenshot 2023-02-15 at 6 58 13 PM" src="https://user-images.githubusercontent.com/72149587/219562574-5fbbcb31-2e06-4b17-a2c5-753844632f14.png">
