### PR TITLE
Sign up page alignment

### DIFF
--- a/app/javascript/src/common/FormikFields/InputField/index.tsx
+++ b/app/javascript/src/common/FormikFields/InputField/index.tsx
@@ -67,7 +67,7 @@ const InputField = ({
     <div
       className={classNames(
         defaultWrapperClassName,
-        "field relative mb-6 xsm:mb-2",
+        "field relative mb-2 xsm:mb-6",
         wrapperClassName
       )}
     >

--- a/app/javascript/src/components/Authentication/FooterLinks/index.tsx
+++ b/app/javascript/src/components/Authentication/FooterLinks/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import FOOTER_LINKS from "./utils";
 
 const FooterLinks = () => (
-  <div className="absolute bottom-0 mx-auto mb-4 w-4/5 md:mb-10 md:w-full">
+  <div className="mx-auto mt-auto mb-4 w-4/5 md:mb-10 md:w-full">
     <ul className="flex items-center justify-center">
       {FOOTER_LINKS?.map((footerLink, i) => (
         <li className="flex items-center" key={footerLink.text}>

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -60,7 +60,7 @@ const SignInForm = () => {
     !(values.email?.trim() && values?.password?.trim());
 
   return (
-    <div className="relative w-full px-8 pt-10 pb-4 md:px-0 md:pt-36 lg:w-1/2">
+    <div className="relative flex w-full flex-col items-center justify-center px-8 pt-5vh md:px-0 lg:w-1/2">
       <div className="d-block lg:hidden">
         <a href={MIRU_APP_URL} rel="noreferrer noopener">
           <img
@@ -70,11 +70,11 @@ const SignInForm = () => {
           />
         </a>
       </div>
-      <div className="mx-auto md:w-1/2 lg:w-352">
+      <div className="mx-auto mt-auto md:w-1/2 lg:w-352">
         <h1 className="text-center font-manrope text-2xl font-extrabold text-miru-han-purple-1000 md:text-3xl lg:text-4.5xl">
           Welcome back!
         </h1>
-        <div className="pt-10 lg:pt-20">
+        <div className="pt-2vh lg:pt-5vh">
           <Formik
             initialValues={signInFormInitialValues}
             validateOnBlur={false}

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -58,8 +58,8 @@ const SignUpForm = () => {
     );
 
   return (
-    <div className="relative w-full px-8 pt-10 pb-4 md:px-0 md:pt-36 lg:w-1/2">
-      <div className="mx-auto min-h-full md:w-1/2 lg:w-352">
+    <div className="relative flex w-full flex-col items-center justify-center px-8 pb-4 md:px-0 lg:w-1/2">
+      <div className="mx-auto mt-auto md:w-1/2 lg:w-352">
         <div className="d-block lg:hidden">
           <a href={MIRU_APP_URL} rel="noreferrer noopener">
             <img
@@ -72,7 +72,7 @@ const SignUpForm = () => {
         <h1 className="text-center font-manrope text-2xl font-extrabold text-miru-han-purple-1000 md:text-3xl lg:text-4.5xl">
           Signup for Miru
         </h1>
-        <div className="pt-10 lg:pt-20">
+        <div className="pt-2vh lg:pt-5vh">
           <Formik
             initialValues={signUpFormInitialValues}
             validateOnBlur={false}
@@ -179,7 +179,7 @@ const SignUpForm = () => {
                       Sign Up
                     </button>
                   </div>
-                  <div className="relative flex items-center py-7">
+                  <div className="relative flex items-center py-2vh">
                     <div className="flex-grow border-t border-miru-gray-1000" />
                     <span className="mx-4 flex-shrink text-xs text-miru-dark-purple-1000">
                       or
@@ -220,7 +220,7 @@ const SignUpForm = () => {
               )}
             </Formik>
           </div>
-          <p className="pt-5 pb-10 text-center font-manrope text-xs font-normal not-italic text-miru-dark-purple-1000">
+          <p className="py-2vh text-center font-manrope text-xs font-normal not-italic text-miru-dark-purple-1000">
             Already have an account?&nbsp;
             <span className="form__link inline cursor-pointer">
               <a href={Paths.LOGIN}>

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -58,7 +58,7 @@ const SignUpForm = () => {
     );
 
   return (
-    <div className="relative flex w-full flex-col items-center justify-center px-8 pb-4 md:px-0 lg:w-1/2">
+    <div className="relative flex w-full flex-col items-center justify-center px-8 pt-5vh md:px-0 lg:w-1/2">
       <div className="mx-auto mt-auto md:w-1/2 lg:w-352">
         <div className="d-block lg:hidden">
           <a href={MIRU_APP_URL} rel="noreferrer noopener">

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -105,13 +105,13 @@ const UserActions = setVisiblity => {
 
   return (
     <ul className="w-full">
-      <li className="flex border-b border-miru-gray-100 px-6 last:border-b-0 hover:bg-miru-gray-100 md:border-b-0 lg:justify-start">
+      <li className="flex border-b border-miru-gray-100 last:border-b-0 hover:bg-miru-gray-100 lg:justify-start lg:border-b-0">
         <NavLink
           to={isDesktop ? "/profile/edit" : "/profile/edit/option"}
           className={({ isActive }) =>
             isActive
               ? activeClassName
-              : "flex w-full items-start justify-start py-3 hover:bg-miru-gray-100"
+              : "flex w-full items-start justify-start py-3 px-6 hover:bg-miru-gray-100"
           }
           onClick={() => {
             if (!isDesktop) {
@@ -124,7 +124,7 @@ const UserActions = setVisiblity => {
         </NavLink>
       </li>
       <li
-        className="flex cursor-pointer items-start  justify-start border-b border-miru-gray-100 px-6 last:border-b-0 hover:bg-miru-gray-100 md:border-b-0"
+        className="flex cursor-pointer border-b border-miru-gray-100 px-6 py-3 last:border-b-0 hover:bg-miru-gray-100 lg:justify-start lg:border-b-0"
         id="logoutBtn"
         onClick={handleLogout}
       >
@@ -133,7 +133,7 @@ const UserActions = setVisiblity => {
       </li>
       <Tooltip content={currentWorkspace.name} show={showToolTip}>
         <li
-          className="flex w-full cursor-pointer items-center justify-between py-4  px-6 text-sm font-bold leading-4 hover:bg-miru-gray-100"
+          className="flex w-full cursor-pointer items-center justify-between py-3  px-6 text-sm font-bold leading-4 hover:bg-miru-gray-100"
           onClick={() => {
             setShowWorkSpaceList(true);
           }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
     },
     fontSize: {
       xsm: ".5625em",
-      xxs: "0.625rem",//10px
+      xxs: "0.625rem", //10px
       xs: ".75rem",
       sm: ".875rem",
       tiny: ".875rem",
@@ -27,7 +27,7 @@ module.exports = {
     },
     letterSpacing: {
       widest: "0.125em",
-      semiWidest: "0.09375",//1.5px
+      semiWidest: "0.09375", //1.5px
       wider: ".05em",
       normal: "0em",
       "xs-widest": "0.166667em", // 2px when font-size 12px
@@ -63,7 +63,7 @@ module.exports = {
         352: "22rem", //352px
         480: "30rem", //480px
         18: "18%",
-        72: "72%"
+        72: "72%",
       },
       minWidth: {
         12: "12px",
@@ -168,7 +168,7 @@ module.exports = {
         },
         "miru-chart-blue": {
           600: "#0E79B2",
-          1000: "#68AEAA"
+          1000: "#68AEAA",
         },
         "miru-chart-pink": {
           600: "#BF1363",
@@ -209,7 +209,7 @@ module.exports = {
         129: "33rem",
         138: "34.5rem",
         160: "40rem",
-        "1/5": "20%"
+        "1/5": "20%",
       },
       padding: {
         "36/100": "36.66666%",
@@ -218,6 +218,9 @@ module.exports = {
         "26/100": "26.66666%",
         "20/100": "20%",
         "10/100": "10%",
+        "10vh": "10vh",
+        "5vh": "5vh",
+        "2vh": "2vh",
       },
       zIndex: {
         "negative-1": "-1",


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Bugs-When-the-signup-page-loads-658fed6d27444e2ba1144d4d7b207ff2?pvs=4

### **What :**
- Sign-up content is now aligned to the center, no need to scroll down to see the sign-up with the google option.
- Navbar UI issues fixed.
### **Why :**
- The alignment of the page was not right. earlier scrolling was needed to view all the content.
- Padding and border left was incorrect for logout and settings option
### **Preview :**
Before:
<img width="1792" alt="Screenshot 2023-04-25 at 2 18 46 PM" src="https://user-images.githubusercontent.com/72149587/234226314-f2775876-899e-49a2-ba36-d2b4cdebb92b.png">


<img width="331" alt="Screenshot 2023-04-25 at 10 57 55 AM" src="https://user-images.githubusercontent.com/72149587/234182433-754ca80c-34e2-470d-9650-958120e6c620.png">

After:

<img width="1792" alt="Screenshot 2023-04-25 at 2 06 24 PM" src="https://user-images.githubusercontent.com/72149587/234222858-03139a9f-f6c5-4ec5-b77a-41d4712b4ef3.png">

<img width="1792" alt="Screenshot 2023-04-25 at 2 08 40 PM" src="https://user-images.githubusercontent.com/72149587/234223071-e99b5953-5987-4fab-9555-8f2171887680.png">

<img width="367" alt="Screenshot 2023-04-25 at 2 13 14 PM" src="https://user-images.githubusercontent.com/72149587/234223345-4df0892e-1fb3-433b-8718-5cdd01220e79.png">


### **Todos** (for testing):
- Tested on responsive screens as well as desktop screens with different height ports.