### PR TITLE
Added auth email, token to request headers and updated toastr to handle error message of object type

### DIFF
--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -1,6 +1,10 @@
 import axios from "axios";
 
 import Toastr from "common/Toastr";
+import {
+  clearCredentialsFromLocalStorage,
+  getValueFromLocalStorage,
+} from "utils/storage";
 
 class ApiHandler {
   axios: any;
@@ -28,6 +32,12 @@ class ApiHandler {
         return response;
       },
       (error: any) => {
+        if (error.response?.status === 401) {
+          clearCredentialsFromLocalStorage();
+          Toastr.error(error.response?.data?.error);
+          setTimeout(() => (window.location.href = "/"), 500);
+        }
+
         Toastr.error(
           error.response?.data?.errors ||
             error.response?.data?.error ||
@@ -37,7 +47,7 @@ class ApiHandler {
             "Something went wrong!"
         );
         if (error.response?.status === 423) {
-          window.location.href = "/";
+          setTimeout(() => (window.location.href = "/"), 500);
         }
 
         return Promise.reject(error);
@@ -46,14 +56,12 @@ class ApiHandler {
 
     this.axios.interceptors.request.use(
       async (config: any) => {
-        // add token headers in below header constant.
-        // example
-        // const headers = {
-        //  "X-Auth-Email": "vipul@example.com",
-        //  "X-Auth-Token": "nyDMsho2Pr2Zgk7dXyf6XEXsf3QLAsrhTUQW1aybMxymSJVACo",
-        // };
-
-        const headers = {};
+        const token = getValueFromLocalStorage("authToken");
+        const email = getValueFromLocalStorage("authEmail");
+        const headers = {
+          "X-Auth-Email": email,
+          "X-Auth-Token": token,
+        };
 
         const newConfig = {
           ...config,

--- a/app/javascript/src/common/Toastr.tsx
+++ b/app/javascript/src/common/Toastr.tsx
@@ -24,11 +24,10 @@ const showToastr = message => {
 };
 
 const isError = e => e && e.stack && e.message;
+const isString = e => typeof e === "string" || e instanceof String;
+const isArray = e => Array.isArray(e);
 
 const showErrorToastr = error => {
-  const arrayOfErrorMsgs = Array.isArray(error);
-  const errorMessage = isError(error) ? error.message : error;
-
   const toastMsg = err =>
     toast.error(<ToastrComponent message={err} />, {
       toastId: customId,
@@ -41,11 +40,23 @@ const showErrorToastr = error => {
       hideProgressBar: true,
     });
 
-  arrayOfErrorMsgs
-    ? error.forEach(err => {
-        toastMsg(err);
-      })
-    : toastMsg(errorMessage);
+  if (isError(error)) {
+    toastMsg(error);
+  } else if (isString(error)) {
+    toastMsg(error);
+  } else if (isArray(error)) {
+    error.forEach(err => {
+      toastMsg(err);
+    });
+  } else {
+    Object.keys(error).forEach(key => {
+      isArray(error[key])
+        ? error[key].forEach(newErr => {
+            toastMsg(newErr);
+          })
+        : toastMsg(error[key]);
+    });
+  }
 };
 
 const showWarningToastr = warning => {

--- a/app/javascript/src/components/Authentication/FeaturePreviews/index.tsx
+++ b/app/javascript/src/components/Authentication/FeaturePreviews/index.tsx
@@ -25,7 +25,7 @@ const FeaturePreviews = () => (
         {carouselItems?.map((feature, i) => (
           <div key={i}>
             <img
-              className="h-300 w-480 mb-4 object-contain"
+              className="h-300 mb-4 w-480 object-contain"
               src={feature.image}
               style={{ boxShadow: "0px 0px 32px rgba(0, 0, 0, 0.1)" }}
             />

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -74,7 +74,7 @@ const SignUpForm = () => {
                 return (
                   <Form>
                     <div className="mb-3 flex justify-between">
-                      <div className="field lg:w-168 relative mr-6 w-1/2">
+                      <div className="field relative mr-6 w-1/2 lg:w-168">
                         <div className="outline relative">
                           <Field
                             autoFocus
@@ -99,7 +99,7 @@ const SignUpForm = () => {
                           )}
                         </div>
                       </div>
-                      <div className="field lg:w-168 relative w-1/2">
+                      <div className="field relative w-1/2 lg:w-168">
                         <div className="outline relative">
                           <Field
                             data-cy="sign-up-lastName"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,11 +46,14 @@ module.exports = {
       width: {
         fit: "fit-content",
         30: "7.5rem", //120px
-        128: "32rem", // 512px
         34: "8.6rem",
-        352: "22rem", //352px
-        228: "14.25rem", //228px
+        128: "32rem", // 512px
+        168: "10.5rem", // 168px
         180: "11.25rem", //180px
+        228: "14.25rem", //228px
+        300: "18.75rem", //300px
+        352: "22rem", //352px
+        480: "30rem", //480px
       },
       minWidth: {
         12: "12px",


### PR DESCRIPTION
Closes
https://www.notion.so/saeloun/Redevelop-Sign-In-page-using-React-1ccc0724feb24e7485a02bdf4c51a17a
https://www.notion.so/saeloun/Redevelop-Sign-Up-page-using-React-58ea46ef7bbd4b239b191ca1863d1063

Why
Currently, we have authentication views on rails views. We want to move our routing completely to react and use rails API to handle requests.

What
This PR is part of the feature:move-authentication to react. In this PR I did
- Updated tailwind config with custom widths
- Updated toastr component to handle error messages of object {[]} type
- Added auth email and auth token to request headers