### PR TITLE
Replaced --with bundler argument

### DIFF
--- a/scripts/ci/rspec.sh
+++ b/scripts/ci/rspec.sh
@@ -2,7 +2,8 @@
 
 set -eu
 
-bundle install --without development production test
+bundle config set --local with 'ci'
+bundle config set --local without 'development production test'
 bin/yarn install
 bin/rails db:create
 bin/rails db:migrate

--- a/scripts/ci/rubocop.sh
+++ b/scripts/ci/rubocop.sh
@@ -2,5 +2,7 @@
 
 set -eu
 
-bundle install --with test
+bundle config set --local with 'test'
+bundle config set --local without 'development production ci'
+bundle install
 bundle exec rubocop

--- a/scripts/ci/setup.sh
+++ b/scripts/ci/setup.sh
@@ -2,7 +2,8 @@
 
 set -eu
 
-bundle install --with test
+bundle config set --local with 'test'
+bundle config set --local without 'development production ci'
 
 yarn install
 

--- a/scripts/ci/system_spec.sh
+++ b/scripts/ci/system_spec.sh
@@ -2,7 +2,8 @@
 
 set -eu
 
-bundle install --without development production test
+bundle config set --local with 'ci'
+bundle config set --local without 'development production test'
 bin/yarn install
 bin/rails db:create
 bin/rails db:migrate


### PR DESCRIPTION
Fixes #1223

What changed:

- Removed the `--with` option in bundle command with `bundle config set --local with <env>`

Why:

--with bunder option is deprecated