### PR TITLE
Fix: Show payment success page after paying for an invoice

### DIFF
--- a/app/controllers/invoices/payments_controller.rb
+++ b/app/controllers/invoices/payments_controller.rb
@@ -8,7 +8,7 @@ class Invoices::PaymentsController < ApplicationController
 
   def new
     session = @invoice.create_checkout_session!(
-      success_url: internal_api_v1_invoices_success_url(@invoice),
+      success_url: request.base_url + "/invoices/#{@invoice.id}/payments/success",
       cancel_url: cancel_invoice_payments_url(@invoice)
     )
 
@@ -27,7 +27,7 @@ class Invoices::PaymentsController < ApplicationController
 
     def ensure_invoice_unpaid
       if @invoice.paid?
-        redirect_to internal_api_v1_invoices_success_url(@invoice)
+        redirect_to request.base_url + "/invoices/#{@invoice.id}/payments/success"
       end
     end
 end

--- a/spec/requests/invoices/payments_controller_spec.rb
+++ b/spec/requests/invoices/payments_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Invoices::PaymentsController, type: :request do
   describe "GET new", :vcr do
     subject { send_request :get, new_invoice_payment_path(params) }
 
-    let(:success_path) { internal_api_v1_invoices_success_path(invoice.id) }
+    let(:success_path) { "/invoices/#{invoice.id}/payments/success" }
     let(:checkout_response) { Struct.new(:url).new(success_path) }
 
     before do
@@ -73,12 +73,12 @@ RSpec.describe Invoices::PaymentsController, type: :request do
       stripe_connected_account.update_columns(account_id: account.id)
 
       invoice.create_checkout_session!(
-        success_url: internal_api_v1_invoices_success_url(invoice),
+        success_url: "https://example.com/invoices/#{invoice.id}/payments/success",
         cancel_url: cancel_invoice_payments_url(invoice)
       )
     end
 
-    subject { send_request :get, internal_api_v1_invoices_success_path(invoice) }
+    subject { send_request :get, "/invoices/#{invoice.id}/payments/success" }
 
     it "doesn't mark invoice status as paid" do
       expect(invoice.status).not_to eq "paid"

--- a/spec/services/invoice_payment/stripe_payment_intent_spec.rb
+++ b/spec/services/invoice_payment/stripe_payment_intent_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe InvoicePayment::StripePaymentIntent do
 
     before(:each, :checkout_session) do
       @checkout = invoice.create_checkout_session!(
-        success_url: internal_api_v1_invoices_success_url(invoice, host: "https://example.com"),
+        success_url: "https://example.com/invoices/#{invoice.id}/payments/success",
         cancel_url: cancel_invoice_payments_url(invoice, host: "https://example.com")
       )
     end


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Show-payment-success-page-after-paying-for-an-invoice-2b613a174ce240e98e7980d62e718dc2)

## Description
- Fixed the issue where a JSON response was shown on the screen instead of redirecting to the payments success page upon payment success.

## Preview

https://user-images.githubusercontent.com/57438322/233999298-8e273cd9-bba5-44f9-bcb8-75140c7fb8c5.mp4
