### PR TITLE
Team member modal bugs

### DIFF
--- a/app/javascript/src/components/Projects/Details/EditMembersList.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { useKeypress } from "helpers";
 import Logger from "js-logger";
 import { XIcon } from "miruIcons";
 
@@ -63,6 +64,12 @@ const EditMembersList = ({
     modalMembers[memberIndex] = memberToEdit;
     setMembers(modalMembers);
   };
+
+  const handleEscapeKey = () => {
+    setShowAddMemberDialog(false);
+  };
+
+  useKeypress("Escape", handleEscapeKey);
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -146,6 +153,7 @@ const EditMembersList = ({
             currencySymbol={currencySymbol}
             handleSubmit={handleSubmit}
             members={members}
+            setAllMemberList={setAllMemberList}
             setMembers={setMembers}
             updateMemberState={updateMemberState}
           />

--- a/app/javascript/src/components/Projects/Details/EditMembersList.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersList.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useRef } from "react";
 
-import { useKeypress } from "helpers";
+import { useKeypress, useOutsideClick } from "helpers";
 import Logger from "js-logger";
 import { XIcon } from "miruIcons";
 
@@ -32,6 +32,7 @@ const EditMembersList = ({
     addedMembers.map(v => ({ ...v, isExisting: true }))
   );
   const [allMemberList, setAllMemberList] = React.useState([]);
+  const wrapperRef = useRef(null);
 
   const markAddedMembers = allMembers =>
     allMembers.map(memberFromAllMembers =>
@@ -64,6 +65,10 @@ const EditMembersList = ({
     modalMembers[memberIndex] = memberToEdit;
     setMembers(modalMembers);
   };
+
+  useOutsideClick(wrapperRef, () => {
+    setShowAddMemberDialog(false);
+  });
 
   const handleEscapeKey = () => {
     setShowAddMemberDialog(false);
@@ -133,7 +138,10 @@ const EditMembersList = ({
       }}
     >
       <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
-        <div className="min-w-1/2 relative top-1/3 mx-auto transform rounded-lg bg-white py-6 pl-6 shadow-xl transition-all sm:max-w-md sm:align-middle md:top-0 md:min-w-400">
+        <div
+          className="min-w-1/2 relative top-1/3 mx-auto transform rounded-lg bg-white py-6 pl-6 shadow-xl transition-all sm:max-w-md sm:align-middle md:top-0 md:min-w-400"
+          ref={wrapperRef}
+        >
           <div className=" mr-6 flex items-center justify-between">
             <h6 className="text-base font-extrabold capitalize">
               Add Team Members

--- a/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
@@ -21,7 +21,7 @@ const EditMembersListForm = ({
     {}
   );
 
-  useEffect(() => {
+  const getFormattedMemberList = () => {
     allMemberList.length > 0 &&
       allMemberList.reduce((memberList, currentMember) => {
         if (!currentMember.isAdded) {
@@ -37,6 +37,10 @@ const EditMembersListForm = ({
 
         return memberList;
       }, []);
+  };
+
+  useEffect(() => {
+    getFormattedMemberList();
   }, [allMemberList]);
 
   const removeMemberHandler = (memberIndex, member) => {

--- a/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { DeleteIcon } from "miruIcons";
 
@@ -13,13 +13,43 @@ const EditMembersListForm = ({
   setMembers,
   handleSubmit,
   currencySymbol,
+  setAllMemberList,
 }) => {
   const [focusedRateInputBoxId, setFocusedRateInputBoxId] = useState("");
+  const [formattedMemberList, setFormattedMemberList] = useState([]);
   const [errorForInvalidHourlyRate, setErrorForInvalidHourlyRate] = useState(
     {}
   );
 
-  const removeMemberHandler = memberIndex => {
+  useEffect(() => {
+    allMemberList.length > 0 &&
+      allMemberList.reduce((memberList, currentMember) => {
+        if (!currentMember.isAdded) {
+          memberList = [
+            ...memberList,
+            {
+              label: currentMember.name,
+              value: currentMember.id,
+            },
+          ];
+        }
+        memberList && setFormattedMemberList(memberList);
+
+        return memberList;
+      }, []);
+  }, [allMemberList]);
+
+  const removeMemberHandler = (memberIndex, member) => {
+    const newArr = allMemberList.map(currentMember => {
+      if (member.id == currentMember.id) {
+        return { ...currentMember, isAdded: false };
+      }
+
+      return currentMember;
+    });
+
+    setAllMemberList(newArr);
+
     setMembers(members => members.filter((_, i) => i != memberIndex));
   };
 
@@ -48,23 +78,6 @@ const EditMembersListForm = ({
       memberFromAllMemberList => memberFromAllMemberList.id == member.id
     );
 
-    const formattedMemberList = allMemberList.reduce(
-      (memberList, currentMember) => {
-        if (!currentMember.isAdded) {
-          memberList = [
-            ...memberList,
-            {
-              label: currentMember.name,
-              value: currentMember.id,
-            },
-          ];
-        }
-
-        return memberList;
-      },
-      []
-    );
-
     const valueObj = {
       label: currentMemberDetails?.name || "",
       value: currentMemberDetails?.id || "",
@@ -86,6 +99,7 @@ const EditMembersListForm = ({
                 "id",
                 parseInt(selectedMember.value)
               );
+          document.getElementById(member.hourlyRate).focus();
         }}
       />
     );
@@ -137,7 +151,7 @@ const EditMembersListForm = ({
                 inputBoxClassName={` text-right ${
                   isInvalidRateInputBox(memberIndex)
                     ? "border-miru-red-400 error-input"
-                    : "border-miru-gray-1000"
+                    : "border-miru-gray-1000 focus:border-miru-han-purple-1000"
                 }`}
                 onChange={e => handleHourlyRateInput(e, memberIndex)}
                 onFocus={() => setFocusedRateInputBoxId(memberIndex)}
@@ -153,7 +167,7 @@ const EditMembersListForm = ({
                 className="menuButton__button"
                 id="removeMember"
                 type="button"
-                onClick={() => removeMemberHandler(memberIndex)}
+                onClick={() => removeMemberHandler(memberIndex, member)}
               >
                 <DeleteIcon color="#5B34EA" fill="#5B34EA" size={12} />
               </button>
@@ -171,9 +185,14 @@ const EditMembersListForm = ({
       ))}
       <div className="actions mt-4 text-center">
         <button
-          className="menuButton__button text-xs text-miru-han-purple-1000"
+          disabled={!(formattedMemberList.length > 0)}
           name="add"
           type="button"
+          className={`menuButton__button text-xs ${
+            formattedMemberList.length > 0
+              ? "text-miru-han-purple-1000"
+              : "text-miru-dark-purple-400"
+          }`}
           onClick={addNewMemberRowHandler}
         >
           <span>+</span>

--- a/app/javascript/src/helpers/index.ts
+++ b/app/javascript/src/helpers/index.ts
@@ -8,6 +8,7 @@ import { minFromHHMM, minToHHMM } from "./hhmmParser";
 import { lineTotalCalc } from "./lineTotalCalc";
 import { getNumberWithOrdinal } from "./ordinal";
 import { useOutsideClick } from "./outsideClick";
+import useKeypress from "./useKeyPress";
 import { validateTimesheetEntry } from "./validateTimesheetEntry";
 import {
   separateAddressFields,
@@ -28,5 +29,6 @@ export {
   separateAddressFields,
   useDebounce,
   useOutsideClick,
+  useKeypress,
   validateTimesheetEntry,
 };

--- a/app/javascript/src/helpers/useKeyPress.ts
+++ b/app/javascript/src/helpers/useKeyPress.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export default function useKeypress(key, action) {
+  useEffect(() => {
+    const onKeyDown = e => {
+      if (e.key === key) action();
+    };
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Update-the-UI-for-Add-Team-members-modal-on-project-details-page-3964466aada34ef189fd8f4aac6881ee?pvs=4
### **What :**
- Added usekeyPress hook to handle all key events.
- The modal is now closing on hitting the ‘esc’ key. 
- After adding a team member the cursor is now moving automatically to the rate field.
- Disabled add team member button if no members are remaining to add.
 
### **Why :**
- Added useKeyPress hook as a helper to save time, now we just need to pass event name and actions to perform.
- Bug fixes
  
### **Preview :**

Before:
https://www.loom.com/share/315f83ea1355489594a220cac00942ba

After:
https://www.loom.com/share/ac3846e37f5c4e8b94d9b1de39e5e92a

### **Todos** (for testing):
- Checked add/remove team member flow.
- Checked if modal is closing on esc key.
- Checked if after adding a team member the now cursor is moving automatically to the rate field.