### PR TITLE
Add  --frozen-lockfile when doing local bin/yarn

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -20,7 +20,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   puts "\n== Executing yarn =="
-  system!("bin/yarn")
+  system!("bin/yarn --frozen-lockfile ")
 
   puts "\n== Setup ENV's =="
   system! "cp .env.example .env"


### PR DESCRIPTION
What:
- Add  --frozen-lockfile when doing local bin/yarn

Why:
- So that setup always uses provided lockfile