### PR TITLE
Only consider kept invoices while calculating invoice summary

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -56,7 +56,7 @@ class Company < ApplicationRecord
 
   def overdue_and_outstanding_and_draft_amount
     currency = base_currency
-    status_and_amount = invoices.group(:status).sum(:amount)
+    status_and_amount = invoices.kept.group(:status).sum(:amount)
     status_and_amount.default = 0
     outstanding_amount = status_and_amount["sent"] + status_and_amount["viewed"] + status_and_amount["overdue"]
     {

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     amount_paid { Faker::Number.decimal(r_digits: 2) }
     amount_due { Faker::Number.decimal(r_digits: 2) }
     discount { Faker::Number.decimal(r_digits: 2) }
-    status { [:draft, :paid].sample }
+    status { [:draft, :paid, :overdue].sample }
     external_view_key { "#{SecureRandom.hex}" }
     factory :invoice_with_invoice_line_items do
       transient do


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/Although-I-don-t-have-any-invoice-in-draft-the-amount-is-still-getting-displayed-on-the-amount-secti-348765c53b5e4adeb7ac10a530ed030e?pvs=4

What: Fixed the invoice summary calculation by not considering deleted invoices

Why: We soft delete the invoice and hence need to use kept query while selecting the invoices.