### PR TITLE
Bulk download loop bug fixed

### DIFF
--- a/app/javascript/src/components/Invoices/List/index.tsx
+++ b/app/javascript/src/components/Invoices/List/index.tsx
@@ -75,17 +75,23 @@ const Invoices = () => {
 
   useEffect(() => sendGAPageView(), []);
 
+  const aferDownloadActions = () => {
+    setCounter(0);
+    setReceived(null);
+    setConnected(false);
+    setSelectedInvoiceCounter(selectedInvoices.length);
+    setShowBulkDownloadDialog(false);
+  };
+
   useEffect(() => {
     if (!downloading) {
-      const timer = setTimeout(() => {
-        setCounter(0);
-        setReceived(null);
-        setConnected(false);
-        setSelectedInvoiceCounter(selectedInvoices.length);
-        setShowBulkDownloadDialog(false);
-      }, 3000);
+      if (isDesktop) {
+        const timer = setTimeout(aferDownloadActions, 3000);
 
-      return () => clearTimeout(timer);
+        return () => clearTimeout(timer);
+      }
+
+      aferDownloadActions();
     }
   }, [downloading]);
 


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Fix-invoice-download-loop-on-mobile-view-922179cad6224043a33559102b224648?pvs=4
### **What :**
- Bulk download loop error fixed.
### **Why :**
- Earlier the bulk download action was triggering in a loop till we change the tab or reload it.
### **Preview :**
Before:
https://www.loom.com/share/0fb11a326723410c9afd763bf1153d7f
After:
https://www.loom.com/share/867da51a8cf04e99a70e7381de400df6
### **Todos** (for testing):
- Checked workflow of bulk download on desktop view as well as mobile view.