### PR TITLE
Time entry filter mobile responsive design

### DIFF
--- a/app/javascript/src/common/CustomDateRangeWIthInput/index.tsx
+++ b/app/javascript/src/common/CustomDateRangeWIthInput/index.tsx
@@ -256,7 +256,7 @@ const CustomDateRangeWithInput = ({
           )}
         </div>
       </div>
-      <div className="absolute z-20 mt-1 flex flex-col  overflow-y-auto rounded-lg bg-miru-white-1000 shadow-c1 lg:ml-2 xl:ml-10">
+      <div className="absolute z-20 mt-1 ml-10 flex  flex-col overflow-y-auto rounded-lg bg-miru-white-1000 shadow-c1 lg:ml-2 xl:ml-10">
         <DatePicker
           inline
           calendarClassName="miru-calendar-date-range"

--- a/app/javascript/src/components/Reports/Header/index.tsx
+++ b/app/javascript/src/components/Reports/Header/index.tsx
@@ -106,13 +106,37 @@ const Header = ({
           {showMoreOptions && (
             <MobileMoreOptions setVisibilty={setShowMoreOptions}>
               <li
-                className="flex items-center p-2 text-miru-han-purple-1000"
+                className="flex items-center p-2 text-sm text-miru-han-purple-1000"
                 onClick={() => {
                   setIsFilterVisible(!isFilterVisible);
                 }}
               >
                 <FilterIcon className="mr-4" color="#7C5DEE" size={16} />{" "}
                 Filters
+              </li>
+              <li>
+                <button
+                  className="menuButton__list-item pl-2"
+                  onClick={() => {
+                    setShowExportOptions(false);
+                    handleDownload("csv");
+                  }}
+                >
+                  <FileCsvIcon color="#5B34EA" size={16} weight="bold" />
+                  <span className="ml-3 text-sm">Export as CSV</span>
+                </button>
+              </li>
+              <li>
+                <button
+                  className="menuButton__list-item pl-2"
+                  onClick={() => {
+                    setShowExportOptions(false);
+                    handleDownload("pdf");
+                  }}
+                >
+                  <FilePdfIcon color="#5B34EA" size={16} weight="bold" />
+                  <span className="ml-3 text-sm">Export as PDF</span>
+                </button>
               </li>
               {/* <li className="flex items-center p-2 text-miru-dark-purple-400">
                 <PaperPlaneTiltIcon className="mr-4" size={16} /> Share


### PR DESCRIPTION
Notion- https://www.notion.so/saeloun/Time-entry-report-Mobile-responsive-filter-panel-afc8705efaa842c580442bbd07f6b032?pvs=4

What- 
1. Added mobile responsive filter panel.
2. Added menu items on the popup.

Why-
1. Added responsive margin for the smaller screens and kept the margin for the desktop view as it is.

Note-
Tested manually on my local machine with different screen resolutions.

loom video- 
https://www.loom.com/share/031e778152b348afaaa65ed909e4c380
