### PR TITLE
Fix undefined address on personal details

### DIFF
--- a/app/javascript/src/components/Team/Details/PersonalDetails/MobilePersonalDetails.tsx
+++ b/app/javascript/src/components/Team/Details/PersonalDetails/MobilePersonalDetails.tsx
@@ -66,12 +66,14 @@ const MobilePersonalDetails = ({
           {addresses && (
             <InfoDescription
               title="Address"
-              description={`${addresses.address_line_1},
-                  ${addresses.address_line_2}
-                  ${addresses.city},
-                  ${addresses.state},
-                  ${addresses.country} -
-                  ${addresses.pin}`}
+              description={`${
+                addresses.address_line_1 ? `${addresses.address_line_1},` : ""
+              }
+            ${addresses.address_line_2 ? `${addresses.address_line_2},` : ""}
+            ${addresses.city ? `${addresses.city},` : ""}
+            ${addresses.state ? `${addresses.state},` : ""}
+            ${addresses.country ? `${addresses.country} -` : ""}
+            ${addresses.pin ? addresses.pin : ""}`}
             />
           )}
         </div>


### PR DESCRIPTION
What
- Fixed undefined address in case of the newly invited user on the team's page mobile screen.

Before
- 
![Screenshot 2023-04-27 at 1 53 36 PM](https://user-images.githubusercontent.com/18750194/234818438-8ee02550-5d64-4ce9-b35d-8a238f764f5d.png)

After
-
<img width="643" alt="Screenshot 2023-04-27 at 2 49 49 PM" src="https://user-images.githubusercontent.com/18750194/234818536-3d4b3b9e-a2d4-42de-bce4-73b51b29184a.png">
