### PR TITLE
Add setup to run specs in parallel on local

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -222,3 +222,6 @@ gem "strong_migrations"
 # Error tracking: https://docs.sentry.io/platforms/ruby/guides/rails/
 gem "sentry-rails"
 gem "sentry-ruby"
+
+# https://github.com/grosser/parallel_tests
+gem "parallel_tests", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,8 @@ GEM
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
+    parallel_tests (4.2.0)
+      parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
@@ -594,6 +596,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.0)
   omniauth-rails_csrf_protection (~> 1.0)
   pagy (~> 5.10)
+  parallel_tests
   pg
   puma (~> 5.0)
   pundit (~> 2.2)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ add `EMAIL_DELIVERY_METHOD='letter_opener_web'` to `.env`)
 2. Run `bin/rails db:migrate RAILS_ENV=test`
 3. Run `bundle exec rspec`
 
+### Running Tests in Parallel
+
+Change `database.yml` to embed `TEST_ENV_NUMBER`
+
+```yaml
+test:
+  database: miru_web_test_<%= ENV['TEST_ENV_NUMBER'] %>
+```
+
+```ruby
+# Setup parallel specs
+bundle exec rake parallel:create
+
+# Copy Schema for new changes on branches
+bundle exec rake parallel:prepare
+
+# Run migrations if needed 
+bundle exec rake parallel:migrate
+
+# Run all specs in parallel
+RAILS_ENV=test bundle exec rake parallel:spec
+```
 #### Coverage
 
 1. Run `COVERAGE=true bundle exec rspec`


### PR DESCRIPTION
**What:** 
- Add setup to run specs in parallel on local
- Add README instructions for the same

**Why:**
- For faster feedback loop on local instead of waiting on CI

**Before:**

Example output without Parallel enabled:
```ruby
Finished in 2 minutes 53.2 seconds (files took 1.79 seconds to load)
1175 examples, 0 failures
```

**After**

Example output with Parallel enabled (M1 Macbook Pro with 10 processes):
```ruby
1175 examples, 1 failure

Took 89 seconds (1:29)
Tests Failed
```

Improvements for me = Specs take 51% time instead of before 3 minutes.


**Todo:** 
- Add instructions to run only unit or system specs
