### PR TITLE
Fixed data migration issue

### DIFF
--- a/db/data/20220628121346_create_invitations.rb
+++ b/db/data/20220628121346_create_invitations.rb
@@ -4,6 +4,8 @@ require_relative("./verifiers/invitation_verifier.rb")
 
 class CreateInvitations < ActiveRecord::Migration[7.0]
   def up
+    return unless User.column_names.include?(:invitation_created_at)
+
     Invitation.skip_callback(:validation, :before, :set_expired_at)
     Invitation.skip_callback(:validation, :before, :set_token)
     Invitation.skip_callback(:commit, :after, :send_invitation_mail)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_09_090124) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "devices", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "company_id", null: false


### PR DESCRIPTION
What changed:

Added a condition that checks if the column is present before running the data migration.

Why:

Seed is failing when the column is already deleted