### PR TITLE
Add Index prefix to ES to avoid name collisions in Index

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -2,3 +2,4 @@
 
 Searchkick.client = Elasticsearch::Client.new(url: ENV["ELASTICSEARCH_URL"])
 Searchkick.search_timeout = 300
+Searchkick.index_prefix = "Miru"

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -2,4 +2,4 @@
 
 Searchkick.client = Elasticsearch::Client.new(url: ENV["ELASTICSEARCH_URL"])
 Searchkick.search_timeout = 300
-Searchkick.index_prefix = "Miru_#{Rails.env}_"
+Searchkick.index_prefix = "miru_#{Rails.env}_"

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -2,4 +2,4 @@
 
 Searchkick.client = Elasticsearch::Client.new(url: ENV["ELASTICSEARCH_URL"])
 Searchkick.search_timeout = 300
-Searchkick.index_prefix = "Miru"
+Searchkick.index_prefix = "Miru_#{Rails.env}_"


### PR DESCRIPTION
Fixes #1095 

What:
- Add Index prefix to ES to avoid name collisions in Index
- Add ENV as prefix 

Why:
- To avoid name collisions when sharing same ES