### PR TITLE
Invoices report: The invoices grouped by client sorted by the invoice  issue date in descending order.

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -124,7 +124,7 @@ class Client < ApplicationRecord
   def outstanding_and_overdue_invoices
     outstanding_overdue_statuses = ["overdue", "sent", "viewed"]
     filtered_invoices = invoices
-      .order(updated_at: :desc)
+      .order(issue_date: :desc)
       .includes(:company)
       .select { |invoice| outstanding_overdue_statuses.include?(invoice.status) }
     status_and_amount = invoices.group(:status).sum(:amount)

--- a/spec/requests/internal_api/v1/reports/outstanding_overdue_invoices/index_spec.rb
+++ b/spec/requests/internal_api/v1/reports/outstanding_overdue_invoices/index_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "InternalApi::V1::Reports::OutstandingOverdueInvoicesController::
                           amount: client2_sent_invoice1.amount,
                           status: client2_sent_invoice1.status
                         }
-                      ]
+                      ].sort_by { |k| Date.strptime(k[:issueDate], "%m.%d.%Y") }.reverse
           },
            {
              name: client1.name,
@@ -81,7 +81,7 @@ RSpec.describe "InternalApi::V1::Reports::OutstandingOverdueInvoicesController::
                           amount: client1_sent_invoice1.amount,
                           status: client1_sent_invoice1.status
                         }
-                      ]
+                      ].sort_by { |k| Date.strptime(k[:issueDate], "%m.%d.%Y") }.reverse
            }]
         get internal_api_v1_reports_outstanding_overdue_invoices_path
       end


### PR DESCRIPTION
**Notion:** 

https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=7c5bf09716c7455ba9f1176a03ffd8a7&pm=s

**Description:**
Currently, the invoices are not sorted by the issue date on the invoice report page. Invoices grouped by the client should be sorted by the invoice issue date in descending order i.e. the most recent invoice should be displayed first. 

We have achieved this by changing the order of the invoices.

**Screenshot:**
<img width="1767" alt="Screenshot 2023-02-22 at 6 21 37 PM" src="https://user-images.githubusercontent.com/2971017/220624724-aead1708-9a5b-4445-b7fd-85d14115b3dd.png">
