### PR TITLE
Use locales for errors in models

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include ActionView::Helpers::TranslationHelper
   primary_abstract_class
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -91,7 +91,7 @@ class Invitation < ApplicationRecord
 
     def non_existing_company_user
       if company && employment_in_company_present?
-        self.errors.add(:base, "User is already a team member in workspace")
+        self.errors.add(:base, t("errors.user_already_member"))
       end
     end
 
@@ -101,7 +101,7 @@ class Invitation < ApplicationRecord
 
     def recipient_email_not_changed
       if recipient_email_changed? && self.persisted?
-        self.errors.add(:recipient_email, "updation is not allowed")
+        self.errors.add(:recipient_email, t("errors.updation_not_allowed"))
       end
     end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -172,7 +172,7 @@ class Invoice < ApplicationRecord
 
     def check_if_invoice_paid
       if status_changed? && status_was == "paid"
-        errors.add(:status, "can't be changed to paid")
+        errors.add(:status, t("errors.can't change status"))
       end
     end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,9 @@ en:
     bill_status_billed: You can't bill an entry that has already been billed
     create_billed_entry: You can't create a billed timesheet entry
     internal_server_error: Something went wrong
+    user_already_member: User is already a team member in workspace
+    updation_not_allowed: updation is not allowed"
+    can't change status: can't be changed of a paid invoice
   timesheet_entry:
     create:
       message: "Timesheet created"


### PR DESCRIPTION
What
- Use locales for error messages in custom validation methods in models

<img width="875" alt="Screenshot 2023-03-25 at 1 41 51 PM" src="https://user-images.githubusercontent.com/18750194/227705643-5a29a5bf-e3aa-4aae-93a9-f89c44fff4bb.png">
<img width="1362" alt="Screenshot 2023-03-25 at 1 42 37 PM" src="https://user-images.githubusercontent.com/18750194/227705683-f272bee5-cf1a-450a-aa24-396e9d4263b0.png">
