### PR TITLE
Fix country code in seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,7 +58,7 @@ microsoft_client.addresses.create!(
   city: "Brooklyn",
   state: "NY",
   pin: "12238",
-  country: "USA"
+  country: "US"
 )
 
 project_office_com = microsoft_client.projects.create!(name: "Office.com", description: "Office 365", billable: true)


### PR DESCRIPTION
What
- Used "US" as the country in seed data for the client.

Why
- It was breaking the app

Before
- https://www.loom.com/share/8957ba319f4e4817b2573fde2d3afe6c

After
- https://www.loom.com/share/a28aaf0fb1ba444690ab37a9b9b97301