### PR TITLE
Time logging validations fixed

### DIFF
--- a/app/javascript/src/components/TimeTracking/MobileView/MobileEntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/MobileView/MobileEntryForm.tsx
@@ -12,7 +12,12 @@ import {
   CopyIcon,
   DeleteIcon,
 } from "miruIcons";
-import { Button, MobileMoreOptions, SidePanel } from "StyledComponents";
+import {
+  Button,
+  MobileMoreOptions,
+  SidePanel,
+  TimeInput,
+} from "StyledComponents";
 
 import CustomCheckbox from "common/CustomCheckbox";
 import CustomDatePicker from "common/CustomDatePicker";
@@ -125,6 +130,10 @@ const AddEntryMobile = ({
     handleSave();
     setNewEntryView(false);
     setEditEntryId(0);
+  };
+
+  const handleDurationChange = val => {
+    setDuration(val);
   };
 
   return (
@@ -334,11 +343,12 @@ const AddEntryMobile = ({
                 weight="bold"
               />
             </Button>
-            <input
-              className="laceholder:text-miru-dark-purple-200 focus:outline-none cursor-pointer rounded text-center text-xl font-bold text-miru-dark-purple-1000 focus:border-miru-gray-1000 focus:bg-white focus:ring-1 focus:ring-miru-gray-1000"
+            <TimeInput
+              className="focus:outline-none cursor-pointer rounded text-center text-xl font-bold text-miru-dark-purple-1000 placeholder:text-miru-dark-purple-200 focus:border-miru-gray-1000 focus:bg-white focus:ring-1 focus:ring-miru-gray-1000"
+              initTime={duration}
+              name="timeInput"
               placeholder="00:00"
-              value={duration}
-              onChange={e => setDuration(e.target.value)}
+              onTimeChange={handleDurationChange}
             />
             <Button onClick={handleIncreaseTime}>
               <PlusIcon


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Fix-validations-for-logging-time-for-mobile-view-f32d1d7372b741f4a2406558b87c21ba?pvs=4
### **What :**
- Time logging validations fixed for mobile view.
### **Why :**
- Earlier timeInput was allowing data like (-, .) which is wrong.
### **Preview :**
before:
https://www.loom.com/share/c74d0b2b42264c9ba2e03e03ef9779f2
After:
https://www.loom.com/share/9398f270d496485dae8ea008d5060b82
### **Todos** (for testing):
- Checked if time input is allowing data which is not correct (like decimal point, - , etc).