### PR TITLE
Added login, logout, signup, forgot password, resend password and resend email confirmation routes to the internal api

### DIFF
--- a/app/controllers/internal_api/v1/email_confirmations_controller.rb
+++ b/app/controllers/internal_api/v1/email_confirmations_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::EmailConfirmationsController < InternalApi::V1::ApplicationController
+  skip_before_action :authenticate_user_using_x_auth_token
+  skip_before_action :authenticate_user!
+  skip_after_action :verify_authorized
+  before_action :verify_confirmed_user
+
+  def resend
+    user.send_confirmation_instructions
+    render json: { notice: I18n.t("confirmation.send_instructions", email: user.email) },
+      status: :ok
+  end
+
+  private
+
+    def verify_confirmed_user
+      if user.confirmed?
+        redirect_to root_path
+      end
+    end
+
+    def user
+      @_user ||= User.kept.find_by_email!(params[:email])
+    end
+end

--- a/app/controllers/internal_api/v1/passwords_controller.rb
+++ b/app/controllers/internal_api/v1/passwords_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::PasswordsController < Devise::PasswordsController
+  respond_to :json
+
+  def create
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    if successfully_sent?(resource)
+      render json: { notice: "Instructions for resetting your password have been sent to your email." }, status: :ok
+    else
+      respond_with_error(resource)
+    end
+  end
+
+  def update
+    user = User.reset_password_by_token(password_params)
+    if user.errors.empty?
+      render json: { notice: "Your password has been updated." }, status: :ok
+    else
+      respond_with_error(user)
+    end
+  end
+
+  private
+
+    def password_params
+      params.require(:user).permit(:reset_password_token, :password, :password_confirmation)
+    end
+
+    def respond_with_error(resource)
+      if resource.errors.any?
+        resource.errors.full_messages.each do |message|
+          render json: { error: message }, status: :unprocessable_entity
+        end
+      end
+    end
+end

--- a/app/controllers/internal_api/v1/registrations_controller.rb
+++ b/app/controllers/internal_api/v1/registrations_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::RegistrationsController < Devise::RegistrationsController
+  respond_to :json
+
+  def respond_with(user, _opts = {})
+    if user.errors.present?
+      render json: { error: user.errors }, status: :unprocessable_entity
+    else
+      render json: { notice: "Signed up successfully" }, status: :ok
+    end
+  end
+end

--- a/app/controllers/internal_api/v1/sessions_controller.rb
+++ b/app/controllers/internal_api/v1/sessions_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class InternalApi::V1::SessionsController < InternalApi::V1::ApplicationController
+  skip_before_action :authenticate_user_using_x_auth_token
+  skip_before_action :authenticate_user!
+  skip_after_action :verify_authorized
+
+  def create
+    user = User.find_for_database_authentication(email: user_params[:email])
+    if invalid_password?(user)
+      return render json: { error: "Invalid email or password" }, status: :unprocessable_entity
+    end
+
+    sign_in(user)
+    render json: { notice: "Signed in successfully", user: }, status: :ok
+  end
+
+  def destroy
+    sign_out(@user)
+    reset_session
+    render json: { notice: "Logged out successfully" }, status: :ok
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:email, :password)
+    end
+
+    def invalid_password?(user)
+      user.blank? || !user.valid_password?(user_params[:password])
+    end
+end

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -103,6 +103,10 @@ namespace :internal_api, defaults: { format: "json" } do
       delete "/remove_avatar", to: "profile#remove_avatar"
     end
 
+    resource :email_confirmation, only: :show do
+      post :resend
+    end
+
     resources :vendors, only: [:create]
     resources :expense_categories, only: [:create]
     resources :expenses, only: [:create, :index, :show]

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -3,6 +3,8 @@
 namespace :internal_api, defaults: { format: "json" } do
   namespace :v1 do
     devise_scope :user do
+      post "login", to: "sessions#create", as: "login"
+      delete "logout", to: "sessions#destroy", as: "logout"
       post "signup", to: "registrations#create", as: "signup"
     end
 

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -2,6 +2,10 @@
 
 namespace :internal_api, defaults: { format: "json" } do
   namespace :v1 do
+    devise_scope :user do
+      post "signup", to: "registrations#create", as: "signup"
+    end
+
     resources :clients, only: [:index, :update, :destroy, :show, :create]
     resources :project, only: [:index]
     resources :timesheet_entry do

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -6,6 +6,8 @@ namespace :internal_api, defaults: { format: "json" } do
       post "login", to: "sessions#create", as: "login"
       delete "logout", to: "sessions#destroy", as: "logout"
       post "signup", to: "registrations#create", as: "signup"
+      post "forgot_password", to: "passwords#create", as: "forgot_password"
+      put "reset_password", to: "passwords#update", as: "reset_password"
     end
 
     resources :clients, only: [:index, :update, :destroy, :show, :create]

--- a/spec/requests/internal_api/v1/email_confirmations/resend_spec.rb
+++ b/spec/requests/internal_api/v1/email_confirmations/resend_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "EmailConfirmationsController", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST #resend" do
+    context "when user is not confirmed" do
+      before do
+        user.update(confirmed_at: nil)
+      end
+
+      it "sent confirmation instructions" do
+        post resend_internal_api_v1_email_confirmation_path(email: user.email)
+        expect(JSON.parse(response.body)).to include("notice" => "A confirmation email has been sent to #{user.email}.")
+      end
+    end
+
+    context "when user is already confirmed" do
+      before do
+        user.confirm
+      end
+
+      it "redirects to root_path" do
+        post resend_internal_api_v1_email_confirmation_path(email: user.email)
+
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end

--- a/spec/requests/internal_api/v1/passwords/create_spec.rb
+++ b/spec/requests/internal_api/v1/passwords/create_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Passwords#create", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST #create" do
+    context "with valid email" do
+      it "sends password reset instructions" do
+        send_request :post, internal_api_v1_forgot_password_path, params: { user: { email: user.email } }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to include(
+          "notice" => "Instructions for resetting your password have been sent to your email."
+        )
+      end
+    end
+
+    context "with invalid email" do
+      it "responds with error message" do
+        send_request :post, internal_api_v1_forgot_password_path, params: { user: { email: "invalid@example.com" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to include("error" => "Email not found")
+      end
+    end
+  end
+end

--- a/spec/requests/internal_api/v1/passwords/update_spec.rb
+++ b/spec/requests/internal_api/v1/passwords/update_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Passwords#update", type: :request do
+  let(:user) { create(:user) }
+
+  describe "PUT #update" do
+    context "with valid token and passwords" do
+      it "updates user password" do
+        user.send_reset_password_instructions
+        token = user.send(:set_reset_password_token)
+        send_request :put, internal_api_v1_reset_password_path, params: {
+          user: {
+            reset_password_token: token, password: "newpassword",
+            password_confirmation: "newpassword"
+          }
+        }
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to include("notice" => "Your password has been updated.")
+      end
+    end
+
+    context "with invalid token" do
+      it "responds with error message" do
+        send_request :put, internal_api_v1_reset_password_path, params: {
+          user: {
+            reset_password_token: "invalidtoken", password: "newpassword",
+            password_confirmation: "newpassword"
+          }
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to include("error" => "Reset password token is invalid")
+      end
+    end
+
+    context "with mismatching passwords" do
+      it "responds with error message" do
+        user.send_reset_password_instructions
+        token = user.send(:set_reset_password_token)
+        send_request :put, internal_api_v1_reset_password_path, params: {
+          user: {
+            reset_password_token: token, password: "newpassword",
+            password_confirmation: "differentpassword"
+          }
+        }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to include(
+          "error" => "Password confirmation doesn't match with new password"
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/internal_api/v1/registrations/create_spec.rb
+++ b/spec/requests/internal_api/v1/registrations/create_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Registrations#create", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id, password: "welcome") }
+
+  context "when signs up with valid info" do
+    valid_email = "miru@example.com"
+
+    valid_user_json = {
+      email: valid_email,
+      first_name: "Miru",
+      last_name: "Smith",
+      password: "welcome",
+      password_confirmation: "welcome",
+      phone_number: "1(555)555-5555"
+    }
+
+    it "creates user successfully" do
+      send_request :post, internal_api_v1_signup_path, params: {
+        user: valid_user_json
+      }
+      expect(response).to have_http_status(:ok)
+      expect(json_response["notice"]).to eq("Signed up successfully")
+    end
+  end
+
+  context "when signs up with invalid info" do
+    valid_email = "miru@example.com"
+
+    let(:valid_user_json) { {
+      email: user.email,
+      first_name: "Miru",
+      last_name: "Smith",
+      password: "welcome",
+      password_confirmation: "welcome",
+      phone_number: "1(555)555-5555"
+    }
+}
+
+    it "wont create user if email already exists" do
+      send_request :post, internal_api_v1_signup_path, params: {
+        user: valid_user_json
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response["error"]).to eq({ "email" => ["Email ID already exists"] })
+    end
+
+    it "wont create user if password is not matching" do
+      valid_user_json["email"] = valid_email
+      valid_user_json["password_confirmation"] = "welcome123"
+      send_request :post, internal_api_v1_signup_path, params: {
+        user: valid_user_json
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response["error"]).to eq({ "password_confirmation" => ["doesn't match with new password"] })
+    end
+  end
+end

--- a/spec/requests/internal_api/v1/sessions/create_spec.rb
+++ b/spec/requests/internal_api/v1/sessions/create_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Sessions#create", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id, password: "welcome") }
+
+  context "when logged in with valid email and password" do
+    it "logs the user successfully" do
+      send_request :post, internal_api_v1_login_path, params: {
+        user: {
+          email: user.email,
+          password: user.password
+        }
+      }
+      expect(response).to have_http_status(:ok)
+      expect(json_response["notice"]).to eq("Signed in successfully")
+    end
+  end
+
+  context "when logged in with wrong combination of email and password" do
+    it "not able to log in" do
+      send_request :post, internal_api_v1_login_path, params: {
+        user: {
+          email: user.email,
+          password: user.password + "abc"
+        }
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response["error"]).to eq("Invalid email or password")
+    end
+  end
+end


### PR DESCRIPTION
Closes
https://www.notion.so/saeloun/Redevelop-Sign-In-page-using-React-1ccc0724feb24e7485a02bdf4c51a17a
https://www.notion.so/saeloun/Redevelop-Sign-Up-page-using-React-58ea46ef7bbd4b239b191ca1863d1063

Why
Currently, we have authentication views on rails views. We want to move our routing completely to react and use rails API to handle requests.

What
This PR is part of the feature:move-authentication to react. In this PR I did
- Added custom `InternalApi::V1::RegistrationsController` to handle signup on internal API along with specs
- Added custom `InternalApi::V1::SessionsController` to handle login and logout on internal API along with specs
- Added custom `InternalApi::V1::PasswordsController` to handle forgot and reset passwords on internal API and specs.
- Added custom `InternalApi::V1::EmailConfirmationsController` to handle user confirmations on internal API and specs.