### PR TITLE
Deliver email with AWS SES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ APP_BASE_URL="localhost:3000"
 
 # Mailer Configuration
 EMAIL_DELIVERY_METHOD='letter_opener'
-MAILER_SENDER="info@miru.so"
+DEFAULT_MAILER_SENDER="info@miru.so"
 REPLY_TO_EMAIL="no-reply@getmiru.com"
 
 # SendGrid Email Configuration

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ APP_BASE_URL="localhost:3000"
 
 # Mailer Configuration
 EMAIL_DELIVERY_METHOD='letter_opener'
-MAILER_SENDER="info@miru.saeloun.com"
+MAILER_SENDER="info@miru.so"
 REPLY_TO_EMAIL="no-reply@getmiru.com"
 
 # SendGrid Email Configuration

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,6 +2,6 @@
 
 class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join("app", "views", "mailers")
-  default from: ENV["MAILER_SENDER"]
+  default from: ENV["DEFAULT_MAILER_SENDER"]
   layout "mailer"
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,11 +8,10 @@ Rails.application.initialize!
 
 # Sendgrid config
 ActionMailer::Base.smtp_settings = {
-  user_name: ENV["SENDGRID_USERNAME"],
-  password: ENV["SENDGRID_PASSWORD"],
-  domain: ENV["SMTP_DOMAIN"],
-  address: "smtp.sendgrid.net",
-  port: ENV["SMTP_PORT"],
-  authentication: :plain,
+  address: "email-smtp.us-east-1.amazonaws.com",
+  port: 587,
+  authentication: :login,
+  user_name: ENV["SES_SMTP_USERNAME"],
+  password: ENV["SES_SMTP_PASSWORD"],
   enable_starttls_auto: true
 }

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,10 +8,10 @@ Rails.application.initialize!
 
 # Sendgrid config
 ActionMailer::Base.smtp_settings = {
-  address: "email-smtp.us-east-1.amazonaws.com",
-  port: 587,
+  address: ENV["SMPT_ADDRESS"],
+  port: ENV["SMTP_PORT"],
   authentication: :login,
-  user_name: ENV["SES_SMTP_USERNAME"],
-  password: ENV["SES_SMTP_PASSWORD"],
+  user_name: ENV["SMTP_USERNAME"],
+  password: ENV["SMTP_PASSWORD"],
   enable_starttls_auto: true
 }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV["MAILER_SENDER"]
+  config.mailer_sender = ENV["DEFAULT_MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -44,7 +44,7 @@ services:
       - WISE_ACCESS_TOKEN=access-token-12345
       - WISE_PROFILE_ID=123456
       - EMAIL_DELIVERY_METHOD=letter_opener
-      - MAILER_SENDER=info@miru.so
+      - DEFAULT_MAILER_SENDER=info@miru.so
       - REPLY_TO_EMAIL=no-reply@getmiru.com
       - STRIPE_PUBLISHABLE_KEY=stripe_publishable_key
       - STRIPE_SECRET_KEY=stripe_secret_key

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -44,7 +44,7 @@ services:
       - WISE_ACCESS_TOKEN=access-token-12345
       - WISE_PROFILE_ID=123456
       - EMAIL_DELIVERY_METHOD=letter_opener
-      - MAILER_SENDER=info@miru.saeloun.com
+      - MAILER_SENDER=info@miru.so
       - REPLY_TO_EMAIL=no-reply@getmiru.com
       - STRIPE_PUBLISHABLE_KEY=stripe_publishable_key
       - STRIPE_SECRET_KEY=stripe_secret_key


### PR DESCRIPTION
What changed:

Replaced the Sendgrid related smtp setting with AWS SES.

Our account is verified now, we can send 50,000 emails daily and 14 emails per second.

<img width="1500" alt="Screenshot 2023-02-28 at 4 06 53 PM" src="https://user-images.githubusercontent.com/52308930/221829852-3b3e80eb-0f9a-4eb4-8ce3-046884adb847.png">

Demo: https://www.loom.com/share/ba3b9e9aae104b43a69dad61b6c4d1e9