### PR TITLE
Fixed workspace navigation for employee

### DIFF
--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -7,10 +7,10 @@ import { NavLink } from "react-router-dom";
 import { Avatar, Tooltip } from "StyledComponents";
 
 import authenticationApi from "apis/authentication";
-import companiesApi from "apis/companies";
 import WorkspaceApi from "apis/workspaces";
 import { LocalStorageKeys } from "constants/index";
 import { useAuthDispatch } from "context/auth";
+import { useUserContext } from "context/UserContext";
 
 import { activeClassName } from "./utils";
 
@@ -26,10 +26,10 @@ const UserActions = () => {
   const toolTipRef = useRef(null);
 
   const authDispatch = useAuthDispatch();
+  const { user } = useUserContext();
 
   useEffect(() => {
     fetchWorkspaces();
-    fetchCurrentComapny();
   }, []);
 
   const handleTooltip = () => {
@@ -46,14 +46,15 @@ const UserActions = () => {
     showWorkSpaceList
   );
 
-  const fetchCurrentComapny = async () => {
-    const res = await companiesApi.index();
-    setCurrentWorkspace(res.data.company_details);
-  };
-
   const fetchWorkspaces = async () => {
     const res = await WorkspaceApi.get();
-    setWorkSpaceList(res.data.workspaces);
+    const { workspaces } = res.data;
+    setWorkSpaceList(workspaces);
+    workspaces.find(wrk => {
+      if (wrk.id == user.current_workspace_id) {
+        setCurrentWorkspace(wrk);
+      }
+    });
   };
 
   const handleSwitch = async id => {

--- a/app/javascript/src/context/UserContext.tsx
+++ b/app/javascript/src/context/UserContext.tsx
@@ -4,7 +4,13 @@ import { createContext, useContext } from "react";
 
 const UserContext = createContext({
   isAdminUser: false,
-  user: {},
+  user: {
+    current_workspace_id: null,
+    email: "",
+    token: "",
+    first_name: "",
+    last_name: "",
+  },
   companyRole: "", //current company user role
   confirmedUser: "",
   isDesktop: false,


### PR DESCRIPTION
Closes 
 https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=b4528f26f4424af7beaf036262796cb3&p=74dbc8c31d2745f68668921e1f8007b0&pm=s
 
 ### Why
 On current development if an employee logs in companies controller index action throws an error ->. you are not authorised
Reason: In this PR https://github.com/saeloun/miru-web/pull/1122/files company policy we are only checking for the owner role and admin role and we are missing the employee role. But on the sidebar of the app, we are fetching companies which cause this issue

```
class CompanyPolicy < ApplicationPolicy
  attr_reader :error_message_key
  def index?
    user_owner_role? || user_admin_role?
  end
end
```
On the `userActions` inside `app/javascript/src/components/Navbar/UserActions.tsx `we are using `companiesApi` index action for all the users

### What
- on `userActions` there is no need of fetching all the company details to display the current user details.
- With the help of the workspaces we can set the current user info.