### PR TITLE
Fix: Multiple entries are created by clicking on the save button multiple times

### DIFF
--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -46,6 +46,7 @@ const AddEntry: React.FC<Iprops> = ({
   const [projectBillable, setProjectBillable] = useState<boolean>(true);
   const [selectedDate, setSelectedDate] = useState<string>(selectedFullDate);
   const [displayDatePicker, setDisplayDatePicker] = useState<boolean>(false);
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   const datePickerRef: MutableRefObject<any> = useRef();
   const { isDesktop } = useUserContext();
@@ -155,7 +156,7 @@ const AddEntry: React.FC<Iprops> = ({
   const handleDisableBtn = () => {
     const tse = getPayload();
     const message = validateTimesheetEntry(tse, client, projectId);
-    if (message) {
+    if (message || submitting) {
       return true;
     }
 
@@ -291,7 +292,10 @@ const AddEntry: React.FC<Iprops> = ({
                 ? "cursor-not-allowed bg-miru-gray-1000"
                 : "bg-miru-han-purple-1000 hover:border-transparent"
             }`}
-            onClick={handleSave}
+            onClick={() => {
+              setSubmitting(true);
+              handleSave();
+            }}
           >
             SAVE
           </button>


### PR DESCRIPTION
## Notion
[Notion Card](https://www.notion.so/saeloun/Multiple-entries-are-created-by-clicking-on-the-save-button-multiple-times-3c395f462a2a4335b0d01a1fdfd6fd03)

## Description
Fixed the bug where clicking the save button multiple times while creating timesheet entries would create multiple time entries.

## Preview

https://user-images.githubusercontent.com/57438322/226536715-43563a54-0cef-4a64-88cf-635a74709c8f.mp4

## How was it resolved?
- It was resolved by disabling the button when it is clicked and then sending the request thereby preventing the button to be clicked multiple times.
