### PR TITLE
client name crop got fixed

### DIFF
--- a/app/javascript/src/components/Reports/AccountsAgingReport/Container/Table/TableRow.tsx
+++ b/app/javascript/src/components/Reports/AccountsAgingReport/Container/Table/TableRow.tsx
@@ -25,7 +25,7 @@ const TableRow = ({ currency, report }) => {
         {isDesktop ? (
           <Tooltip content={name} show={showToolTip}>
             <p
-              className="overflow-hidden text-ellipsis whitespace-normal pr-2 text-sm font-medium text-miru-dark-purple-1000 lg:whitespace-nowrap lg:text-base"
+              className="overflow-hidden text-ellipsis break-words pr-2 text-sm font-medium text-miru-dark-purple-1000 lg:whitespace-normal lg:text-base"
               ref={toolTipRef}
               onMouseEnter={handleTooltip}
             >


### PR DESCRIPTION
Client name which was getting hidden now getting breakdown.

**Notion link**
https://www.notion.so/The-client-names-are-getting-cropped-in-Accounts-Aging-Report-8d6947346c1343a3823b676ff258a593

**Preview**
<img width="1792" alt="Screenshot 2023-03-30 at 1 58 22 PM" src="https://user-images.githubusercontent.com/22776061/228777269-a4400844-1d3c-43d4-9da4-dae255d5a34f.png">
