### PR TITLE
Duplicate timesheet entry

### DIFF
--- a/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
@@ -90,23 +90,25 @@ const TableRow = ({
           wrapperClassName="h-8 w-8 m-auto rounded-3xl p-2 hover:bg-miru-gray-1000"
         />
       </td>
-      <Tooltip content={name} show={showToolTip}>
-        <td className="flex w-40 cursor-pointer items-center py-5 pr-2 text-left font-medium tracking-normal sm:w-80 md:w-96 lg:w-full">
-          <Avatar url={logo} />
-          <div
-            className="ml-2 overflow-hidden truncate whitespace-nowrap lg:ml-4"
-            ref={toolTipRef}
-            onMouseEnter={handleTooltip}
-          >
-            <span className="text-sm font-semibold capitalize leading-4 text-miru-dark-purple-1000 lg:text-base lg:leading-5">
-              {name}
-            </span>
-            <h3 className="text-xs font-medium leading-4 text-miru-dark-purple-400 lg:text-sm lg:leading-5">
-              {invoiceNumber}
-            </h3>
+      <td>
+        <Tooltip content={name} show={showToolTip}>
+          <div className="flex w-40 cursor-pointer items-center py-5 pr-2 text-left font-medium tracking-normal sm:w-80 md:w-96 lg:w-full">
+            <Avatar url={logo} />
+            <div
+              className="ml-2 overflow-hidden truncate whitespace-nowrap lg:ml-4"
+              ref={toolTipRef}
+              onMouseEnter={handleTooltip}
+            >
+              <span className="text-sm font-semibold capitalize leading-4 text-miru-dark-purple-1000 lg:text-base lg:leading-5">
+                {name}
+              </span>
+              <h3 className="text-xs font-medium leading-4 text-miru-dark-purple-400 lg:text-sm lg:leading-5">
+                {invoiceNumber}
+              </h3>
+            </div>
           </div>
-        </td>
-      </Tooltip>
+        </Tooltip>
+      </td>
       {isDesktop && (
         <td className="w-1/4 whitespace-nowrap px-4 py-5 font-medium tracking-normal lg:px-6">
           <h1 className="text-xs font-normal text-miru-dark-purple-1000 lg:text-base lg:font-semibold">

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 import { minToHHMM } from "helpers";
-import { DeleteIcon, EditIcon } from "miruIcons";
+import { DeleteIcon, EditIcon, CopyIcon } from "miruIcons";
 import { Badge } from "StyledComponents";
 
 import { useUserContext } from "context/UserContext";
@@ -20,6 +20,7 @@ interface props {
   bill_status: string;
   currentUserRole: string;
   setNewEntryView: any;
+  handleDuplicate: any;
 }
 
 const canEditTimeEntry = (billStatus, role) =>
@@ -49,6 +50,18 @@ const showDeleteAction = (billStatus, role, id, handleDeleteEntry) => {
   return <div className="mr-10 h-4 w-4" />;
 };
 
+const showDuplicateAction = (billStatus, role, id, handleDuplicate) => {
+  if (canEditTimeEntry(billStatus, role)) {
+    return (
+      <button className="icon-hover " onClick={() => handleDuplicate(id)}>
+        <CopyIcon className="text-miru-han-purple-1000" size={20} />
+      </button>
+    );
+  }
+
+  return <div className="mr-10 h-4 w-4" />;
+};
+
 const EntryCard: React.FC<props> = ({
   id,
   client,
@@ -60,6 +73,7 @@ const EntryCard: React.FC<props> = ({
   bill_status,
   currentUserRole,
   setNewEntryView,
+  handleDuplicate,
 }) => {
   const { isDesktop } = useUserContext();
 
@@ -141,6 +155,12 @@ const EntryCard: React.FC<props> = ({
           <p className="mx-auto text-4xl">{minToHHMM(duration)}</p>
         </div>
         <div className="flex w-5/12 items-center justify-evenly">
+          {showDuplicateAction(
+            bill_status,
+            currentUserRole,
+            id,
+            handleDuplicate
+          )}
           {showUpdateAction(bill_status, currentUserRole, id, setEditEntryId)}
           {showDeleteAction(
             bill_status,

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -65,7 +65,6 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     value: `${e["id"]}`,
     label: `${e["first_name"]} ${e["last_name"]}`,
   }));
-  //setEmployees(employeeOptions);
 
   useEffect(() => {
     sendGAPageView();
@@ -216,6 +215,28 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     const res = await timesheetEntryApi.destroy(id);
     if (!(res.status === 200)) return;
     await handleFilterEntry(selectedFullDate, id);
+  };
+
+  const handleDuplicate = async id => {
+    if (!id) return;
+    const entry = entryList[selectedFullDate].find(entry => entry.id === id);
+    const data = {
+      work_date: entry.work_date,
+      duration: entry.duration,
+      note: entry.note,
+      bill_status: entry.bill_status,
+    };
+
+    const res = await timesheetEntryApi.create(
+      {
+        project_id: entry.project_id,
+        timesheet_entry: data,
+      },
+      selectedEmployeeId
+    );
+    if (res.status === 200) {
+      await fetchEntries(selectedFullDate, selectedFullDate);
+    }
   };
 
   const calculateTotalHours = () => {
@@ -527,6 +548,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
               <EntryCard
                 currentUserRole={entryList["currentUserRole"]}
                 handleDeleteEntry={handleDeleteEntry}
+                handleDuplicate={handleDuplicate}
                 key={weekCounter}
                 setEditEntryId={setEditEntryId}
                 setNewEntryView={setNewEntryView}

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -224,7 +224,8 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
       work_date: entry.work_date,
       duration: entry.duration,
       note: entry.note,
-      bill_status: entry.bill_status,
+      bill_status:
+        entry.bill_status == "billed" ? "unbilled" : entry.bill_status,
     };
 
     const res = await timesheetEntryApi.create(


### PR DESCRIPTION
### **Notion:**
https://www.notion.so/saeloun/fix-these-browser-warnings-with-any-up-coming-PR-4fdb2e95791d4f4093395f21bee217a9?pvs=4

https://www.notion.so/saeloun/User-should-be-able-to-duplicate-a-time-entry-278811bdbffe4428a3e8e08301fdc421?pvs=4

### **What :**
- Duplicate timesheet entry functionality.
- Console warnings fixed for invoice list page. 

### **Why :**
- User can duplicate an existing entry.
 
### **Preview :**
https://www.loom.com/share/065fea311e514a9b8be2e38cea3b7904

To-do's (Testing):
- Checked if the console warning is not appearing again and if the existing hover functionality is not affected.
- Checked if data is getting duplicated as it is except for the status "billed".
- Checked if the user copies a billed entry then after a new copy is created the status is non-billed. 

