### PR TITLE
Fixed total hours calculation on time tracking header

### DIFF
--- a/app/javascript/src/components/TimeTracking/Header.tsx
+++ b/app/javascript/src/components/TimeTracking/Header.tsx
@@ -123,6 +123,7 @@ const Header = ({
       return weeklyTotalHours;
     }
   };
+
   return (
     <div className="flex w-full items-center justify-between bg-miru-han-purple-1000 px-3 py-3 text-white lg:h-10 lg:p-2">
       <button

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -115,7 +115,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     if (view === "month") return;
     parseWeeklyViewData();
     calculateTotalHours();
-  }, [weekDay, entryList]);
+  }, [weekDay, entryList, view]);
 
   useEffect(() => {
     setIsWeeklyEditing(false);


### PR DESCRIPTION
### Notion
https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=b34eff1be48e4f55889c57dad6943604&pm=s

### Why
- The total hour's calculation on the time tracking header is not consistent. Whenever we change the view from month to week or day the total hour's calculation either goes wrong or calculates to blank.

### What
- With this PR, whenever a user changes the view from month to week or day or date change, an useEffect will run the total hours calculation.

### Before

https://user-images.githubusercontent.com/52771571/234158925-fbfae6b5-0574-4db3-be93-c88f9472b5fa.mov



### After


https://user-images.githubusercontent.com/52771571/234158340-a3ff513a-ad94-42cb-8b25-0a5aed50b11a.mov

