### PR TITLE
Fixed current user logout

### DIFF
--- a/app/controllers/internal_api/v1/users/sessions_controller.rb
+++ b/app/controllers/internal_api/v1/users/sessions_controller.rb
@@ -18,7 +18,7 @@ class InternalApi::V1::Users::SessionsController < Devise::SessionsController
   end
 
   def destroy
-    sign_out(@user)
+    sign_out(current_user)
     reset_session
     render json: { notice: I18n.t("devise.sessions.signed_out"), reset_session: true }, status: :ok
   end

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -108,6 +108,7 @@ const UserActions = () => {
       </li>
       <li
         className="flex cursor-pointer items-start  justify-start border-b border-miru-gray-100 px-6 last:border-b-0 hover:bg-miru-gray-100 md:border-b-0"
+        id="logoutBtn"
         onClick={handleLogout}
       >
         <SignOutIcon className="mr-4" size={26} />

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -107,18 +107,11 @@ const UserActions = () => {
         </NavLink>
       </li>
       <li
-        className="flex items-start justify-start  border-b border-miru-gray-100 px-6 last:border-b-0 hover:bg-miru-gray-100 md:border-b-0"
+        className="flex cursor-pointer items-start  justify-start border-b border-miru-gray-100 px-6 last:border-b-0 hover:bg-miru-gray-100 md:border-b-0"
         onClick={handleLogout}
       >
-        <a
-          className="flex w-full items-start justify-start py-3 hover:bg-miru-gray-100"
-          data-method="delete"
-          href="/users/sign_out"
-          rel="nofollow"
-        >
-          <SignOutIcon className="mr-4" size={26} />
-          Logout
-        </a>
+        <SignOutIcon className="mr-4" size={26} />
+        Logout
       </li>
       <Tooltip content={currentWorkspace.name} show={showToolTip}>
         <li

--- a/spec/requests/internal_api/v1/users/sessions/destroy_spec.rb
+++ b/spec/requests/internal_api/v1/users/sessions/destroy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InternalApi::V1::Users::Sessions#destroy", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id, password: "welcome") }
+
+  context "when logged in with valid email and password" do
+    before do
+      sign_in user
+    end
+
+    it "logout the user successfully" do
+      send_request :delete, internal_api_v1_users_logout_path
+      expect(response).to have_http_status(:ok)
+      expect(json_response["notice"]).to eq(I18n.t("devise.sessions.signed_out"))
+    end
+  end
+end

--- a/spec/system/users/logout_spec.rb
+++ b/spec/system/users/logout_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Logout", type: :system do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+
+  context "when user want to logout" do
+    before do
+      create(:employment, company:, user:)
+      user.add_role :admin, company
+      sign_in(user)
+    end
+
+    it "logout the current user when user clicks on logout" do
+      with_forgery_protection do
+        visit "/time-tracking"
+        find("#logoutBtn").click()
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_content("Sign In")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
- If an invited user accepts the invitation from the email he is redirected to the home page instead of the reset password page
- Ref: https://www.loom.com/share/6f87a22b880540cb88b0f89dfab69563
- if the user resets the password also it’s redirecting me to the home page instead of the reset password


### What
- The above bug is not noticeable to the new users and reset password users as they open the app for the first time in their browsers. This bug is noticeable to users who logout from the app in their browsers and tries to access the reset password page either by clicking on forgot password or by accepting the user invitation from email.
- When a user clicks on logout, on the current develop branch we are not removing the current user from the session as `@user` is not available.
- On the frontend, when the user clicks on `Logout`, we wrapped it around the anchor tag with path `/users/sign_out` which is no more present
