### PR TITLE
Sign in page spacing fixed

### DIFF
--- a/app/javascript/src/common/FormikFields/InputField/index.tsx
+++ b/app/javascript/src/common/FormikFields/InputField/index.tsx
@@ -63,7 +63,7 @@ const InputField = ({
     resetErrorOnChange || onChange ? { onChange: e => handleChange(e) } : {};
 
   return (
-    <div className="field relative">
+    <div className="field relative mb-6">
       <div className={classNames(defaultWrapperClassName, wrapperClassName)}>
         <Field
           autoComplete={autoComplete}

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -88,7 +88,7 @@ const SignInForm = () => {
 
               return (
                 <Form>
-                  <div className="field relative mb-6">
+                  <div className="field relative">
                     <InputField
                       autoFocus
                       hasError={errors.email && touched.email}
@@ -104,7 +104,7 @@ const SignInForm = () => {
                       fieldTouched={touched.email}
                     />
                   </div>
-                  <div className="field mb-6">
+                  <div className="field">
                     <InputField
                       hasError={errors.password && touched.password}
                       id="password"

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -88,7 +88,7 @@ const SignInForm = () => {
 
               return (
                 <Form>
-                  <div className="field relative">
+                  <div className="field relative mb-6">
                     <InputField
                       autoFocus
                       hasError={errors.email && touched.email}
@@ -104,7 +104,7 @@ const SignInForm = () => {
                       fieldTouched={touched.email}
                     />
                   </div>
-                  <div className="field">
+                  <div className="field mb-6">
                     <InputField
                       hasError={errors.password && touched.password}
                       id="password"


### PR DESCRIPTION
### **Notion :**
NA
### **What :**
- Spacing between input field fixed on sign in page.
### **Why :**
- Input fields did not have spacing between them. 
### **Preview :**
Before : 

<img width="356" alt="Screenshot 2023-04-04 at 12 48 20 PM" src="https://user-images.githubusercontent.com/72149587/229717444-1f27ae5d-b410-4c44-9481-b30fb59f9565.png">

After:
<img width="382" alt="Screenshot 2023-04-04 at 12 48 31 PM" src="https://user-images.githubusercontent.com/72149587/229717414-60e599df-f9d0-4fa9-929b-89b80571092a.png">
