### PR TITLE
Fixed unbilled timsheet entries bug on generate invoice

### DIFF
--- a/app/services/generate_invoice/new_line_items_service.rb
+++ b/app/services/generate_invoice/new_line_items_service.rb
@@ -32,7 +32,9 @@ module GenerateInvoice
 
       # merging selected_entries from params with ids already present in other invoice line items
       def filtered_ids
+        discarded_invoice_ids = Invoice.kept.pluck(:id)
         @filtered_ids ||= params[:selected_entries].to_a | InvoiceLineItem.joins(:timesheet_entry)
+          .where(invoice_id: discarded_invoice_ids)
           .where(timesheet_entries: { bill_status: "unbilled" })
           .pluck(:timesheet_entry_id)
       end


### PR DESCRIPTION
### Notion
https://www.notion.so/Unbilled-time-entries-are-not-getting-fetched-when-the-draft-invoice-is-deleted-b5e4098a27a744e3a36f5b67b7784737

### Why
- Currently, if we delete a draft invoice, the unbilled timesheet entries of discarded invoice won't be visible on the new generate invoice new line items.

### What
- With this PR, the unbilled timesheet entries of a discarded invoice will be visible on the new generate invoice new line items.

### Before
https://youtu.be/iXaYQxWv5kk

### After
https://youtu.be/-FFdUW_nxSk
