### PR TITLE
Updated Authenticable concern to support auth email and token 

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,7 +83,7 @@ RSpec.configure do |config|
     end
   end
 
-  def headers(auth_user, options = {})
+  def auth_headers(auth_user, options = {})
     {
       "X-Auth-Token" => auth_user[:token],
       "X-Auth-Email" => auth_user[:email]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,4 +82,11 @@ RSpec.configure do |config|
       Capybara.server_port = 3000
     end
   end
+
+  def headers(auth_user, options = {})
+    {
+      "X-Auth-Token" => auth_user[:token],
+      "X-Auth-Email" => auth_user[:email]
+    }.merge(options)
+  end
 end

--- a/spec/requests/api/v1/timesheet_entries/create_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/create_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
             timesheet_entry: @timesheet_details,
             auth_token: user.token
           },
-          headers: headers(user)
+          headers: auth_headers(user)
       end
 
       it "he should be able to create timesheet entry record successfully" do
@@ -53,7 +53,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
           {
             timesheet_entry: @timesheet_details
           },
-          headers: headers(user)
+          headers: auth_headers(user)
       end
 
       it "he should be able to create timesheet entry record successfully" do
@@ -80,7 +80,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
               work_date: Time.now
             }
           },
-          headers: headers(user)
+          headers: auth_headers(user)
         expect(response).to have_http_status(:ok)
         expect(json_response["entry"]["note"]).to match("")
         expect(json_response["entry"]["bill_status"]).to match("unbilled")
@@ -95,7 +95,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
         {
           timesheet_entry: @timesheet_details
         },
-        headers: headers({ email: user.email, token: "Abc" })
+        headers: auth_headers({ email: user.email, token: "Abc" })
       expect(response).to have_http_status(:unauthorized)
       expect(json_response["error"]).to match(I18n.t("devise.failure.unauthenticated"))
     end
@@ -106,7 +106,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
         {
           timesheet_entry: @timesheet_details
         },
-        headers: headers(user)
+        headers: auth_headers(user)
       expect(response).to have_http_status(:forbidden)
       expect(json_response["notice"]).to match("User is not a project member.")
     end

--- a/spec/requests/api/v1/timesheet_entries/create_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/create_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
           {
             timesheet_entry: @timesheet_details,
             auth_token: user.token
-          }
+          },
+          headers: headers(user)
       end
 
       it "he should be able to create timesheet entry record successfully" do
@@ -52,7 +53,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
           {
             timesheet_entry: @timesheet_details
           },
-          headers: { Authorization: "Bearer " + user.token }
+          headers: headers(user)
       end
 
       it "he should be able to create timesheet entry record successfully" do
@@ -79,7 +80,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
               work_date: Time.now
             }
           },
-          headers: { Authorization: "Bearer " + user.token }
+          headers: headers(user)
         expect(response).to have_http_status(:ok)
         expect(json_response["entry"]["note"]).to match("")
         expect(json_response["entry"]["bill_status"]).to match("unbilled")
@@ -94,9 +95,9 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
         {
           timesheet_entry: @timesheet_details
         },
-        headers: { Authorization: "Bearer " + "123" }
+        headers: headers({ email: user.email, token: "Abc" })
       expect(response).to have_http_status(:unauthorized)
-      expect(json_response["notice"]).to match("Invalid Token.")
+      expect(json_response["error"]).to match(I18n.t("devise.failure.unauthenticated"))
     end
 
     it "user is not a project member for the given project id" do
@@ -105,7 +106,7 @@ RSpec.describe "Api::V1::TimesheetEntry#create", type: :request do
         {
           timesheet_entry: @timesheet_details
         },
-        headers: { Authorization: "Bearer " + user.token }
+        headers: headers(user)
       expect(response).to have_http_status(:forbidden)
       expect(json_response["notice"]).to match("User is not a project member.")
     end


### PR DESCRIPTION
Closes
https://www.notion.so/saeloun/Redevelop-Sign-In-page-using-React-1ccc0724feb24e7485a02bdf4c51a17a
https://www.notion.so/saeloun/Redevelop-Sign-Up-page-using-React-58ea46ef7bbd4b239b191ca1863d1063

Why
Currently, we have authentication views on rails views. We want to move our routing completely to react and use rails API to handle requests.

What
This PR is part of the feature:move-authentication to react. In this PR I did
- Updated Authenticable concern to support auth email and token from any client-side app like postman instead of bearer token.
- Fixed failing specs related to the removal of bearer tokens as we changed to auth token.