### PR TITLE
Add, remove auth token & email on Login and Logout respectively

### DIFF
--- a/app/javascript/src/components/App.tsx
+++ b/app/javascript/src/components/App.tsx
@@ -5,6 +5,7 @@ import { ToastContainer } from "react-toastify";
 
 import { Roles, TOASTER_DURATION, Paths } from "constants/index";
 import { miruApp } from "constants/miruApp";
+import { AuthProvider } from "context/auth";
 import UserContext from "context/UserContext";
 
 import Main from "./Main";
@@ -32,16 +33,18 @@ const App = props => {
         setSelectedTab,
       }}
     >
-      <BrowserRouter>
-        <ToastContainer autoClose={TOASTER_DURATION} />
-        <Main
-          {...props}
-          isAdminUser={isAdminUser}
-          isDesktop={isDesktop}
-          setIsDesktop={setIsDesktop}
-          user={user}
-        />
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <ToastContainer autoClose={TOASTER_DURATION} />
+          <Main
+            {...props}
+            isAdminUser={isAdminUser}
+            isDesktop={isDesktop}
+            setIsDesktop={setIsDesktop}
+            user={user}
+          />
+        </BrowserRouter>
+      </AuthProvider>
     </UserContext.Provider>
   );
 };

--- a/app/javascript/src/components/Main.tsx
+++ b/app/javascript/src/components/Main.tsx
@@ -1,10 +1,32 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { Roles } from "constants/index";
+import { useAuthDispatch } from "context/auth";
 
 import Dashboard from "./Dashboard";
 
-const Main = (props: Iprops) => <Dashboard {...props} />;
+const Main = (props: Iprops) => {
+  const authDispatch = useAuthDispatch();
+  //@ts-expect-error for authDispatch initial values
+  const { token, email } = props.user;
+
+  useEffect(() => {
+    handleAuthLogin();
+  }, [email, token]);
+
+  const handleAuthLogin = async () => {
+    //@ts-expect-error for authDispatch initial values
+    authDispatch({
+      type: "LOGIN",
+      payload: {
+        token,
+        email,
+      },
+    });
+  };
+
+  return <Dashboard {...props} />;
+};
 interface Iprops {
   user: object;
   companyRole: Roles;

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -9,6 +9,7 @@ import { Avatar, Tooltip } from "StyledComponents";
 import companiesApi from "apis/companies";
 import WorkspaceApi from "apis/workspaces";
 import { LocalStorageKeys } from "constants/index";
+import { useAuthDispatch } from "context/auth";
 
 import { activeClassName } from "./utils";
 
@@ -22,6 +23,8 @@ const UserActions = () => {
   const [showToolTip, setShowToolTip] = useState<boolean>(false);
   const wrapperRef = useRef(null);
   const toolTipRef = useRef(null);
+
+  const authDispatch = useAuthDispatch();
 
   useEffect(() => {
     fetchWorkspaces();
@@ -60,6 +63,8 @@ const UserActions = () => {
 
   const handleLogout = () => {
     window.localStorage.removeItem(LocalStorageKeys.INVOICE_FILTERS);
+    //@ts-expect-error for authDispatch object
+    authDispatch({ type: "LOGOUT" });
   };
 
   const WorkspaceList = () => (


### PR DESCRIPTION
Closes
https://www.notion.so/saeloun/Redevelop-Sign-In-page-using-React-1ccc0724feb24e7485a02bdf4c51a17a
https://www.notion.so/saeloun/Redevelop-Sign-Up-page-using-React-58ea46ef7bbd4b239b191ca1863d1063

Why
Currently, we have authentication views on rails views. We want to move our routing completely to react and use rails API to handle requests.

What
This PR is part of the feature:move-authentication to react. In this PR I did

- Added AuthProvider to `App` component
- Login the user on the frontend so that in future it will be helpful when we include `Authenticable` concern at controller level
- Remove auth token and email on logout