### PR TITLE
Bugfix- Add payment modal Issue 

### DIFF
--- a/app/javascript/src/helpers/outsideClick.ts
+++ b/app/javascript/src/helpers/outsideClick.ts
@@ -7,7 +7,12 @@ export const useOutsideClick = (
 ) => {
   useEffect(() => {
     const handleClickOutside = event => {
-      if (ref.current && !ref.current.contains(event.target) && condition) {
+      if (
+        ref &&
+        ref.current &&
+        !ref.current.contains(event.target) &&
+        condition
+      ) {
         callback();
       }
     };


### PR DESCRIPTION
What-
The coutside click on the date filter was giving an error for undefined ref.

Why-
The issue was breaking a UI for the Add payment modal.

Notion-
https://www.notion.so/saeloun/App-breaking-on-clicking-on-a-date-on-transaction-date-field-on-payments-modal-be5db4cfeec84ece9be072c38a12de50?pvs=4