### PR TITLE
Fixed invalid csrf token on signin form by reloading session after logout

### DIFF
--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -68,6 +68,7 @@ const UserActions = () => {
     window.localStorage.removeItem(LocalStorageKeys.INVOICE_FILTERS);
     //@ts-expect-error for authDispatch object
     authDispatch({ type: "LOGOUT" });
+    window.location.href = "/";
   };
 
   const WorkspaceList = () => (


### PR DESCRIPTION
### Why 
if a user tries to log in after logging out
We are getting the below error. Reason when the user logout, we are logging out the user and rendering the signin form and we are not reloading the screen
```
Started POST "/internal_api/v1/users/login" for 127.0.0.1 at 2023-03-22 16:02:59 +0530
16:02:59 web.1       | Processing by InternalApi::V1::Users::SessionsController#create as JSON
16:02:59 web.1       |   Parameters: {"user"=>{"email"=>"supriya@example.com", "password"=>"[FILTERED]"}, "session"=>{"user"=>{"email"=>"supriya@example.com", "password"=>"[FILTERED]"}}}
16:02:59 web.1       | Can't verify CSRF token authenticity.
16:02:59 web.1       | Completed 422 Unprocessable Entity in 3ms (ActiveRecord: 0.0ms | Allocations: 1094)
16:02:59 web.1       |
16:02:59 web.1       |
16:02:59 web.1       |
16:02:59 web.1       | ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.):
```

### What 
- Reload the root_path after the user logged out.