### PR TITLE
Fix: Duplicate entry is added to the old date

### DIFF
--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -71,7 +71,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     sendGAPageView();
     fetchTimeTrackingData();
     !isDesktop && setView("day");
-  }, []);
+  }, [entryList]);
 
   const fetchTimeTrackingData = async () => {
     try {

--- a/spec/system/time_tracking/day_view_spec.rb
+++ b/spec/system/time_tracking/day_view_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Time Tracking - day view", type: :system do
   let!(:project) { create(:project, client:) }
   let(:admin) { create(:user, current_workspace_id: company.id) }
   let(:employee) { create(:user, current_workspace_id: company.id) }
+  let(:user_two) { create(:user, current_workspace_id: company.id) }
+  let(:employment_two) { create(:employment, company:, user: user_two) }
+  let(:project_member_two) { create(:project_member, user: user_two, project:) }
 
   context "when user is admin" do
     before do
@@ -76,9 +79,6 @@ RSpec.describe "Time Tracking - day view", type: :system do
     end
 
     it "can view other users entry" do
-      user_two = create(:user, current_workspace_id: company.id)
-      create(:employment, company:, user: user_two)
-      create(:project_member, user: user_two, project:)
       time_entry = create(:timesheet_entry, user: user_two, project:)
       with_forgery_protection do
         visit "time-tracking"


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Duplicate-entry-is-added-to-the-old-date-fc48c1903f42420c87f166571bfd0975)

## Description
- Duplicate entry was being added to the old date after moving the entry to another date.

## Preview

https://user-images.githubusercontent.com/57438322/233572573-0b2e8613-8f44-4cb0-b6c2-8bd530d909e3.mp4

