### PR TITLE
Remove duplicate country on address on invoice pages

### DIFF
--- a/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
+++ b/app/javascript/src/components/Invoices/common/CompanyInfo/index.tsx
@@ -32,7 +32,6 @@ const CompanyInfo = ({ company, logo = "" }) => {
         <p className="whitespace-pre">
           {`${address_line_1},\n ${address_line_2},\n ${city}, ${state}, ${country},\n ${pin}`}
         </p>
-        <p>{country}</p>
       </div>
     </div>
   );

--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -25,7 +25,6 @@ html {
     </div>
     <div class="mt-2 font-normal text-base text-right text-miru-dark-purple-1000 w-40">
       <p><%=invoice.company.formatted_address%></p>
-      <p><%=invoice.company.country%></p>
     </div>
   </div>
 


### PR DESCRIPTION
What
- Removed duplicate country names appearing on invoices pages

Before
- 
<img width="1204" alt="Screenshot 2023-04-27 at 10 38 25 AM" src="https://user-images.githubusercontent.com/18750194/234764657-acdea57e-d072-4a30-9b5e-6360f2ff52fb.png">

After
<img width="848" alt="Screenshot 2023-04-27 at 10 38 57 AM" src="https://user-images.githubusercontent.com/18750194/234764725-211d3ef0-6644-49fc-8bfb-9084b9996ce2.png">
