### PR TITLE
Fixed omniauth request specs

### DIFF
--- a/spec/requests/users/omniauth_callbacks/google_oauth2_spec.rb
+++ b/spec/requests/users/omniauth_callbacks/google_oauth2_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Users::OmniauthCallbacks#google_oauth2", type: :request do
 
     it "redirects to dashboard page" do
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to("#{root_path}?google_oauth_success=true")
     end
 
     it "returns a success flash message" do


### PR DESCRIPTION
### Why
- Omniauth request specs are failing due to redirect path


### What
- Fixed omniauth request specs by updating the redirect path