### PR TITLE
Redirect user to root path after accepting invitation

### DIFF
--- a/app/controllers/invitations/accept_controller.rb
+++ b/app/controllers/invitations/accept_controller.rb
@@ -19,10 +19,10 @@ class Invitations::AcceptController < ApplicationController
       flash[:error] = service.error_message
     end
 
-    redirect_to user_session_path
+    redirect_to root_path
   end
 
   def show
-    redirect_to user_session_path, notice: t(".success")
+    redirect_to root_path, notice: t(".success")
   end
 end


### PR DESCRIPTION
Closes #1134

### Why
- Once a user accepts the invitation, the system should redirect them root path. Currently, it's redirecting them to "/users/sign_in"

### What
- On accept invitation controller fixed the redirect_url to `root_path`