### PR TITLE
Using addresses association to store company address.

### DIFF
--- a/app/controllers/internal_api/v1/companies_controller.rb
+++ b/app/controllers/internal_api/v1/companies_controller.rb
@@ -5,13 +5,16 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
 
   def index
     authorize current_company
-    render :index, locals: { current_company:, client_list: current_company.client_list }, status: :ok
+    render :index, locals: {
+      current_company:, client_list: current_company.client_list, address: current_company.current_address
+    }, status: :ok
   end
 
   def create
     authorize Company
-    if CreateCompanyService.new(current_user, params: company_params).process
-      render json: { notice: I18n.t("companies.create.success") }
+    company = CreateCompanyService.new(current_user, params: company_params).process
+    if company
+      render json: { notice: I18n.t("companies.create.success"), company: }
     end
   end
 
@@ -27,7 +30,8 @@ class InternalApi::V1::CompaniesController < InternalApi::V1::ApplicationControl
     def company_params
       params.require(:company).permit(
         :name, :address, :business_phone, :country, :timezone, :base_currency,
-        :standard_price, :fiscal_year_end, :date_format, :logo
+        :standard_price, :fiscal_year_end, :date_format, :logo,
+        addresses_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin]
       )
     end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -32,4 +32,8 @@ class Address < ApplicationRecord
   # Validations
   validates :address_type, :address_line_1, :state, :city, :country, :pin, presence: true
   validates :address_type, uniqueness: { scope: [ :addressable_id, :addressable_type ] }
+
+  def formatted_address
+    [address_line_1, address_line_2, city, state, pin, country].reject(&:blank?).join(", ")
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -3,7 +3,7 @@
 # Table name: companies
 #
 #  id              :bigint           not null, primary key
-#  address         :text             not null
+#  address         :text
 #  base_currency   :string           default("USD"), not null
 #  business_phone  :string
 #  country         :string           not null
@@ -39,6 +39,8 @@ class Company < ApplicationRecord
   has_many :expense_categories, dependent: :destroy
   has_many :vendors, dependent: :destroy
   resourcify
+
+  accepts_nested_attributes_for :addresses, reject_if: :address_attributes_blank?, allow_destroy: true
 
   # Validations
   validates :name, :business_phone, :standard_price, :country, :base_currency, presence: true
@@ -79,5 +81,17 @@ class Company < ApplicationRecord
 
   def all_expense_categories
     ExpenseCategory.default_categories.order(:created_at) + expense_categories.order(:created_at)
+  end
+
+  def address_attributes_blank?(attributes)
+    attributes.except("id, address_line_2").values.all?(&:blank?)
+  end
+
+  def current_address
+    addresses.first
+  end
+
+  def formatted_address
+    current_address.formatted_address
   end
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -36,8 +36,8 @@ class CompanyPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:name, :address, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end,
-     :date_format, :logo]
+    [:name, :business_phone, :country, :timezone, :base_currency, :standard_price, :fiscal_year_end, :logo,
+     :date_format, addresses_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin]]
   end
 
   def purge_logo?

--- a/app/services/create_company_service.rb
+++ b/app/services/create_company_service.rb
@@ -13,6 +13,7 @@ class CreateCompanyService
   def process
     company.save!
     add_current_user_to_company
+    company
   end
 
   private

--- a/app/views/internal_api/v1/companies/index.json.jbuilder
+++ b/app/views/internal_api/v1/companies/index.json.jbuilder
@@ -5,7 +5,6 @@ json.company_details do
   json.logo current_company.logo.attached? ? polymorphic_url(current_company.logo) : ""
   json.name current_company.name
   json.business_phone current_company.business_phone
-  json.address current_company.address
   json.country current_company.country
   json.currency current_company.base_currency
   json.standard_price current_company.standard_price
@@ -13,6 +12,9 @@ json.company_details do
   json.timezone current_company.timezone
   json.date_format current_company.date_format
   json.logo_url
+  json.address do
+    json.partial! "internal_api/v1/partial/address", locals: { address: }
+  end
 end
 json.issue_date Date.current
 json.due_date Date.current + 30

--- a/app/views/internal_api/v1/partial/_address.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_address.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.address_line_1 address.address_line_1
+json.address_line_2 address.address_line_2
+json.city address.city
+json.state address.state
+json.country address.country
+json.pin address.pin

--- a/app/views/internal_api/v1/partial/_company.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_company.json.jbuilder
@@ -4,7 +4,7 @@ json.id company.id
 json.logo company.logo.attached? ? polymorphic_url(company.logo) : ""
 json.name company.name
 json.phone_number company.business_phone
-json.address company.address
+json.address company.current_address
 json.country company.country
 json.currency company.base_currency
 json.date_format company.date_format

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -24,7 +24,7 @@ html {
       </div>
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
-      <p><%=invoice.company.address%></p>
+      <p><%=invoice.company.formatted_address%></p>
       <p><%=invoice.company.country%></p>
     </div>
   </div>

--- a/db/migrate/20230309061016_change_company_address_to_null.rb
+++ b/db/migrate/20230309061016_change_company_address_to_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeCompanyAddressToNull < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :companies, :address, true
+  end
+end

--- a/db/migrate/20230309061149_copy_company_address_to_address_model.rb
+++ b/db/migrate/20230309061149_copy_company_address_to_address_model.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CopyCompanyAddressToAddressModel < ActiveRecord::Migration[7.0]
+  def change
+    Company.find_each do |company|
+      puts " * * * * * * * * * Company* * * * * * * * Id: #{company.id}, Name: #{company.name}"
+      address_record = company.current_address
+      unless address_record.present?
+        old_address = company.address || ""
+        address = company.addresses.build(address_line_1: old_address, city: "", state: "", country: "", pin: "")
+        address.save!(validate: false)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_122149) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_061149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_122149) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
-    t.text "address", null: false
+    t.text "address"
     t.string "business_phone"
     t.string "base_currency", default: "USD", null: false
     t.decimal "standard_price", default: "0.0", null: false

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       timezone { "Asia/Kolkata" }
     end
 
+    factory :company_with_address do
+      addresses { [ create(:address, :with_company) ] }
+    end
+
     trait :with_logo do
       after :build do |company|
         file_name = "test-image.png"

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe InvoiceMailer, type: :mailer do
   describe "invoice" do
-    let(:company) { create :company, :with_logo }
+    let(:company) { create :company_with_address, :with_logo }
     let(:client) { create :client, company: }
-    let(:invoice) { create :invoice, client: }
+    let(:invoice) { create :invoice, client:, company: }
     let(:recipients) { [invoice.client.email, "miru@example.com"] }
     let(:subject) { "Invoice (#{invoice.invoice_number}) due on #{invoice.due_date}" }
     let(:mail) { InvoiceMailer.with(invoice:, subject:, recipients:).invoice }

--- a/spec/requests/companies/create_spec.rb
+++ b/spec/requests/companies/create_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe "Companies#create", type: :request do
   let(:company) { create(:company) }
   let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:address) {
+                  {
+                    address_line_1: "Saeloun Inc", address_line_2: "475 Clermont Ave",
+                    state: "NY", city: "Brooklyn", country: "US", pin: "12238"
+                  }
+                }
 
   context "when user is an admin" do
     before do
@@ -19,20 +25,30 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              addresses_attributes: [address]
             }
           }, headers: auth_headers(user))
       end
 
       it "creates a new company" do
+        company = Company.last
+        company_address = company.addresses.last
         change(Company, :count).by(1)
+        expect(company.name).to eq("Test Company")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.date_format).to eq("DD/MM/YYYY")
+        expect(company_address.address_line_1).to eq("Saeloun Inc")
+        expect(company_address.city).to eq("Brooklyn")
+        expect(company_address.country).to eq("US")
+        expect(company_address.pin).to eq("12238")
       end
 
       it "sets the current_workspace_id to current_user" do
@@ -86,20 +102,29 @@ RSpec.describe "Companies#create", type: :request do
           :post, company_path, params: {
             company: {
               name: "Test Company",
-              address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              addresses_attributes: [attributes_for(:address)]
             }
           }, headers: auth_headers(user))
       end
 
       it "will be created" do
+        company = Company.last
         change(Company, :count).by(1)
+        change(Address, :count).by(1)
+        expect(company.name).to eq("Test Company")
+        expect(company.business_phone).to eq("Test phone")
+        expect(company.base_currency).to eq("Rs")
+        expect(company.timezone).to eq("IN")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.date_format).to eq("DD/MM/YYYY")
       end
 
       it "sets the current_workspace_id to current_user" do
@@ -124,20 +149,27 @@ RSpec.describe "Companies#create", type: :request do
             :post, company_path, params: {
               company: {
                 name: "Test Company",
-                address: "test address",
                 business_phone: "Test phone",
                 country: "India",
                 timezone: "IN",
                 base_currency: "Rs",
                 standard_price: "1000",
                 fiscal_year_end: "April",
-                date_format: "DD/MM/YYYY"
+                date_format: "DD/MM/YYYY",
+                addresses_attributes: [attributes_for(:address)]
               }
             }, headers: auth_headers(user))
         end
 
         it "will be created" do
+          company = Company.last
           change(Company, :count).by(1)
+          expect(company.name).to eq("Test Company")
+          expect(company.business_phone).to eq("Test phone")
+          expect(company.timezone).to eq("IN")
+          expect(company.standard_price).to eq(1000)
+          expect(company.fiscal_year_end).to eq("April")
+          expect(company.date_format).to eq("DD/MM/YYYY")
         end
 
         it "sets the current_workspace_id to current_user" do
@@ -185,14 +217,14 @@ RSpec.describe "Companies#create", type: :request do
         :post, company_path, params: {
           company: {
             name: "Test Company",
-            address: "test address",
             business_phone: "Test phone",
             country: "India",
             timezone: "IN",
             base_currency: "Rs",
             standard_price: "1000",
             fiscal_year_end: "April",
-            date_format: "DD/MM/YYYY"
+            date_format: "DD/MM/YYYY",
+            addresses_attributes: [attributes_for(:address)]
           }
         })
       expect(response).to redirect_to(user_session_path)

--- a/spec/requests/companies/update_spec.rb
+++ b/spec/requests/companies/update_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Companies#create", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company_with_address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is an admin" do
@@ -19,16 +19,20 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
-              business_phone: "1234556"
+              business_phone: "1234556",
+              addresses_attributes: [{
+                id: company.addresses.last.id,
+                address_line_1: "updated address"
+              }]
             }
           })
       end
 
       it "updates the company" do
         company.reload
+        address = company.current_address
         expect(company.name).to eq("Updated Company")
-        expect(company.address).to eq("updated address")
+        expect(address.address_line_1).to eq("updated address")
       end
 
       it "redirects to root_path" do
@@ -42,7 +46,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "",
-              address: "",
               business_phone: ""
             }
           })
@@ -67,7 +70,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
               business_phone: "1234556"
             }
           })
@@ -88,7 +90,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "",
-              address: "",
               business_phone: ""
             }
           })
@@ -117,7 +118,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "Updated Company",
-              address: "updated address",
               business_phone: "1234556"
             }
           })
@@ -138,7 +138,6 @@ RSpec.describe "Companies#create", type: :request do
           :put, company_path, params: {
             company: {
               name: "",
-              address: "",
               business_phone: ""
             }
           })
@@ -160,7 +159,6 @@ RSpec.describe "Companies#create", type: :request do
         :put, company_path, params: {
           company: {
             name: "Updated Company",
-            address: "updated address",
             business_phone: "1234556"
           }
         })

--- a/spec/requests/internal_api/v1/companies/create_spec.rb
+++ b/spec/requests/internal_api/v1/companies/create_spec.rb
@@ -15,16 +15,35 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
         send_request :post, internal_api_v1_companies_path, params: {
           company: {
             name: "zero labs llc",
-            address: "remote",
             business_phone: "+01 123123",
             country: "india",
             timezone: "+5:30 Chennai",
             base_currency: "INR",
             standard_price: 1000,
             fiscal_year_end: "Jan-Dec",
-            date_format: "DD-MM-YYYY"
+            date_format: "DD-MM-YYYY",
+            addresses_attributes: [{
+              address_line_1: "Somewhere on Earth",
+              city: "Brooklyn",
+              state: "NY",
+              country: "US",
+              pin: "12238"
+            }]
           }
         }, headers: auth_headers(user)
+      end
+
+      it "creates a new compamy & address" do
+        company = Company.last
+        change(Company, :count).by(1)
+        change(Address, :count).by(1)
+        expect(company.name).to eq("zero labs llc")
+        expect(company.business_phone).to eq("+01 123123")
+        expect(company.timezone).to eq("+5:30 Chennai")
+        expect(company.base_currency).to eq("INR")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("Jan-Dec")
+        expect(company.date_format).to eq("DD-MM-YYYY")
       end
 
       it "response should be successful" do
@@ -70,14 +89,20 @@ RSpec.describe "InternalApi::V1::Companies::create", type: :request do
           send_request :post, internal_api_v1_companies_path, params: {
             company: {
               name: "zero labs llc",
-              address: "remote",
               business_phone: "+01 123123",
               country: "india",
               timezone: "+5:30 Chennai",
               base_currency: "INR",
               standard_price: 1000,
               fiscal_year_end: "Jan-Dec",
-              date_format: "DD-MM-YYYY"
+              date_format: "DD-MM-YYYY",
+              addresses_attributes: [{
+                address_line_1: "Somewhere on Earth",
+                city: "Brooklyn",
+                state: "NY",
+                country: "US",
+                pin: "12238"
+              }]
             }
           }, headers: auth_headers(user)
         end

--- a/spec/requests/internal_api/v1/companies/index_spec.rb
+++ b/spec/requests/internal_api/v1/companies/index_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Companies::index", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, addresses_attributes: [attributes_for(:address)]) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   before do
@@ -19,11 +19,21 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
 
     it "response should be successful" do
       expect(response).to be_successful
+      puts " - - -- - -#{json_response.inspect}"
+      expect(
+        json_response["company_details"]["address"]["address_line_1"]
+      ).to eq(company.addresses.first.address_line_1)
     end
 
     it "returns success json response" do
+      address = company.current_address
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]).to eq(company.address)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(address.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_2"]).to eq(address.address_line_2)
+      expect(json_response["company_details"]["address"]["city"]).to eq(address.city)
+      expect(json_response["company_details"]["address"]["state"]).to eq(address.state)
+      expect(json_response["company_details"]["address"]["country"]).to eq(address.country)
+      expect(json_response["company_details"]["address"]["pin"]).to eq(address.pin)
     end
   end
 
@@ -39,25 +49,37 @@ RSpec.describe "InternalApi::V1::Companies::index", type: :request do
     end
 
     it "returns success json response" do
+      address = company.current_address
       expect(json_response["company_details"]["name"]).to eq(company.name)
-      expect(json_response["company_details"]["address"]).to eq(company.address)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(address.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_2"]).to eq(address.address_line_2)
+      expect(json_response["company_details"]["address"]["city"]).to eq(address.city)
+      expect(json_response["company_details"]["address"]["state"]).to eq(address.state)
+      expect(json_response["company_details"]["address"]["country"]).to eq(address.country)
+      expect(json_response["company_details"]["address"]["pin"]).to eq(address.pin)
     end
   end
 
   context "when user is a book keeper" do
-   before do
-     user.add_role :book_keeper, company
-     sign_in user
-     send_request :get, internal_api_v1_companies_path, headers: auth_headers(user)
-   end
+    before do
+      user.add_role :book_keeper, company
+      sign_in user
+      send_request :get, internal_api_v1_companies_path, headers: auth_headers(user)
+    end
 
-   it "response should be successful" do
-     expect(response).to have_http_status(:ok)
-   end
+    it "response should be successful" do
+      expect(response).to have_http_status(:ok)
+    end
 
-   it "returns success json response" do
-     expect(json_response["company_details"]["name"]).to eq(company.name)
-     expect(json_response["company_details"]["address"]).to eq(company.address)
-   end
- end
+    it "returns success json response" do
+      address = company.current_address
+      expect(json_response["company_details"]["name"]).to eq(company.name)
+      expect(json_response["company_details"]["address"]["address_line_1"]).to eq(address.address_line_1)
+      expect(json_response["company_details"]["address"]["address_line_2"]).to eq(address.address_line_2)
+      expect(json_response["company_details"]["address"]["city"]).to eq(address.city)
+      expect(json_response["company_details"]["address"]["state"]).to eq(address.state)
+      expect(json_response["company_details"]["address"]["country"]).to eq(address.country)
+      expect(json_response["company_details"]["address"]["pin"]).to eq(address.pin)
+    end
+  end
 end

--- a/spec/requests/internal_api/v1/companies/update_spec.rb
+++ b/spec/requests/internal_api/v1/companies/update_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Companies::update", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company_with_address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is an admin" do
@@ -19,14 +19,17 @@ RSpec.describe "InternalApi::V1::Companies::update", type: :request do
           :put, "#{internal_api_v1_companies_path}/#{company[:id]}", params: {
             company: {
               name: "Test Company",
-              address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              addresses_attributes: [{
+                id: company.current_address.id,
+                address_line_1: "updated address"
+              }]
             }
           }, headers: auth_headers(user))
       end
@@ -37,6 +40,18 @@ RSpec.describe "InternalApi::V1::Companies::update", type: :request do
 
       it "returns success json response" do
         expect(json_response["notice"]).to eq(I18n.t("companies.update.success"))
+      end
+
+      it "updates the company" do
+        company.reload
+        company.current_address.reload
+        expect(company.name).to eq("Test Company")
+        expect(company.business_phone).to eq("Test phone")
+        expect(company.standard_price).to eq(1000)
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.fiscal_year_end).to eq("April")
+        expect(company.base_currency).to eq("Rs")
+        expect(company.current_address.address_line_1).to eq("updated address")
       end
     end
 
@@ -63,6 +78,30 @@ RSpec.describe "InternalApi::V1::Companies::update", type: :request do
         change(Company, :count).by(0)
       end
     end
+
+    context "when address is invalid" do
+      before do
+        send_request(
+          :put, "#{internal_api_v1_companies_path}/#{company[:id]}", params: {
+            company: {
+              business_phone: "12345677",
+              timezone: "IN",
+              base_currency: "Rs",
+              standard_price: "1000",
+              fiscal_year_end: "April",
+              date_format: "",
+              addresses_attributes: [{
+                id: company.current_address.id,
+                address_line_1: ""
+              }]
+            }
+          }, headers: auth_headers(user))
+      end
+
+      it "will fail" do
+        expect(json_response["errors"]).to eq("Addresses address line 1 can't be blank")
+      end
+    end
   end
 
   context "when user is a book keeper" do
@@ -78,14 +117,17 @@ RSpec.describe "InternalApi::V1::Companies::update", type: :request do
           :put, "#{internal_api_v1_companies_path}/#{company[:id]}", params: {
             company: {
               name: "Test Company",
-              address: "test address",
               business_phone: "Test phone",
               country: "India",
               timezone: "IN",
               base_currency: "Rs",
               standard_price: "1000",
               fiscal_year_end: "April",
-              date_format: "DD/MM/YYYY"
+              date_format: "DD/MM/YYYY",
+              addresses_attributes: [{
+                id: company.current_address.id,
+                address_line_2: "updated address"
+              }]
             }
           }, headers: auth_headers(user))
       end

--- a/spec/requests/internal_api/v1/invoices/download_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/download_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Invoices#download", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company_with_address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let!(:client) { create(:client, company:) }
   let!(:invoice) { create(:invoice, client:, company:, status: "sent") }

--- a/spec/services/bulk_invoice_download_service_spec.rb
+++ b/spec/services/bulk_invoice_download_service_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 require "zip"
 
 RSpec.describe BulkInvoiceDownloadService do
-  let(:company) { create(:company) }
+  let(:company) { create(:company_with_address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let!(:client) { create(:client, company:, name: "bob") }
-  let!(:invoice1) { create(:invoice, client:) }
-  let!(:invoice2) { create(:invoice, client:) }
-  let(:invoice3) { create(:invoice, client:) }
+  let!(:invoice1) { create(:invoice, client:, company:) }
+  let!(:invoice2) { create(:invoice, client:, company:) }
+  let(:invoice3) { create(:invoice, client:, company:) }
 
   describe "#process" do
     before do

--- a/spec/system/clients/create_spec.rb
+++ b/spec/system/clients/create_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Create client", type: :system do
-  let(:company) { create(:company) }
+  let(:company) { create(:company_with_address) }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   context "when user is admin" do


### PR DESCRIPTION
Notion:

https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=5578743881b44e108a04efb88153c00e&pm=s

Description:

After developing the updated designs of the organization settings page, backend changes are required for address fields on the organization settings page. 

- The address field is a text field that needs to be updated to different fields for Address line 1, Address line 2, Country, State, City & Zipcode. 

- We used Address association to save the company's address.
- Added a migration that will copy address field data to the Address model.
- Updated create company API.

API Endpoint:
 
 http://localhost:3000/internal_api/v1/companies 

Input Params:
`
{
    "company": {
        "name": "Saeloun",
        "business_phone": "+918390108472",
        "country": "US",
        "base_currency": "USD",
        "standard_price": "200.00",
        "fiscal_year_end": "Dec",
        "date_format": "MM-DD-YYYY",
        "timezone": "(GMT-05:00) Eastern Time (US & Canada)",
        "addresses_attributes":[ {
            "address_line_1": "Saeloun Inc",
            "address_line_2": "475 Clermont Ave",
            "state": "NY",
            "city": "Brooklyn",
            "country": "US",
            "pin": "12238"
        }]
    }
}
`