### PR TITLE
Removed websocket url in consumer.js

### DIFF
--- a/app/javascript/src/components/Invoices/popups/consumer.js
+++ b/app/javascript/src/components/Invoices/popups/consumer.js
@@ -1,4 +1,3 @@
 import { createConsumer } from "@rails/actioncable";
 
-const consumer = createConsumer(process.env.WEBSOCKET_URL);
-export default consumer;
+export default createConsumer();


### PR DESCRIPTION
What changed:

Removed websocket url in consumer.js

Why:

By default websocket consume will be connected to /cable path [doc ref.](https://guides.rubyonrails.org/action_cable_overview.html#connect-consumer)

Demo:

https://www.loom.com/share/f24d48168bde440c8f5cce2c38c90e2e