### PR TITLE
Added logic to reset bundle config without arguments

### DIFF
--- a/scripts/ci/rspec.sh
+++ b/scripts/ci/rspec.sh
@@ -8,3 +8,4 @@ bin/yarn install
 bin/rails db:create
 bin/rails db:migrate
 bundle exec rspec --color --exclude-pattern "spec/system/**/*.rb"
+bundle config set --local without ''

--- a/scripts/ci/rubocop.sh
+++ b/scripts/ci/rubocop.sh
@@ -6,3 +6,4 @@ bundle config set --local with 'test'
 bundle config set --local without 'development production ci'
 bundle install
 bundle exec rubocop
+bundle config set --local without ''

--- a/scripts/ci/setup.sh
+++ b/scripts/ci/setup.sh
@@ -8,3 +8,4 @@ bundle config set --local without 'development production ci'
 yarn install
 
 bundle exec rake db:reset
+bundle config set --local without ''

--- a/scripts/ci/system_spec.sh
+++ b/scripts/ci/system_spec.sh
@@ -10,3 +10,4 @@ bin/rails db:migrate
 bin/rails assets:precompile
 
 bundle exec rspec --color spec/system/
+bundle config set --local without ''


### PR DESCRIPTION
What changed:

- Resets the bundle config without argument after running each scripts in CI

Why:

Currently, CI is failing in Buildkite as some environments are set in both with and without arguments

```
Setting `with` to [:ci] failed:
- a group cannot be in both `with` & `without` simultaneously
- `without` is current set to [:development, :production, :ci]
- the `ci` groups conflict
```