### PR TITLE
projet bug fixed on time tracking page

### DIFF
--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -77,7 +77,10 @@ const AddEntry: React.FC<Iprops> = ({
   };
 
   useEffect(() => {
-    if (!project) return;
+    if (!project) {
+      return setProjectId(0);
+    }
+
     const selectedProject = projects[client].find(
       currentProject => currentProject.name === project
     );
@@ -88,7 +91,7 @@ const AddEntry: React.FC<Iprops> = ({
         setBillable(selectedProject.billable);
       }
     }
-  }, [project]);
+  }, [project, client]);
 
   const handleDurationChange = val => {
     setDuration(val);
@@ -183,7 +186,7 @@ const AddEntry: React.FC<Iprops> = ({
             value={client || "Client"}
             onChange={e => {
               setClient(e.target.value);
-              setProject(projects[e.target.value][0].name);
+              setProject(projects ? projects[e.target.value][0]?.name : "");
             }}
           >
             {!client && (


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Fix-project-selection-bug-on-time-tracking-a8a45adff45443ed92269101ff31dbf7?pvs=4
### **What :**
- We can not create a timesheet entry if the client has no projects. 
 
### **Why :**
- If a client doesn't have any projects then we should not be able to create a timesheet for it. But on the add entry dropdown if we were selecting any client that has a project and then selecting a client that does not have a project then it was allowing  us to create an entry for a client that doesn't have any projects

### **Preview :**
Before:
https://www.loom.com/share/0031e07f33b146ee8cc23d76d81470e6

After:
https://www.loom.com/share/11510f465a8641d1a53d954d22beb0f4

### **Todos** (for testing):
- Checked if we are not able to create an entry for a client that doesn't have any projects on both desktop and mobile view.