### PR TITLE
Fixed client search on generate and edit invoice

### DIFF
--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -20,6 +20,7 @@ const ClientSelection = ({
 
   const [isClientVisible, setIsClientVisible] =
     useState<boolean>(clientVisible);
+
   const wrapperRef = useRef(null);
 
   useOutsideClick(wrapperRef, () => setIsClientVisible(false), isClientVisible);
@@ -66,7 +67,7 @@ const ClientSelection = ({
       <div
         className="relative h-full"
         onClick={() => {
-          setIsClientVisible(!isClientVisible);
+          setIsClientVisible(true);
         }}
       >
         <CustomAdvanceInput
@@ -88,12 +89,12 @@ const ClientSelection = ({
             )
           }
         />
-        <div className=" absolute top-2 left-0 w-fit" ref={wrapperRef}>
+        <div className="absolute top-2 w-full" ref={wrapperRef}>
           {isClientVisible && (
             <Select
               defaultMenuIsOpen
               isSearchable
-              className="client-select m-0 mt-2 w-52 text-white"
+              className="client-select m-0 mt-2  w-full text-white"
               classNamePrefix="m-0 truncate font-medium text-sm text-miru-dark-purple-1000 bg-white"
               components={{ DropdownIndicator, IndicatorSeparator: () => null }}
               defaultValue={null}


### PR DESCRIPTION
### Why
- Currently, on generate & edit invoices, we can't search for clients from the clients dropdown


### What
- With this PR, we can search for clients on generate & edit invoices from the clients dropdown.

### Before

https://user-images.githubusercontent.com/52771571/230408664-eef340c2-621c-4222-8c8d-6f3c28191fcb.mov


### After

https://user-images.githubusercontent.com/52771571/230408228-d7cb8233-3640-46d1-8753-011285fa235d.mov

