### PR TITLE
Updated Organization settings API for Address changes.

### DIFF
--- a/app/controllers/internal_api/v1/addresses_controller.rb
+++ b/app/controllers/internal_api/v1/addresses_controller.rb
@@ -5,13 +5,17 @@ class InternalApi::V1::AddressesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize @addressable, policy_class: AddressPolicy
-    addresses = @addressable.addresses
+    addresses =  params[:company_id] ?  [@addressable.address] : @addressable.addresses
     render :index, locals: { addresses: }, status: :ok
  end
 
   def create
     authorize @addressable, policy_class: AddressPolicy
-    address = @addressable.addresses.create!(address_params)
+    address = if params[:company_id]
+                @addressable.create_address!(address_params)
+              elsif params[:user_id]
+                @addressable.addresses.create!(address_params)
+             end
     render :create, locals: { address: }, status: :ok
  end
 

--- a/app/controllers/internal_api/v1/addresses_controller.rb
+++ b/app/controllers/internal_api/v1/addresses_controller.rb
@@ -5,17 +5,17 @@ class InternalApi::V1::AddressesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize @addressable, policy_class: AddressPolicy
-    addresses =  params[:company_id] ?  [@addressable.address] : @addressable.addresses
+    addresses = params[:company_id] ? [@addressable.address] : @addressable.addresses
     render :index, locals: { addresses: }, status: :ok
  end
 
   def create
     authorize @addressable, policy_class: AddressPolicy
     address = if params[:company_id]
-                @addressable.create_address!(address_params)
-              elsif params[:user_id]
-                @addressable.addresses.create!(address_params)
-             end
+      @addressable.create_address!(address_params)
+    elsif params[:user_id]
+      @addressable.addresses.create!(address_params)
+    end
     render :create, locals: { address: }, status: :ok
  end
 

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -5,7 +5,7 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize current_company
-    render :index, locals: { current_company:, client_list: current_company.client_list, address: current_company.addresses.last }, status: :ok
+    render :index, locals: { current_company:, client_list: current_company.client_list, address: current_company.addresses&.last }, status: :ok
   end
 
   def create

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -5,7 +5,9 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize current_company
-    render :index, locals: { current_company:, client_list: current_company.client_list, address: current_company.address }, status: :ok
+    render :index, locals: {
+      current_company:, client_list: current_company.client_list, address: current_company.address
+    }, status: :ok
   end
 
   def create

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -17,7 +17,6 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
   end
 
   def update
-    authorize Company
     authorize current_company
     if current_company.update!(company_params)
       render json: { notice: I18n.t("companies.update.success") }

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -14,7 +14,7 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
     authorize Company
     company = CreateCompanyService.new(current_user, params: company_params).process
     if company
-      render json: { notice: I18n.t("companies.create.success") }
+      render json: { notice: I18n.t("companies.create.success"), company: company }
     end
   end
 

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -5,7 +5,7 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize current_company
-    render :index, locals: { current_company:, client_list: current_company.client_list, address: current_company.addresses&.last }, status: :ok
+    render :index, locals: { current_company:, client_list: current_company.client_list, address: current_company.address }, status: :ok
   end
 
   def create
@@ -29,6 +29,6 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
       params.require(:company).permit(
         :name, :business_phone, :country, :timezone, :base_currency,
         :standard_price, :fiscal_year_end, :date_format, :logo,
-        addresses_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin])
+        address_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin])
     end
 end

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -14,7 +14,7 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
     authorize Company
     company = CreateCompanyService.new(current_user, params: company_params).process
     if company
-      render json: { notice: I18n.t("companies.create.success"), company: company }
+      render json: { notice: I18n.t("companies.create.success"), company: }
     end
   end
 

--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -12,12 +12,12 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
     authorize Company
     company = CreateCompanyService.new(current_user, params: company_params).process
     if company
-      company.addresses.create!(address_params)
       render json: { notice: I18n.t("companies.create.success") }
     end
   end
 
   def update
+    authorize Company
     authorize current_company
     if current_company.update!(company_params)
       render json: { notice: I18n.t("companies.update.success") }
@@ -27,14 +27,9 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
   private
 
     def company_params
-      params.except(:address).require(:company).permit(
+      params.require(:company).permit(
         :name, :business_phone, :country, :timezone, :base_currency,
-        :standard_price, :fiscal_year_end, :date_format, :logo)
-    end
-
-    def address_params
-      params.require(:address).permit(
-        :address_type, :address_line_1, :address_line_2, :city, :state, :country, :pin
-      )
+        :standard_price, :fiscal_year_end, :date_format, :logo,
+        addresses_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin])
     end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -32,4 +32,8 @@ class Address < ApplicationRecord
   # Validations
   validates :address_type, :address_line_1, :state, :city, :country, :pin, presence: true
   validates :address_type, uniqueness: { scope: [ :addressable_id, :addressable_type ] }
+
+  def formatted_address
+    [address_line_1, address_line_2, city, state, pin, country].reject(&:blank?).join(", ")
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -3,7 +3,6 @@
 # Table name: companies
 #
 #  id              :bigint           not null, primary key
-#  address         :text             not null
 #  base_currency   :string           default("USD"), not null
 #  business_phone  :string
 #  country         :string           not null

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,6 +9,7 @@
 #  date_format     :string
 #  fiscal_year_end :string
 #  name            :string           not null
+#  old_address     :text             not null
 #  standard_price  :decimal(, )      default(0.0), not null
 #  timezone        :string
 #  created_at      :datetime         not null

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -30,8 +30,8 @@ class Company < ApplicationRecord
   has_many :invoices
   has_many :payments, through: :invoices
   has_one :stripe_connected_account, dependent: :destroy
+  has_one :address, as: :addressable, dependent: :destroy
   has_many :payments_providers, dependent: :destroy
-  has_many :addresses, as: :addressable, dependent: :destroy
   has_many :devices, dependent: :destroy
   has_many :invitations, dependent: :destroy
   has_many :expenses, dependent: :destroy
@@ -39,7 +39,7 @@ class Company < ApplicationRecord
   has_many :vendors, dependent: :destroy
   resourcify
 
-  accepts_nested_attributes_for :addresses
+  accepts_nested_attributes_for :address
 
   # Validations
   validates :name, :business_phone, :standard_price, :country, :base_currency, presence: true

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,7 +9,7 @@
 #  date_format     :string
 #  fiscal_year_end :string
 #  name            :string           not null
-#  old_address     :text             not null
+#  old_address     :text
 #  standard_price  :decimal(, )      default(0.0), not null
 #  timezone        :string
 #  created_at      :datetime         not null
@@ -40,7 +40,7 @@ class Company < ApplicationRecord
   has_many :vendors, dependent: :destroy
   resourcify
 
-  accepts_nested_attributes_for :address
+  accepts_nested_attributes_for :address, reject_if: :attributes_blank?, allow_destroy: true
 
   # Validations
   validates :name, :business_phone, :standard_price, :country, :base_currency, presence: true
@@ -81,5 +81,9 @@ class Company < ApplicationRecord
 
   def all_expense_categories
     ExpenseCategory.default_categories.order(:created_at) + expense_categories.order(:created_at)
+  end
+
+  def attributes_blank?(attributes)
+    attributes.except('id, address_line_2').values.all?(&:blank?)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -50,6 +50,8 @@ class Company < ApplicationRecord
   scope :with_kept_employments, -> { merge(Employment.kept) }
   scope :valid_invitations, -> { where(company: self).valid_invitations }
 
+  delegate :formatted_address, to: :address
+
   def client_list
     clients.kept.map do |client|
       { id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.address }

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -39,6 +39,8 @@ class Company < ApplicationRecord
   has_many :vendors, dependent: :destroy
   resourcify
 
+  accepts_nested_attributes_for :addresses
+
   # Validations
   validates :name, :business_phone, :standard_price, :country, :base_currency, presence: true
   validates :standard_price, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -40,7 +40,7 @@ class Company < ApplicationRecord
   has_many :vendors, dependent: :destroy
   resourcify
 
-  accepts_nested_attributes_for :address, reject_if: :attributes_blank?, allow_destroy: true
+  accepts_nested_attributes_for :address, reject_if: :address_attributes_blank?, allow_destroy: true
 
   # Validations
   validates :name, :business_phone, :standard_price, :country, :base_currency, presence: true
@@ -83,7 +83,7 @@ class Company < ApplicationRecord
     ExpenseCategory.default_categories.order(:created_at) + expense_categories.order(:created_at)
   end
 
-  def attributes_blank?(attributes)
+  def address_attributes_blank?(attributes)
     attributes.except("id, address_line_2").values.all?(&:blank?)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -84,6 +84,6 @@ class Company < ApplicationRecord
   end
 
   def attributes_blank?(attributes)
-    attributes.except('id, address_line_2').values.all?(&:blank?)
+    attributes.except("id, address_line_2").values.all?(&:blank?)
   end
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -36,8 +36,8 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :old_address, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
-     :date_format, :logo]
+    [:name, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
+     :date_format, :logo, address_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin]]
   end
 
   def purge_logo?

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -36,7 +36,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :address, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
+    [:name, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
      :date_format, :logo]
   end
 

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -36,7 +36,7 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
+    [:name, :old_address, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
      :date_format, :logo]
   end
 

--- a/app/services/create_company_service.rb
+++ b/app/services/create_company_service.rb
@@ -13,6 +13,7 @@ class CreateCompanyService
   def process
     company.save!
     add_current_user_to_company
+    company
   end
 
   private

--- a/app/views/internal_api/v1/companies/index.json.jbuilder
+++ b/app/views/internal_api/v1/companies/index.json.jbuilder
@@ -13,7 +13,7 @@ json.company_details do
   json.date_format current_company.date_format
   json.logo_url
   json.address do
-    json.partial! "internal_api/v1/partial/address", locals: { address: address }
+    json.partial! "internal_api/v1/partial/address", locals: { address: }
   end
 end
 

--- a/app/views/internal_api/v1/companies/index.json.jbuilder
+++ b/app/views/internal_api/v1/companies/index.json.jbuilder
@@ -5,7 +5,14 @@ json.company_details do
   json.logo current_company.logo.attached? ? polymorphic_url(current_company.logo) : ""
   json.name current_company.name
   json.business_phone current_company.business_phone
-  json.address current_company.address
+  json.address do
+    json.address_line_1 address.address_line_1
+    json.address_line_2 address.address_line_2
+    json.city address.city
+    json.state address.state
+    json.country address.country
+    json.pin address.pin
+  end
   json.country current_company.country
   json.currency current_company.base_currency
   json.standard_price current_company.standard_price

--- a/app/views/internal_api/v1/companies/index.json.jbuilder
+++ b/app/views/internal_api/v1/companies/index.json.jbuilder
@@ -5,14 +5,6 @@ json.company_details do
   json.logo current_company.logo.attached? ? polymorphic_url(current_company.logo) : ""
   json.name current_company.name
   json.business_phone current_company.business_phone
-  json.address do
-    json.address_line_1 address&.address_line_1
-    json.address_line_2 address&.address_line_2
-    json.city address&.city
-    json.state address&.state
-    json.country address&.country
-    json.pin address&.pin
-  end
   json.country current_company.country
   json.currency current_company.base_currency
   json.standard_price current_company.standard_price
@@ -20,7 +12,11 @@ json.company_details do
   json.timezone current_company.timezone
   json.date_format current_company.date_format
   json.logo_url
+  json.address do
+    json.partial! "internal_api/v1/partial/address", locals: { address: address }
+  end
 end
+
 json.issue_date Date.current
 json.due_date Date.current + 30
 json.company_client_list client_list

--- a/app/views/internal_api/v1/companies/index.json.jbuilder
+++ b/app/views/internal_api/v1/companies/index.json.jbuilder
@@ -6,12 +6,12 @@ json.company_details do
   json.name current_company.name
   json.business_phone current_company.business_phone
   json.address do
-    json.address_line_1 address.address_line_1
-    json.address_line_2 address.address_line_2
-    json.city address.city
-    json.state address.state
-    json.country address.country
-    json.pin address.pin
+    json.address_line_1 address&.address_line_1
+    json.address_line_2 address&.address_line_2
+    json.city address&.city
+    json.state address&.state
+    json.country address&.country
+    json.pin address&.pin
   end
   json.country current_company.country
   json.currency current_company.base_currency

--- a/app/views/internal_api/v1/partial/_address.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_address.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.address_line_1 address.address_line_1
+json.address_line_2 address.address_line_2
+json.city address.city
+json.state address.state
+json.country address.country
+json.pin address.pin

--- a/app/views/internal_api/v1/partial/_company.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_company.json.jbuilder
@@ -4,7 +4,7 @@ json.id company.id
 json.logo company.logo.attached? ? polymorphic_url(company.logo) : ""
 json.name company.name
 json.phone_number company.business_phone
-json.address company.address
+json.address company.addresses&.last
 json.country company.country
 json.currency company.base_currency
 json.date_format company.date_format

--- a/app/views/internal_api/v1/partial/_company.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_company.json.jbuilder
@@ -4,7 +4,7 @@ json.id company.id
 json.logo company.logo.attached? ? polymorphic_url(company.logo) : ""
 json.name company.name
 json.phone_number company.business_phone
-json.address company.addresses&.last
+json.address company.address
 json.country company.country
 json.currency company.base_currency
 json.date_format company.date_format

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -24,8 +24,7 @@ html {
       </div>
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
-      <p><%=invoice.company.addresses&.last%></p>
-      <p><%=invoice.company.country%></p>
+      <p><%=invoice.company.address&.formatted_address%></p>
     </div>
   </div>
 

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -24,7 +24,7 @@ html {
       </div>
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
-      <p><%=invoice.company.address.formatted_address%></p>
+      <p><%=invoice.company.formatted_address%></p>
     </div>
   </div>
 

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -24,7 +24,7 @@ html {
       </div>
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
-      <p><%=invoice.company.address%></p>
+      <p><%=invoice.company.addresses&.last%></p>
       <p><%=invoice.company.country%></p>
     </div>
   </div>

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -24,7 +24,7 @@ html {
       </div>
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
-      <p><%=invoice.company.address&.formatted_address%></p>
+      <p><%=invoice.company.address.formatted_address%></p>
     </div>
   </div>
 

--- a/db/migrate/20230220112211_remove_address_from_company.rb
+++ b/db/migrate/20230220112211_remove_address_from_company.rb
@@ -1,0 +1,5 @@
+class RemoveAddressFromCompany < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :companies, :address }
+  end
+end

--- a/db/migrate/20230220112211_remove_address_from_company.rb
+++ b/db/migrate/20230220112211_remove_address_from_company.rb
@@ -1,5 +1,0 @@
-class RemoveAddressFromCompany < ActiveRecord::Migration[7.0]
-  def change
-    safety_assured { remove_column :companies, :address }
-  end
-end

--- a/db/migrate/20230224071256_rename_address_column_of_company.rb
+++ b/db/migrate/20230224071256_rename_address_column_of_company.rb
@@ -1,5 +1,6 @@
 class RenameAddressColumnOfCompany < ActiveRecord::Migration[7.0]
   def change
     safety_assured { rename_column :companies, :address, :old_address }
+    change_column_null :companies, :old_address, true
   end
 end

--- a/db/migrate/20230224071256_rename_address_column_of_company.rb
+++ b/db/migrate/20230224071256_rename_address_column_of_company.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameAddressColumnOfCompany < ActiveRecord::Migration[7.0]
   def change
     safety_assured { rename_column :companies, :address, :old_address }

--- a/db/migrate/20230224071256_rename_address_column_of_company.rb
+++ b/db/migrate/20230224071256_rename_address_column_of_company.rb
@@ -1,0 +1,5 @@
+class RenameAddressColumnOfCompany < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { rename_column :companies, :address, :old_address }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_112211) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_24_071256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_112211) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
+    t.text "old_address", null: false
     t.string "business_phone"
     t.string "base_currency", default: "USD", null: false
     t.decimal "standard_price", default: "0.0", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_122149) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_20_112211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,7 +75,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_122149) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
-    t.text "address", null: false
     t.string "business_phone"
     t.string "base_currency", default: "USD", null: false
     t.decimal "standard_price", default: "0.0", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_24_071256) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
-    t.text "old_address", null: false
+    t.text "old_address"
     t.string "business_phone"
     t.string "base_currency", default: "USD", null: false
     t.decimal "standard_price", default: "0.0", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -93,7 +93,7 @@ invoice_2 = company.invoices.create!(
 Invoice.reindex
 puts "Invoice Created"
 
-company.addresses.create!(
+company.address.create!(
   address_type: "permanent",
   address_line_1: "Saeloun Inc",
   address_line_2: "475 Clermont Ave",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,6 @@
 company = Company.create!(
   {
     name: "Saeloun Inc",
-    old_address: "475 Clermont Ave, Brooklyn, NY-12238",
     business_phone: "+1 9296207865",
     base_currency: "USD",
     standard_price: 1000,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@
 company = Company.create!(
   {
     name: "Saeloun Inc",
-    address: "475 Clermont Ave, Brooklyn, NY-12238",
+    old_address: "475 Clermont Ave, Brooklyn, NY-12238",
     business_phone: "+1 9296207865",
     base_currency: "USD",
     standard_price: 1000,
@@ -93,7 +93,7 @@ invoice_2 = company.invoices.create!(
 Invoice.reindex
 puts "Invoice Created"
 
-company.address.create!(
+company.create_address!(
   address_type: "permanent",
   address_line_1: "Saeloun Inc",
   address_line_2: "475 Clermont Ave",

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -9,8 +9,8 @@ def copy_address_into_address_table
   Company.find_each do |company|
     address_record = company.address
     unless address_record.present?
-        address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")
-        address.save(validate: false)
+      address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")
+      address.save(validate: false)
     end
   end
 end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -10,7 +10,8 @@ def copy_address_into_address_table
     puts " * * * * * * * * * Company* * * * * * * * Id: #{company.id}, Name: #{company.name}"
     address_record = company.address
     unless address_record.present?
-      address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")
+      old_address = company.old_address || ""
+      address = company.build_address(address_line_1: old_address, city: "", state: "", country: "", pin: "")
       address.save!(validate: false)
     end
   end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -7,6 +7,7 @@
 # We have few records of the company i.e 140 because of that using each.
 def copy_address_into_address_table
   Company.find_each do |company|
+    puts " * * * * * * * * * Company* * * * * * * * Id: #{company.id}, Name: #{company.name}"
     address_record = company.address
     unless address_record.present?
       address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -9,7 +9,7 @@ def copy_address_into_address_table
   Company.find_each do |company|
     address_record = company.address
     unless address_record.present?
-        address = company.build_address(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
+        address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")
         address.save(validate: false)
     end
   end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -9,7 +9,8 @@ def copy_address_into_address_table
   Company.find_each do |company|
     address_record = company.addresses&.last
     unless address_record.present?
-      company.addresses.create!(address_line_1: company.address)
+        address = company.addresses.new(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
+        address.save(validate: false)
     end
   end
 end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -7,9 +7,9 @@
 # We have few records of the company i.e 140 because of that using each.
 def copy_address_into_address_table
   Company.find_each do |company|
-    address_record = company.addresses&.last
+    address_record = company.address
     unless address_record.present?
-        address = company.addresses.new(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
+        address = company.address.new(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
         address.save(validate: false)
     end
   end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -11,7 +11,7 @@ def copy_address_into_address_table
     address_record = company.address
     unless address_record.present?
       address = company.build_address(address_line_1: company&.old_address, city: "", state: "", country: "", pin: "")
-      address.save(validate: false)
+      address.save!(validate: false)
     end
   end
 end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -9,7 +9,7 @@ def copy_address_into_address_table
   Company.find_each do |company|
     address_record = company.address
     unless address_record.present?
-        address = company.address.new(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
+        address = company.build_address(address_line_1: company&.address, city: "", state: "", country: "", pin: "")
         address.save(validate: false)
     end
   end

--- a/scripts/update_company_addresses.rb
+++ b/scripts/update_company_addresses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+# This script copies the company address from the address field to the address_line_1 field of the Address model.
+# ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+
+# We have few records of the company i.e 140 because of that using each.
+def copy_address_into_address_table
+  Company.find_each do |company|
+    address_record = company.addresses&.last
+    unless address_record.present?
+      company.addresses.create!(address_line_1: company.address)
+    end
+  end
+end
+
+copy_address_into_address_table

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :company do
     name { "Saeloun" }
-    address { Faker::Address.full_address }
     business_phone { Faker::PhoneNumber.cell_phone_in_e164 }
     base_currency { Faker::Currency.code }
     standard_price { Faker::Number.decimal(l_digits: 3, r_digits: 2) }

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe InvoiceMailer, type: :mailer do
   describe "invoice" do
-    let(:company) { create :company, :with_logo }
+    let(:company) { create :company, :with_logo, address_attributes: attributes_for(:address) }
     let(:client) { create :client, company: }
-    let(:invoice) { create :invoice, client: }
+    let(:invoice) { create :invoice, client:, company: }
     let(:recipients) { [invoice.client.email, "miru@example.com"] }
     let(:subject) { "Invoice (#{invoice.invoice_number}) due on #{invoice.due_date}" }
     let(:mail) { InvoiceMailer.with(invoice:, subject:, recipients:).invoice }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Company, type: :model do
     it { is_expected.to have_many(:clients).dependent(:destroy) }
     it { is_expected.to have_many(:projects).through(:clients).dependent(:destroy) }
     it { is_expected.to have_one_attached(:logo) }
+    it { is_expected.to have_one(:address).dependent(:destroy) }
     it { is_expected.to have_many(:current_workspace_users).dependent(:nullify) }
-    it { is_expected.to have_many(:addresses).dependent(:destroy) }
     it { is_expected.to have_many(:devices).dependent(:destroy) }
     it { is_expected.to have_many(:expenses).dependent(:destroy) }
     it { is_expected.to have_many(:expense_categories).dependent(:destroy) }

--- a/spec/requests/companies/create_spec.rb
+++ b/spec/requests/companies/create_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe "Companies#create", type: :request do
   let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:address) {
+                  {
+                    address_line_1: "Saeloun Inc", address_line_2: "475 Clermont Ave",
+                    state: "NY", city: "Brooklyn", country: "US", pin: "12238"
+                  }
+                }
 
   context "when user is an admin" do
     before do
@@ -26,13 +32,24 @@ RSpec.describe "Companies#create", type: :request do
               standard_price: "1000",
               fiscal_year_end: "April",
               date_format: "DD/MM/YYYY",
-              address_attributes: attributes_for(:address)
+              address_attributes: address
             }
           }, headers: auth_headers(user))
       end
 
       it "creates a new company" do
+        company = Company.last
+        company_address = company.address
         change(Company, :count).by(1)
+        change(Address, :count).by(1)
+        expect(company.name).to eq("Test Company")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.date_format).to eq("DD/MM/YYYY")
+        expect(company_address.address_line_1).to eq("Saeloun Inc")
+        expect(company_address.city).to eq("Brooklyn")
+        expect(company_address.country).to eq("US")
+        expect(company_address.pin).to eq("12238")
       end
 
       it "sets the current_workspace_id to current_user" do
@@ -86,20 +103,29 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              old_address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              address_attributes: attributes_for(:address)
             }
           }, headers: auth_headers(user))
       end
 
       it "will be created" do
+        company = Company.last
         change(Company, :count).by(1)
+        change(Address, :count).by(1)
+        expect(company.name).to eq("Test Company")
+        expect(company.business_phone).to eq("Test phone")
+        expect(company.base_currency).to eq("Rs")
+        expect(company.timezone).to eq("IN")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.date_format).to eq("DD/MM/YYYY")
       end
 
       it "sets the current_workspace_id to current_user" do
@@ -124,20 +150,27 @@ RSpec.describe "Companies#create", type: :request do
             :post, company_path, params: {
               company: {
                 name: "Test Company",
-                old_address: "test address",
                 business_phone: "Test phone",
                 country: "India",
                 timezone: "IN",
                 base_currency: "Rs",
                 standard_price: "1000",
                 fiscal_year_end: "April",
-                date_format: "DD/MM/YYYY"
+                date_format: "DD/MM/YYYY",
+                address_attributes: attributes_for(:address)
               }
             }, headers: auth_headers(user))
         end
 
         it "will be created" do
+          company = Company.last
           change(Company, :count).by(1)
+          expect(company.name).to eq("Test Company")
+          expect(company.business_phone).to eq("Test phone")
+          expect(company.timezone).to eq("IN")
+          expect(company.standard_price).to eq(1000)
+          expect(company.fiscal_year_end).to eq("April")
+          expect(company.date_format).to eq("DD/MM/YYYY")
         end
 
         it "sets the current_workspace_id to current_user" do
@@ -185,14 +218,14 @@ RSpec.describe "Companies#create", type: :request do
         :post, company_path, params: {
           company: {
             name: "Test Company",
-            old_address: "test address",
             business_phone: "Test phone",
             country: "India",
             timezone: "IN",
             base_currency: "Rs",
             standard_price: "1000",
             fiscal_year_end: "April",
-            date_format: "DD/MM/YYYY"
+            date_format: "DD/MM/YYYY",
+            address_attributes: attributes_for(:address)
           }
         })
       expect(response).to redirect_to(user_session_path)

--- a/spec/requests/companies/create_spec.rb
+++ b/spec/requests/companies/create_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Companies#create", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is an admin" do
@@ -19,14 +19,14 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              old_address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              address_attributes: attributes_for(:address)
             }
           }, headers: auth_headers(user))
       end

--- a/spec/requests/companies/create_spec.rb
+++ b/spec/requests/companies/create_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              address: "test address",
+              old_address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
@@ -86,7 +86,7 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              address: "test address",
+              old_address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
@@ -124,7 +124,7 @@ RSpec.describe "Companies#create", type: :request do
             :post, company_path, params: {
               company: {
                 name: "Test Company",
-                address: "test address",
+                old_address: "test address",
                 business_phone: "Test phone",
                 country: "India",
                 timezone: "IN",
@@ -185,7 +185,7 @@ RSpec.describe "Companies#create", type: :request do
         :post, company_path, params: {
           company: {
             name: "Test Company",
-            address: "test address",
+            old_address: "test address",
             business_phone: "Test phone",
             country: "India",
             timezone: "IN",

--- a/spec/requests/companies/update_spec.rb
+++ b/spec/requests/companies/update_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              business_phone: "1234556"
+              business_phone: "1234556",
+              old_address: "updated address"
             }
           })
       end
@@ -27,6 +28,7 @@ RSpec.describe "Companies#create", type: :request do
       it "updates the company" do
         company.reload
         expect(company.name).to eq("Updated Company")
+        expect(company.old_address).to eq("updated address")
       end
 
       it "redirects to root_path" do

--- a/spec/requests/companies/update_spec.rb
+++ b/spec/requests/companies/update_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
               business_phone: "1234556"
             }
           })
@@ -28,7 +27,6 @@ RSpec.describe "Companies#create", type: :request do
       it "updates the company" do
         company.reload
         expect(company.name).to eq("Updated Company")
-        expect(company.address).to eq("updated address")
       end
 
       it "redirects to root_path" do
@@ -67,7 +65,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
               business_phone: "1234556"
             }
           })
@@ -88,7 +85,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "",
-              address: "",
               business_phone: ""
             }
           })
@@ -117,7 +113,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
               business_phone: "1234556"
             }
           })
@@ -138,7 +133,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "",
-              address: "",
               business_phone: ""
             }
           })
@@ -160,7 +154,6 @@ RSpec.describe "Companies#create", type: :request do
         :put, company_path, params: {
           company: {
             name: "Updated Company",
-            address: "updated address",
             business_phone: "1234556"
           }
         })

--- a/spec/requests/companies/update_spec.rb
+++ b/spec/requests/companies/update_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Companies#create", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is an admin" do
@@ -20,7 +20,10 @@ RSpec.describe "Companies#create", type: :request do
             company: {
               name: "Updated Company",
               business_phone: "1234556",
-              old_address: "updated address"
+              address_attributes: {
+                id: company.address.id,
+                address_line_1: "updated address"
+              }
             }
           })
       end
@@ -28,7 +31,7 @@ RSpec.describe "Companies#create", type: :request do
       it "updates the company" do
         company.reload
         expect(company.name).to eq("Updated Company")
-        expect(company.old_address).to eq("updated address")
+        expect(company.address.address_line_1).to eq("updated address")
       end
 
       it "redirects to root_path" do

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -22,13 +22,7 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
             standard_price: 1000,
             fiscal_year_end: "Jan-Dec",
             date_format: "DD-MM-YYYY",
-            address_attributes: {
-              address_line_1: "Somewhere on Earth",
-              city: "Brooklyn",
-              state: "NY",
-              country: "US",
-              pin: "12238"
-            }
+            address_attributes: attributes_for(:address)
           }
         }, headers: auth_headers(user)
       end
@@ -83,13 +77,7 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
               standard_price: 1000,
               fiscal_year_end: "Jan-Dec",
               date_format: "DD-MM-YYYY",
-              address_attributes: {
-                address_line_1: "Somewhere on Earth",
-                city: "Brooklyn",
-                state: "NY",
-                country: "US",
-                pin: "12238"
-              }
+              address_attributes: attributes_for(:address)
             }
           }, headers: auth_headers(user)
         end

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
             standard_price: 1000,
             fiscal_year_end: "Jan-Dec",
             date_format: "DD-MM-YYYY",
-            addresses_attributes:  [{
+            address_attributes:  {
               address_line_1: "Somewhere on Earth",
               city: "Brooklyn",
               state: "NY",
               country: "US",
               pin: "12238"
-            }]
+            }
           }
         }, headers: auth_headers(user)
       end
@@ -83,13 +83,13 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
               standard_price: 1000,
               fiscal_year_end: "Jan-Dec",
               date_format: "DD-MM-YYYY",
-              addresses_attributes:  [{
+              address_attributes:  {
                 address_line_1: "Somewhere on Earth",
                 city: "Brooklyn",
                 state: "NY",
                 country: "US",
                 pin: "12238"
-            }]
+            }
             }
           }, headers: auth_headers(user)
         end

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
             standard_price: 1000,
             fiscal_year_end: "Jan-Dec",
             date_format: "DD-MM-YYYY",
-            address_attributes:  {
+            address_attributes: {
               address_line_1: "Somewhere on Earth",
               city: "Brooklyn",
               state: "NY",
@@ -83,13 +83,13 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
               standard_price: 1000,
               fiscal_year_end: "Jan-Dec",
               date_format: "DD-MM-YYYY",
-              address_attributes:  {
+              address_attributes: {
                 address_line_1: "Somewhere on Earth",
                 city: "Brooklyn",
                 state: "NY",
                 country: "US",
                 pin: "12238"
-            }
+              }
             }
           }, headers: auth_headers(user)
         end

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
         }, headers: auth_headers(user)
       end
 
+      it "creates a new compamy & address" do
+        company = Company.last
+        change(Company, :count).by(1)
+        change(Address, :count).by(1)
+        expect(company.name).to eq("zero labs llc")
+        expect(company.business_phone).to eq("+01 123123")
+        expect(company.timezone).to eq("+5:30 Chennai")
+        expect(company.base_currency).to eq("INR")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("Jan-Dec")
+        expect(company.date_format).to eq("DD-MM-YYYY")
+      end
+
       it "response should be successful" do
         expect(response).to be_successful
       end

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -15,14 +15,20 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
         send_request :post, internal_api_v1_companies_path, params: {
           company: {
             name: "zero labs llc",
-            address: "remote",
             business_phone: "+01 123123",
             country: "india",
             timezone: "+5:30 Chennai",
             base_currency: "INR",
             standard_price: 1000,
             fiscal_year_end: "Jan-Dec",
-            date_format: "DD-MM-YYYY"
+            date_format: "DD-MM-YYYY",
+            addresses_attributes:  [{
+              address_line_1: "Somewhere on Earth",
+              city: "Brooklyn",
+              state: "NY",
+              country: "US",
+              pin: "12238"
+            }]
           }
         }, headers: auth_headers(user)
       end
@@ -70,14 +76,20 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
           send_request :post, internal_api_v1_companies_path, params: {
             company: {
               name: "zero labs llc",
-              address: "remote",
               business_phone: "+01 123123",
               country: "india",
               timezone: "+5:30 Chennai",
               base_currency: "INR",
               standard_price: 1000,
               fiscal_year_end: "Jan-Dec",
-              date_format: "DD-MM-YYYY"
+              date_format: "DD-MM-YYYY",
+              addresses_attributes:  [{
+                address_line_1: "Somewhere on Earth",
+                city: "Brooklyn",
+                state: "NY",
+                country: "US",
+                pin: "12238"
+            }]
             }
           }, headers: auth_headers(user)
         end

--- a/spec/requests/internal_api/v1/companies/index_spec.rb
+++ b/spec/requests/internal_api/v1/companies/index_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Companies::index", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, addresses_attributes: [attributes_for(:address)]) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   before do
@@ -23,7 +23,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]).to eq(company.address)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]).to eq(company.address)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
    it "returns success json response" do
      expect(json_response["company_details"]["name"]).to eq(company.name)
-     expect(json_response["company_details"]["address"]).to eq(company.address)
+     expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
    end
  end
 end

--- a/spec/requests/internal_api/v1/companies/index_spec.rb
+++ b/spec/requests/internal_api/v1/companies/index_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Companies::index", type: :request do
-  let(:company) { create(:company, addresses_attributes: [attributes_for(:address)]) }
+  let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   before do
@@ -23,7 +23,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
    it "returns success json response" do
      expect(json_response["company_details"]["name"]).to eq(company.name)
-     expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.addresses&.last&.address_line_1)
+     expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
    end
  end
 end

--- a/spec/requests/internal_api/v1/companies/index_spec.rb
+++ b/spec/requests/internal_api/v1/companies/index_spec.rb
@@ -23,7 +23,12 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_2"]).to eq(company.address.address_line_2)
+      expect(json_response["company_details"]["address"]["city"]).to eq(company.address.city)
+      expect(json_response["company_details"]["address"]["state"]).to eq(company.address.state)
+      expect(json_response["company_details"]["address"]["country"]).to eq(company.address.country)
+      expect(json_response["company_details"]["address"]["pin"]).to eq(company.address.pin)
     end
   end
 
@@ -40,7 +45,12 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "returns success json response" do
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_2"]).to eq(company.address.address_line_2)
+      expect(json_response["company_details"]["address"]["city"]).to eq(company.address.city)
+      expect(json_response["company_details"]["address"]["state"]).to eq(company.address.state)
+      expect(json_response["company_details"]["address"]["country"]).to eq(company.address.country)
+      expect(json_response["company_details"]["address"]["pin"]).to eq(company.address.pin)
     end
   end
 
@@ -57,7 +67,12 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
    it "returns success json response" do
      expect(json_response["company_details"]["name"]).to eq(company.name)
-     expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address&.address_line_1)
+     expect(json_response["company_details"]["address"]["address_line_1"]).to eq(company.address.address_line_1)
+     expect(json_response["company_details"]["address"]["address_line_2"]).to eq(company.address.address_line_2)
+     expect(json_response["company_details"]["address"]["city"]).to eq(company.address.city)
+     expect(json_response["company_details"]["address"]["state"]).to eq(company.address.state)
+     expect(json_response["company_details"]["address"]["country"]).to eq(company.address.country)
+     expect(json_response["company_details"]["address"]["pin"]).to eq(company.address.pin)
    end
  end
 end

--- a/spec/requests/internal_api/v1/invoices/download_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/download_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Invoices#download", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create :company, address_attributes: attributes_for(:address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let!(:client) { create(:client, company:) }
   let!(:invoice) { create(:invoice, client:, company:, status: "sent") }

--- a/spec/services/bulk_invoice_download_service_spec.rb
+++ b/spec/services/bulk_invoice_download_service_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 require "zip"
 
 RSpec.describe BulkInvoiceDownloadService do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let!(:client) { create(:client, company:, name: "bob") }
-  let!(:invoice1) { create(:invoice, client:) }
-  let!(:invoice2) { create(:invoice, client:) }
-  let(:invoice3) { create(:invoice, client:) }
+  let!(:invoice1) { create(:invoice, client:, company:) }
+  let!(:invoice2) { create(:invoice, client:, company:) }
+  let(:invoice3) { create(:invoice, client:, company:) }
 
   describe "#process" do
     before do

--- a/spec/system/clients/create_spec.rb
+++ b/spec/system/clients/create_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Create client", type: :system do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, address_attributes: attributes_for(:address)) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is admin" do


### PR DESCRIPTION
Notion:

https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=5578743881b44e108a04efb88153c00e&pm=s

Description:

After the developing the updated designs of organization settings page, backend changes are required for address fields on the organization settings page. 

- The address field is a text field which needs to be updated to different fields for Address line 1 , Address line 2 , Country, State, City & Zipcode. 

- We removed address column from the company table.
- We used Address association to save company's address.
- Updated create copmany API.

API Endpoint:
 
 http://localhost:3000/internal_api/v1/companies 

Input Params:
`
{
    "company": {
        "name": "Saeloun",
        "business_phone": "+918390108472",
        "country": "US",
        "base_currency": "USD",
        "standard_price": "200.00",
        "fiscal_year_end": "Dec",
        "date_format": "MM-DD-YYYY",
        "timezone": "(GMT-05:00) Eastern Time (US & Canada)",
        "address_attributes": {
            "address_line_1": "Saeloun Inc",
            "address_line_2": "475 Clermont Ave",
            "state": "NY",
            "city": "Brooklyn",
            "country": "US",
            "pin": "12238"
        }
    }
}
`