### PR TITLE
Fix: Incorrect client logo is displayed when the time entry report is grouped by team members

### DIFF
--- a/app/javascript/src/common/CustomRadio.tsx
+++ b/app/javascript/src/common/CustomRadio.tsx
@@ -40,12 +40,11 @@ const CustomRadioButton = ({
     <input
       checked={defaultCheck}
       className={classnames(DEFAULT_STYLE_INPUT, classNameInput)}
-      defaultChecked={defaultCheck}
       id={id}
       name={groupName}
       type="radio"
       value={value}
-      onClick={handleOnChange}
+      onChange={handleOnChange}
     />
     <label
       className={classnames("flex cursor-pointer items-center")}

--- a/app/javascript/src/components/Reports/Container/index.tsx
+++ b/app/javascript/src/components/Reports/Container/index.tsx
@@ -64,10 +64,10 @@ const Container = ({ selectedFilter }: ContainerProps) => {
     ) : null;
   };
 
-  const getEntryList = (entries, clientLogo: string) =>
+  const getEntryList = entries =>
     entries.map((timeEntry, index) => (
       <ReportRow
-        clientLogo={clientLogo}
+        clientLogo={timeEntry.clientLogo}
         key={`${timeEntry.client}-${index}`}
         timeEntry={timeEntry}
       />
@@ -111,7 +111,7 @@ const Container = ({ selectedFilter }: ContainerProps) => {
               )}
               <ReportHeader />
               <div className="mb-6">
-                {entries.length > 0 && getEntryList(entries, clientLogo)}
+                {entries.length > 0 && getEntryList(entries)}
               </div>
             </Fragment>
           )

--- a/app/views/internal_api/v1/reports/time_entries/index.json.jbuilder
+++ b/app/views/internal_api/v1/reports/time_entries/index.json.jbuilder
@@ -4,7 +4,6 @@ json.key_format! camelize: :lower
 json.deep_format_keys!
 json.reports reports do |grouped_report|
   json.label grouped_report[:label]
-  json.client_logo grouped_report[:logo]
 
   json.entries grouped_report[:entries] do |report|
     json.id report.id
@@ -16,6 +15,7 @@ json.reports reports do |grouped_report|
     json.work_date report.formatted_work_date
     json.bill_status report.bill_status
     json.team_member report.user_full_name
+    json.client_logo report.project.client.logo_url
   end
 end
 json.filter_options do


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Incorrect-client-logo-is-displayed-when-the-time-entry-report-is-grouped-by-team-members-654c9936eb6044d69705ec726f8b5f35)

## Description
- Fixed the bug where the incorrect client logo is displayed when the time entry report is grouped by team members and week.
- Fixed some warnings on the browser console whenever the filter was opened.

## Preview

https://user-images.githubusercontent.com/57438322/225597943-b4592657-394e-45ac-9f0a-3efb06a08b23.mp4

