### PR TITLE
Fixed "Admin & owner users are unable to access personal details page…

### DIFF
--- a/app/controllers/internal_api/v1/team_members/details_controller.rb
+++ b/app/controllers/internal_api/v1/team_members/details_controller.rb
@@ -19,7 +19,7 @@ class InternalApi::V1::TeamMembers::DetailsController < InternalApi::V1::Applica
   private
 
     def employment
-      @_employment ||= Employment.find(params[:team_id])
+      @_employment ||= Employment.find_by(user_id: params[:team_id], company_id: current_company.id)
     end
 
     def detail_params

--- a/app/policies/team_members/detail_policy.rb
+++ b/app/policies/team_members/detail_policy.rb
@@ -2,12 +2,14 @@
 
 class TeamMembers::DetailPolicy < ApplicationPolicy
   def show?
+    return false unless record.present?
     user.has_any_role?(
       { name: :admin, resource: record.company },
       { name: :owner, resource: record.company }) || user == record.user
   end
 
   def update?
+    return false unless record.present?
     user.has_any_role?(
       { name: :admin, resource: record.company },
       { name: :owner, resource: record.company }) || user == record.user


### PR DESCRIPTION
**Notion:**

https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=bb05d32a9f4d42c7a8e7c7d230c695bf&pm=s

https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=889342dbbab54a288c365e518276bc80&pm=s

**Description:**

On clicking a user's name on the team page, getting an error message. 
We fixed it by modifying the employment find query. Also modified the details policy when record not found.