### PR TITLE
Fix the date time format 

### DIFF
--- a/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from "react";
 
-import dayjs from "dayjs";
 import { currencyFormat, useDebounce } from "helpers";
 import { DotsThreeVerticalIcon } from "miruIcons";
 import { useNavigate } from "react-router-dom";
@@ -42,7 +41,7 @@ const TableRow = ({
     status,
   } = invoice;
 
-  const { baseCurrency, dateFormat } = company;
+  const { baseCurrency } = company;
   const { name, logo } = client;
 
   const handleCheckboxChange = () => {
@@ -64,8 +63,6 @@ const TableRow = ({
       setShowToolTip(false);
     }
   };
-
-  const formattedDate = date => dayjs(date).format(dateFormat);
 
   return (
     <tr
@@ -112,10 +109,10 @@ const TableRow = ({
       {isDesktop && (
         <td className="w-1/4 whitespace-nowrap px-4 py-5 font-medium tracking-normal lg:px-6">
           <h1 className="text-xs font-normal text-miru-dark-purple-1000 lg:text-base lg:font-semibold">
-            {formattedDate(issueDate)}
+            {issueDate}
           </h1>
           <h3 className="text-xs font-medium text-miru-dark-purple-400 lg:text-sm">
-            Due on {formattedDate(dueDate)}
+            Due on {dueDate}
           </h3>
         </td>
       )}

--- a/app/javascript/src/components/Invoices/common/InvoiceTable/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceTable/index.tsx
@@ -75,6 +75,7 @@ const InvoiceTable = ({
     if (selectedClient && lineItems && showNewLineItemTable) {
       return (
         <NewLineItemTable
+          dateFormat={dateFormat}
           filteredLineItems={filteredLineItems}
           loadMoreItems={loadNewLineItems}
           loading={loading}

--- a/app/javascript/src/components/Invoices/common/NewLineItemTable/index.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemTable/index.tsx
@@ -17,6 +17,7 @@ const NewLineItemTable = ({
   loading,
   setLoading,
   setLineItem,
+  dateFormat,
 }) => {
   const selectRowId = items => {
     setLineItem({});
@@ -51,7 +52,7 @@ const NewLineItemTable = ({
         <div className="relative mt-4 h-20 overflow-scroll md:h-50">
           {filteredLineItems.map((item, index) => {
             const hoursLogged = minToHHMM(item.quantity);
-            const date = dayjs(item.date).format("DD.MM.YYYY");
+            const date = dayjs(item.date).format(dateFormat);
 
             return (
               <div


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/The-date-format-is-incorrect-at-all-places-3f709da1a875466d8433b2031de9fe70?d=a938734eec03482ba9b0cd128cc0220b

https://www.notion.so/saeloun/Invalid-Date-on-changing-date-format-to-DD-MM-YYYY-b9f26d19368742f6870950e690b9f347?pvs=4

What: 
1. Fixed the date format on line item list on invoice details page as per the organisation format
2. Fixed invalid dates on invoices list page

Why: 
1. Format was hardcoded to DD-MM-YYYY.
2. Date was already formatted in the backend, Reformatting in the FE was causing the issue

Screenshot: 

1. Here, selected format in the organisations settings is YYYY-MM-DD

<img width="1500" alt="Screenshot 2023-03-13 at 11 04 51 AM" src="https://user-images.githubusercontent.com/3153596/224616576-30400912-1c4a-42fc-8786-316bfa8d4231.png">
