### PR TITLE
Empty state message updated

### DIFF
--- a/app/javascript/src/components/Reports/AccountsAgingReport/Container/index.tsx
+++ b/app/javascript/src/components/Reports/AccountsAgingReport/Container/index.tsx
@@ -44,7 +44,7 @@ const Container = () => {
       Message={
         accountsAgingReport.filterCounter > 0
           ? "No results match current filters. Try removing some filters."
-          : "There are no clients added yet. Please go to Clients to add your first client."
+          : "No data found. We will display relevant data once it becomes available"
       }
     />
   );

--- a/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
@@ -109,7 +109,7 @@ const Container = () => {
       Message={
         revenueByClientReport.filterCounter > 0
           ? "No results match current filters. Try removing some filters."
-          : "There are no clients added yet. Please go to Clients to add your first client "
+          : " No data found. We will display relevant data once it becomes available"
       }
     />
   );


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Empty-state-design-for-revenue-and-accounts-aging-report-6c9f6b0dcee0428c8df84fbdb5b61dd4?pvs=4
### **What :**
- Empty state message updated on revenue reports and accounts aging report. 
### **Why :**
- We were displaying "no clients present" even if we have clients present. 
(RCA: Reports API is sending only those clients to frontend who have projects created.)
### **Preview :**
<img width="1423" alt="Screenshot 2023-04-28 at 10 58 16 AM" src="https://user-images.githubusercontent.com/72149587/235061990-75f36bc5-af8d-4523-a016-51189c799479.png">

<img width="1396" alt="Screenshot 2023-04-28 at 10 58 27 AM" src="https://user-images.githubusercontent.com/72149587/235062010-c6730dc3-8128-4e96-974f-4da87e229e67.png">

### **Todos** (for testing):
- Checked if updated messages is displayed on empty state.