### PR TITLE
Create address for new users

### DIFF
--- a/app/javascript/src/apis/profile.ts
+++ b/app/javascript/src/apis/profile.ts
@@ -8,6 +8,9 @@ const getAddress = id => axios.get(`/users/${id}/addresses`);
 
 const update = payload => axios.put(`${path}`, payload);
 
+const createAddress = (userId, payload) =>
+  axios.post(`/users/${userId}/addresses`, payload);
+
 const updateAddress = (userId, addressId, payload) =>
   axios.put(`/users/${userId}/addresses/${addressId}`, payload);
 
@@ -19,6 +22,7 @@ const profileApi = {
   removeAvatar,
   getAddress,
   updateAddress,
+  createAddress,
 };
 
 export default profileApi;

--- a/app/javascript/src/apis/teams.ts
+++ b/app/javascript/src/apis/teams.ts
@@ -6,10 +6,12 @@ const updateUser = (userId, payload) =>
   axios.put(`team/${userId}/details`, payload);
 
 const getAddress = async userId => axios.get(`users/${userId}/addresses`);
+const createAddress = (userId, payload) =>
+  axios.post(`/users/${userId}/addresses`, payload);
 
 const updateAddress = (userId, addrId, payload) =>
   axios.put(`users/${userId}/addresses/${addrId}`, payload);
 
-const teamsApi = { get, getAddress, updateUser, updateAddress };
+const teamsApi = { get, getAddress, updateUser, updateAddress, createAddress };
 
 export default teamsApi;

--- a/app/javascript/src/components/Profile/UserDetail/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/Edit/index.tsx
@@ -90,7 +90,7 @@ const UserDetailsEdit = () => {
 
     const userObj = teamsMapper(data.data.user, addressData.data.addresses[0]);
     setUserState("profileSettings", userObj);
-    if (userObj.addresses.address_type.length > 0) {
+    if (userObj.addresses?.address_type?.length > 0) {
       setAddrType(
         addressOptions.find(
           item => item.value === userObj.addresses.address_type
@@ -235,13 +235,30 @@ const UserDetailsEdit = () => {
         userSchema["password_confirmation"] = profileSettings.confirmPassword;
       }
 
+      const payload = {
+        address: {
+          address_line_1: profileSettings.addresses.address_line_1,
+          address_line_2: profileSettings.addresses.address_line_2,
+          address_type: profileSettings.addresses.address_type,
+          city: profileSettings.addresses.city,
+          state: profileSettings.addresses.state,
+          country: profileSettings.addresses.country,
+          pin: profileSettings.addresses.pin,
+        },
+      };
+
       await profileApi.update({
         user: userSchema,
       });
 
-      await profileApi.updateAddress(userId, addrId, {
-        address: { ...profileSettings.addresses },
-      });
+      if (addrId) {
+        await profileApi.updateAddress(userId, addrId, {
+          address: { ...profileSettings.addresses },
+        });
+      } else {
+        await profileApi.createAddress(userId, payload);
+      }
+
       setErrDetails(initialErrState);
       navigate(`/profile/edit`, { replace: true });
     } catch (err) {

--- a/app/javascript/src/components/Team/Details/PersonalDetails/Edit/index.tsx
+++ b/app/javascript/src/components/Team/Details/PersonalDetails/Edit/index.tsx
@@ -81,7 +81,7 @@ const EmploymentDetails = () => {
     const addRes = await teamsApi.getAddress(memberId);
     const teamsObj = teamsMapper(res.data, addRes.data.addresses[0]);
     updateDetails("personal", teamsObj);
-    if (teamsObj.addresses.address_type.length > 0) {
+    if (teamsObj.addresses?.address_type?.length > 0) {
       setAddrType(
         addressOptions.find(
           item => item.value === teamsObj.addresses.address_type
@@ -222,9 +222,25 @@ const EmploymentDetails = () => {
         },
       });
 
-      await teamsApi.updateAddress(memberId, addrId, {
-        address: { ...personalDetails.addresses },
-      });
+      const payload = {
+        address: {
+          address_line_1: personalDetails.addresses.address_line_1,
+          address_line_2: personalDetails.addresses.address_line_2,
+          address_type: personalDetails.addresses.address_type,
+          city: personalDetails.addresses.city,
+          state: personalDetails.addresses.state,
+          country: personalDetails.addresses.country,
+          pin: personalDetails.addresses.pin,
+        },
+      };
+      if (addrId) {
+        await teamsApi.updateAddress(memberId, addrId, {
+          address: { ...personalDetails.addresses },
+        });
+      } else {
+        await teamsApi.createAddress(memberId, payload);
+      }
+
       setErrDetails(initialErrState);
       navigate(`/team/${memberId}`, { replace: true });
     } catch (err) {


### PR DESCRIPTION
What
- Create an Address for new signed-up/invited users.

Why
- We were not creating addresses for newly signed-up users and instead trying to update the address and it was throwing error