### PR TITLE
Fix: If overdue invoices are resent they are marked as “Sent”

### DIFF
--- a/app/controllers/internal_api/v1/invoices_controller.rb
+++ b/app/controllers/internal_api/v1/invoices_controller.rb
@@ -57,7 +57,7 @@ class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationControll
   def send_invoice
     authorize invoice
 
-    invoice.sending! unless invoice.paid?
+    invoice.sending! unless invoice.paid? || invoice.overdue?
     invoice.send_to_email(
       subject: invoice_email_params[:subject],
       message: invoice_email_params[:message],


### PR DESCRIPTION
## Notion
[Notion Card](https://www.notion.so/saeloun/If-overdue-invoices-are-resent-they-are-marked-as-Sent-876703bf517546f19b7c810bcccca358)

## Description
Fixed the issue where the invoices which are overdue are sent/resent are marked as "Sent"

## Preview

https://user-images.githubusercontent.com/57438322/227981384-60325df1-1cca-4217-96a3-e35bfe6d4ffa.mp4

