### PR TITLE
Redirection issue fixed on mobile view

### DIFF
--- a/app/javascript/src/common/Mobile/HOC/withLayout/index.tsx
+++ b/app/javascript/src/common/Mobile/HOC/withLayout/index.tsx
@@ -15,12 +15,7 @@ const WithLayout =
       <div className="h-full">
         {includeNavbar && <Header selectedTab={selectedTab} />}
         <WrappedComponent {...props} />
-        {includeSidebar && (
-          <Navigation
-            isAdminUser={isAdminUser}
-            setSelectedTab={setSelectedTab}
-          />
-        )}
+        {includeSidebar && <Navigation />}
       </div>
     );
   };

--- a/app/javascript/src/components/Navbar/Mobile/MoreOptions.tsx
+++ b/app/javascript/src/components/Navbar/Mobile/MoreOptions.tsx
@@ -12,8 +12,8 @@ import {
   MobileMenuOptions,
 } from "../utils";
 
-const MoreOptions = ({ setVisiblity, setSelectedTab, showMoreOptions }) => {
-  const { user, isAdminUser } = useUserContext();
+const MoreOptions = ({ setVisiblity, showMoreOptions }) => {
+  const { user, isAdminUser, setSelectedTab } = useUserContext();
 
   return (
     <SidePanel WrapperClassname="pt-13 pb-16" setFilterVisibilty={setVisiblity}>

--- a/app/javascript/src/components/Navbar/Mobile/Navigation.tsx
+++ b/app/javascript/src/components/Navbar/Mobile/Navigation.tsx
@@ -1,13 +1,28 @@
-import React, { useState, Fragment } from "react";
+import React, { useState, Fragment, useEffect } from "react";
 
 import { DotsThreeVerticalIcon } from "miruIcons";
+
+import { useUserContext } from "context/UserContext";
 
 import MoreOptions from "./MoreOptions";
 
 import { mobileActiveClassName, MobileMenuOptions } from "../utils";
 
-const Navigation = ({ isAdminUser, setSelectedTab }) => {
-  const [showMoreOptions, setShowMoreOptions] = useState<boolean>(false);
+const Navigation = () => {
+  const { isAdminUser, setSelectedTab, selectedTab } = useUserContext();
+  const defaultShowOption = selectedTab == "More";
+  const [showMoreOptions, setShowMoreOptions] =
+    useState<boolean>(defaultShowOption);
+
+  const handleMoreClick = () => {
+    setShowMoreOptions(true);
+  };
+
+  useEffect(() => {
+    if (showMoreOptions) {
+      setSelectedTab("More");
+    }
+  }, [showMoreOptions]);
 
   return (
     <Fragment>
@@ -25,17 +40,14 @@ const Navigation = ({ isAdminUser, setSelectedTab }) => {
               ? mobileActiveClassName
               : "flex flex-col items-center justify-center text-xs"
           }`}
-          onClick={() => {
-            setSelectedTab("More");
-            setShowMoreOptions(true);
-          }}
+          onClick={handleMoreClick}
         >
-          <DotsThreeVerticalIcon size={26} /> More
+          <DotsThreeVerticalIcon size={26} />
+          More
         </li>
       </ul>
       {showMoreOptions && (
         <MoreOptions
-          setSelectedTab={setSelectedTab}
           setVisiblity={setShowMoreOptions}
           showMoreOptions={showMoreOptions}
         />

--- a/app/javascript/src/components/Navbar/utils.tsx
+++ b/app/javascript/src/components/Navbar/utils.tsx
@@ -117,7 +117,7 @@ const getMobileListClassName = (isActive, index, showMoreOptions) => {
   if (isActive && !showMoreOptions) return mobileActiveClassName;
 
   if (index > 3) {
-    return "px-4 flex items-center justify-start hover:bg-miru-gray-100";
+    return "w-full px-4 flex items-center justify-start hover:bg-miru-gray-100";
   }
 
   return "w-full flex flex-col items-center justify-center hover:bg-miru-gray-100 text-xs font-medium";


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Fix-redirection-for-reports-and-other-pages-on-the-mobile-view-5d2adea4344b48c080568790bc4add66?pvs=4
### **What :**
- Navigation of reports and projects tab fixed on mobile view.
### **Why :**
- Earlier sometimes when we were clicking on the projects and reports tab on mobile view it was navigated to the invoice page  
### **Preview :**
Before:
https://www.loom.com/share/6449b524875340c1b5af3e470b69411b
After:
https://www.loom.com/share/82f752c0c92f4cd59ca9dc7bbee39ad3
### **Todos** (for testing):
- Checked if navigation is working properly  on all tabs on mobile view.