### PR TITLE
Fixed time tracking entries unnecessary render on date change

### DIFF
--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -585,7 +585,9 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
 
   const Main = withLayout(TimeTrackingLayout, !isDesktop, !isDesktop);
 
-  return <Main />;
+  return isDesktop ? TimeTrackingLayout() : <Main />;
+
+  // return <Main />;
 };
 
 interface Iprops {

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -586,8 +586,6 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   const Main = withLayout(TimeTrackingLayout, !isDesktop, !isDesktop);
 
   return isDesktop ? TimeTrackingLayout() : <Main />;
-
-  // return <Main />;
 };
 
 interface Iprops {


### PR DESCRIPTION
Closes
https://www.notion.so/App-re-render-on-clicking-on-dates-on-month-view-5685e04b63d04f92897add39ce59aa98

### Why
- When a user clicks on any date on the time-tracking months view there is a flash of render happens.
- Demo: https://youtu.be/BVNZXoV9x8Y

### What
- With this PR we removed the unnecessary renders. 
- We are directly returning the time-tracking if it's desktop instead of rendering a mobile view on top of it every time.
- Demo:  https://youtu.be/rs3bb0MMLRs