### PR TITLE
Added auth context and its reducer to handle authentication on client side

### DIFF
--- a/app/javascript/src/context/auth.tsx
+++ b/app/javascript/src/context/auth.tsx
@@ -2,15 +2,15 @@ import React, { createContext, useReducer } from "react";
 
 import PropTypes from "prop-types";
 
-import { getFromLocalStorage } from "utils/storage";
+import { getValueFromLocalStorage } from "utils/storage";
 
 import authReducer from "../reducers/auth";
 
 const AuthStateContext = createContext({});
 const AuthDispatchContext = createContext({});
 
-const token = getFromLocalStorage("authToken");
-const email = getFromLocalStorage("authEmail");
+const token = getValueFromLocalStorage("authToken");
+const email = getValueFromLocalStorage("authEmail");
 
 const initialState = {
   isLoggedIn: !!token,

--- a/app/javascript/src/context/auth.tsx
+++ b/app/javascript/src/context/auth.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useReducer } from "react";
+
+import PropTypes from "prop-types";
+
+import { getFromLocalStorage } from "utils/storage";
+
+import authReducer from "../reducers/auth";
+
+const AuthStateContext = createContext({});
+const AuthDispatchContext = createContext({});
+
+const token = getFromLocalStorage("authToken");
+const email = getFromLocalStorage("authEmail");
+
+const initialState = {
+  isLoggedIn: !!token,
+  authToken: token || null,
+  authEmail: email || null,
+};
+
+const AuthProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  return (
+    <AuthStateContext.Provider value={state}>
+      <AuthDispatchContext.Provider value={dispatch}>
+        {children}
+      </AuthDispatchContext.Provider>
+    </AuthStateContext.Provider>
+  );
+};
+
+const useAuthState = () => {
+  const context = React.useContext(AuthStateContext);
+  if (context === undefined) {
+    throw new Error("useAuthState must be used within a AuthProvider");
+  }
+
+  return context;
+};
+
+const useAuthDispatch = () => {
+  const context = React.useContext(AuthDispatchContext);
+  if (context === undefined) {
+    throw new Error("useAuthDispatch must be used within a AuthProvider");
+  }
+
+  return context;
+};
+
+const useAuth = () => [useAuthState(), useAuthDispatch()];
+
+AuthProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export { AuthProvider, useAuthState, useAuthDispatch, useAuth };

--- a/app/javascript/src/reducers/auth.ts
+++ b/app/javascript/src/reducers/auth.ts
@@ -1,0 +1,27 @@
+import { setToLocalStorage } from "utils/storage";
+
+const authReducer = (_, { type, payload }) => {
+  switch (type) {
+    case "LOGIN": {
+      setToLocalStorage("authToken", payload.token);
+      setToLocalStorage("authEmail", payload.email);
+
+      return {
+        isLoggedIn: true,
+        authToken: payload.token,
+        authEmail: payload.email,
+      };
+    }
+    case "LOGOUT": {
+      setToLocalStorage("authToken", null);
+      setToLocalStorage("authEmail", null);
+
+      return { isLoggedIn: false, authToken: null, authEmail: null };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${type}`);
+    }
+  }
+};
+
+export default authReducer;

--- a/app/javascript/src/utils/storage.ts
+++ b/app/javascript/src/utils/storage.ts
@@ -1,0 +1,27 @@
+import Logger from "js-logger";
+
+const setToLocalStorage = (key, value) => {
+  if (value !== null) {
+    localStorage.setItem(key, JSON.stringify(value));
+  } else localStorage.removeItem(key);
+};
+
+const getFromLocalStorage = key => {
+  let response = "";
+  try {
+    const value = localStorage.getItem(key);
+    response = value ? JSON.parse(value) : "";
+  } catch (error) {
+    Logger.error(error);
+    response = "";
+  }
+
+  return response;
+};
+
+const clearLocalStorageCredentials = () => {
+  setToLocalStorage("authEmail", null);
+  setToLocalStorage("authToken", null);
+};
+
+export { setToLocalStorage, getFromLocalStorage, clearLocalStorageCredentials };

--- a/app/javascript/src/utils/storage.ts
+++ b/app/javascript/src/utils/storage.ts
@@ -6,7 +6,7 @@ const setToLocalStorage = (key, value) => {
   } else localStorage.removeItem(key);
 };
 
-const getFromLocalStorage = key => {
+const getValueFromLocalStorage = key => {
   let response = "";
   try {
     const value = localStorage.getItem(key);
@@ -19,9 +19,13 @@ const getFromLocalStorage = key => {
   return response;
 };
 
-const clearLocalStorageCredentials = () => {
+const clearCredentialsFromLocalStorage = () => {
   setToLocalStorage("authEmail", null);
   setToLocalStorage("authToken", null);
 };
 
-export { setToLocalStorage, getFromLocalStorage, clearLocalStorageCredentials };
+export {
+  setToLocalStorage,
+  getValueFromLocalStorage,
+  clearCredentialsFromLocalStorage,
+};


### PR DESCRIPTION
Closes
https://www.notion.so/saeloun/Redevelop-Sign-In-page-using-React-1ccc0724feb24e7485a02bdf4c51a17a
https://www.notion.so/saeloun/Redevelop-Sign-Up-page-using-React-58ea46ef7bbd4b239b191ca1863d1063

Why
Currently, we have authentication views on rails views. We want to move our routing completely to react and use rails API to handle requests.

What
This PR is part of the feature:move-authentication to react. In this PR we created auth context and its reducer to handle the client-side routing.