### PR TITLE
Default organisation logo added

### DIFF
--- a/app/javascript/src/StyledComponents/Avatar.tsx
+++ b/app/javascript/src/StyledComponents/Avatar.tsx
@@ -9,29 +9,32 @@ type AvatarProps = {
   classNameImg?: string;
   classNameInitials?: string;
   classNameInitialsWrapper?: string;
+  initialsLetterCount?: number;
+  size?: string;
 };
 
 const Avatar = ({
   url = "",
   name = "",
+  size = "md:h-10 md:w-10 h-6 w-6",
   classNameImg = "",
   classNameInitials = "",
   classNameInitialsWrapper = "",
+  initialsLetterCount = 2,
 }: AvatarProps) => {
   const [initials, setInitials] = useState<string>(null);
-  const DEFAULT_STYLE_IMAGE =
-    "inline-block md:h-10 md:w-10 h-8 w-8 rounded-full";
+  const DEFAULT_STYLE_IMAGE = "inline-block rounded-full";
 
   const DEFAULT_STYLE_INITIALS =
     "md:text-xl text-xs md:font-medium font-light leading-none text-white";
 
   const DEFAULT_STYLE_INITIALS_WRAPPER =
-    "inline-flex md:h-10 md:w-10 h-6 w-6 rounded-full items-center justify-center bg-gray-500";
+    "inline-flex rounded-full items-center justify-center bg-gray-500";
 
   const getInitials = () => {
     if (name) {
       const parts = name.match(/\b(\w)/g);
-      const initials = parts.join("").slice(0, 2);
+      const initials = parts.join("").slice(0, initialsLetterCount);
       setInitials(initials.toUpperCase());
     }
   };
@@ -42,7 +45,7 @@ const Avatar = ({
     return (
       <img
         alt="profile_pic"
-        className={classnames(DEFAULT_STYLE_IMAGE, classNameImg)}
+        className={classnames(DEFAULT_STYLE_IMAGE, size, classNameImg)}
         id="logo"
         src={url}
       />
@@ -55,6 +58,7 @@ const Avatar = ({
         <span
           className={classnames(
             DEFAULT_STYLE_INITIALS_WRAPPER,
+            size,
             classNameInitialsWrapper
           )}
         >
@@ -71,7 +75,7 @@ const Avatar = ({
   return (
     <img
       alt="avatar"
-      className={classnames(DEFAULT_STYLE_IMAGE, classNameImg)}
+      className={classnames(DEFAULT_STYLE_IMAGE, size, classNameImg)}
       src={NavAvatarSVG}
     />
   );

--- a/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
+++ b/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { Avatar } from "StyledComponents";
+
 const CompanyInfo = ({ company, logo = "" }) => {
   const phoneNumber = company?.phoneNumber || company?.phone_number;
   const { address_line_1, address_line_2, city, state, country, pin } =
@@ -8,9 +10,14 @@ const CompanyInfo = ({ company, logo = "" }) => {
   return (
     <div className="flex h-24 items-center justify-between border-b border-miru-gray-400 p-4 pb-2 lg:h-40 lg:p-10">
       <div className="flex h-full items-center">
-        <img
-          className="mr-2 h-10 w-10 rounded-full lg:mr-5 lg:h-20 lg:w-20"
-          src={company.logo ? company.logo : logo}
+        <Avatar
+          classNameImg="lg:mr-5"
+          classNameInitials="lg:text-5xl font-bold capitalize text-white"
+          classNameInitialsWrapper="lg:mr-5 bg-miru-gray-1000 "
+          initialsLetterCount={1}
+          name={company.name}
+          size="h-10 w-10 lg:h-20 lg:w-20"
+          url={company.logo || logo}
         />
         <div className="text-center md:text-left lg:mt-2">
           <p className="text-xl font-bold leading-7 text-miru-dark-purple-1000 lg:text-3xl">

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -88,7 +88,15 @@ const UserActions = setVisiblity => {
           key={workspace.id}
           onClick={() => handleSwitch(workspace.id)}
         >
-          <Avatar classNameImg="lg:w-6 lg:h-6 mr-4" url={workspace.logo} />
+          <Avatar
+            classNameImg="lg:mr-5"
+            classNameInitials="lg:text-xs font-bold capitalize text-white"
+            classNameInitialsWrapper="lg:mr-5 bg-miru-gray-1000 "
+            initialsLetterCount={1}
+            name={currentWorkspace.name}
+            size="w-6 h-6"
+            url={currentWorkspace.logo}
+          />
           {workspace.name}
         </li>
       ))}
@@ -136,7 +144,12 @@ const UserActions = setVisiblity => {
             onMouseEnter={handleTooltip}
           >
             <Avatar
-              classNameImg="lg:w-6 lg:h-6 mr-4"
+              classNameImg="lg:mr-5"
+              classNameInitials="lg:text-xs font-bold capitalize text-white"
+              classNameInitialsWrapper="lg:mr-5 bg-miru-gray-1000 "
+              initialsLetterCount={1}
+              name={currentWorkspace.name}
+              size="w-6 h-6"
               url={currentWorkspace.logo}
             />
             <span>{currentWorkspace.name}</span>

--- a/app/javascript/src/components/Profile/Organization/Details/StaticPage.tsx
+++ b/app/javascript/src/components/Profile/Organization/Details/StaticPage.tsx
@@ -9,6 +9,7 @@ import {
   PhoneIcon,
   CalendarIcon,
 } from "miruIcons";
+import { Avatar } from "StyledComponents";
 
 dayjs.extend(customParseFormat);
 
@@ -68,13 +69,15 @@ const StaticPage = ({
       </div>
       <div className="w-72">
         <div className="flex h-120 w-30 flex-col items-center justify-center rounded border-miru-dark-purple-100 px-2 text-center text-xs">
-          {logoUrl ? (
-            <img alt="org_logo" className="h-full min-w-full" src={logoUrl} />
-          ) : (
-            <div className="flex h-120 w-30 items-center justify-center rounded-full bg-miru-gray-1000 text-5xl font-bold capitalize text-white">
-              {companyName?.substring(0, 1)}
-            </div>
-          )}
+          <Avatar
+            classNameImg="h-full min-w-full"
+            classNameInitials="lg:text-5xl lg:font-bold capitalize text-white"
+            classNameInitialsWrapper="bg-miru-gray-1000"
+            initialsLetterCount={1}
+            name={companyName}
+            size="h-10 w-10 lg:h-30 lg:w-30"
+            url={logoUrl}
+          />
         </div>
         <div className="mt-3 flex px-2">
           <div className="flex w-6/12 flex-col">


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Show-default-image-or-placeholder-image-on-invoices-when-image-is-not-attached-to-an-org-e6f5c2374c284bffafc6809d6fd8a5ab?pvs=4
### **What :**
- Updated the Avatar common component so that it can be used as an organization logo as well.
- Replaced normal img tag with Avatar component. 
### **Why :**
- Bug fix 
- Earlier a broken image was being displayed, If an image was not attached to the org detail.
### **Preview :**
Before:
<img width="1792" alt="Screenshot 2023-04-17 at 7 33 01 PM (1)" src="https://user-images.githubusercontent.com/72149587/232752952-dede8abe-0d3d-4e7c-aa69-8d03abaac527.png">

After:
<img width="1406" alt="Screenshot 2023-04-18 at 4 11 17 PM" src="https://user-images.githubusercontent.com/72149587/232753197-4b2eb772-c824-4abf-afb4-6fc9053c8561.png">

### **Todos** (for testing):
