### PR TITLE
Fix: Client list responsive page.

### DIFF
--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -253,7 +253,7 @@ const Clients = ({ isAdminUser }) => {
         setnewClient={setClient}
       />
       <div>
-        {isAdminUser && (
+        {isAdminUser && isDesktop && (
           <div className="bg-miru-gray-100 py-10 px-10">
             <div className="flex justify-end">
               <select


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Mobile-Responsive-Clients-list-page-aad6ea8bdf474861a14a537b88a5ede6)

## Description
- Remove showing of charts for the clients' list page on the mobile view.

## Preview
<img width="300" alt="Screenshot 2023-04-24 at 7 02 14 PM" src="https://user-images.githubusercontent.com/57438322/234011560-5554269c-72ca-4f5a-9626-28cf8c92e95f.png">
