### PR TITLE
Bugfix - Invoice filter issue and send Invoice issue

### DIFF
--- a/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
+++ b/app/javascript/src/components/Invoices/List/FilterSideBar/index.tsx
@@ -249,11 +249,11 @@ const FilterSideBar = ({
 
   return (
     <SidePanel
-      WrapperClassname="z-50 justify-content-between"
+      WrapperClassname="z-50 justify-between"
       setFilterVisibilty={setIsFilterVisible}
     >
       <div>
-        <SidePanel.Header className="mb-2 flex items-center justify-between bg-miru-han-purple-1000 px-5 py-5 text-white lg:bg-white lg:font-bold lg:text-miru-dark-purple-1000">
+        <SidePanel.Header className="mb-2 flex h-12 items-center justify-between bg-miru-han-purple-1000 px-2 text-white lg:h-auto lg:bg-white lg:px-5 lg:py-5 lg:font-bold lg:text-miru-dark-purple-1000">
           {isDesktop ? (
             <h4 className="flex items-center text-base">
               <FilterIcon className="mr-2.5" size={16} /> <span>Filters</span>
@@ -270,7 +270,7 @@ const FilterSideBar = ({
             />
           </Button>
         </SidePanel.Header>
-        <SidePanel.Body className="sidebar__filters max-h-80v min-h-80v overflow-y-auto">
+        <SidePanel.Body className="sidebar__filters max-h-70v min-h-70v overflow-y-auto lg:max-h-80v lg:min-h-80v">
           <ul>
             <li className="relative cursor-pointer border-b border-miru-gray-200 pb-5 pt-6 text-miru-dark-purple-1000 hover:text-miru-han-purple-1000">
               <div
@@ -484,7 +484,7 @@ const FilterSideBar = ({
           </ul>
         </SidePanel.Body>
       </div>
-      <SidePanel.Footer className="sidebar__footer h-auto justify-around px-2">
+      <SidePanel.Footer className="sidebar__footer h-auto justify-around px-2 pt-1">
         <Button
           className="mr-2 flex items-center justify-between px-10 py-2.5 text-base font-bold leading-5"
           style="secondary"

--- a/app/javascript/src/components/Invoices/List/MoreOptions.tsx
+++ b/app/javascript/src/components/Invoices/List/MoreOptions.tsx
@@ -155,7 +155,10 @@ const MoreOptions = ({
         <li>
           <button
             className="flex cursor-pointer items-center py-2 text-miru-han-purple-1000"
-            onClick={() => setIsSending(!isSending)}
+            onClick={() => {
+              setIsSending(!isSending);
+              setShowMoreOptions(false);
+            }}
           >
             <PaperPlaneTiltIcon className="mr-4" size={16} /> Send Invoice
           </button>


### PR DESCRIPTION
What- 
-  Added fix for non-responsive filter pane.
- Added fix for the menu options not closing after clicking on send invoice.

Why-
- Invoice filter panel was not responsive to mobile devices.
- Menu options on Invoice filter were popping over the send invoice form.

Notion-
https://www.notion.so/saeloun/The-send-invoice-modal-is-hidden-behind-the-more-menu-option-on-invoice-list-page-7f49e79a0d884ee98a9195b06b39c383?pvs=4

Screenshots-
The issue-
![Screenshot_20230307-125632](https://user-images.githubusercontent.com/104751221/223499399-4be2cdb4-87c5-4a23-aeeb-ff4a18ff749e.jpg)

The resolution-
![WhatsApp Image 2023-03-07 at 10 42 00 PM](https://user-images.githubusercontent.com/104751221/223499024-e576e208-6062-4515-9687-fd0f23374775.jpeg)

![WhatsApp Image 2023-03-07 at 10 51 38 PM](https://user-images.githubusercontent.com/104751221/223500005-d3fea219-d118-4bff-91dd-865bdfb6a67d.jpeg)
