### PR TITLE
Fix responsive issues in project details

### DIFF
--- a/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
@@ -36,6 +36,7 @@ const EditMembersListForm = ({
             ...memberList,
             {
               label: currentMember.name,
+              name: currentMember.name,
               value: currentMember.id,
             },
           ];
@@ -48,8 +49,8 @@ const EditMembersListForm = ({
 
   useEffect(() => {
     if (debouncedSearchQuery && formattedMemberList.length > 0) {
-      const newMemberList = formattedMemberList.filter(client =>
-        client.name.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
+      const newMemberList = formattedMemberList.filter(member =>
+        member.name.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
       );
 
       newMemberList.length > 0
@@ -189,7 +190,7 @@ const EditMembersListForm = ({
                     document.getElementById(member.hourlyRate).focus();
                   }}
                 >
-                  {memberItem.label}
+                  {memberItem.name}
                 </li>
               ))}
             </div>
@@ -245,6 +246,7 @@ const EditMembersListForm = ({
                   label="Rate"
                   moveLabelToRightClassName="right-1"
                   name={member.hourlyRate}
+                  type="number"
                   value={member.hourlyRate}
                   inputBoxClassName={` text-right ${
                     isInvalidRateInputBox(memberIndex)

--- a/app/javascript/src/components/Projects/Details/Mobile/ProjectDetailsForm.tsx
+++ b/app/javascript/src/components/Projects/Details/Mobile/ProjectDetailsForm.tsx
@@ -137,7 +137,7 @@ const ProjectDetailsForm = ({
                           {minToHHMM(member.minutes)}
                         </td>
                         <td className="py-3 text-right text-sm font-medium leading-5 text-miru-dark-purple-1000">
-                          {member.cost}
+                          {currencyFormat(project.currency, member.cost)}
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
Notion
- https://www.notion.so/saeloun/Mobile-responsive-project-details-page-bugs-0344396083784fca93752c3e1ba1f413

What
- Fix searching of team members on mobile view
- Show currency icon on cost field
- Show the number keypad on the rate field on the mobile view