### PR TITLE
Fix camelcase on team's email column

### DIFF
--- a/app/javascript/src/components/Team/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Team/List/Table/TableRow.tsx
@@ -93,8 +93,8 @@ const TableRow = ({ item }) => {
         className="border-b border-miru-gray-200 last:border-0"
         onClick={handleRowClick}
       >
-        <td className="table__data p-6 capitalize">
-          <dl className="flex items-center justify-between text-sm font-semibold text-miru-dark-purple-1000">
+        <td className="table__data p-6">
+          <dl className="flex items-center justify-between text-sm font-semibold capitalize text-miru-dark-purple-1000">
             <dt>{name}</dt>
           </dl>
           <dl className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs font-medium text-miru-dark-purple-400">


### PR DESCRIPTION
What
- Make the email in the normal case for the team's page in the mobile view

Preview:
<img width="512" alt="Screenshot 2023-04-27 at 2 13 31 PM" src="https://user-images.githubusercontent.com/18750194/234808949-df12bba5-593a-415c-8d88-516a3853203a.png">
