### PR TITLE
Fix: Redirect to invoice page after marking payments as paid

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, useEffect } from "react";
 import dayjs from "dayjs";
 import { currencyFormat, useOutsideClick } from "helpers";
 import { CalendarIcon, SearchIcon } from "miruIcons";
+import { useNavigate } from "react-router-dom";
 import Select, { DropdownIndicatorProps, components } from "react-select";
 import { Badge, MobileMoreOptions } from "StyledComponents";
 
@@ -46,6 +47,8 @@ const PaymentEntryForm = ({
 
   const wrapperSelectRef = useRef(null);
   const wrapperCalendartRef = useRef(null);
+
+  const navigate = useNavigate();
 
   const handleSelectedInvoice = () => {
     if (!invoiceList || invoiceList.length == 0) return;
@@ -112,6 +115,9 @@ const PaymentEntryForm = ({
       setAmount("");
       setNote("");
       setShowManualEntryModal(false);
+      if (invoiceId) {
+        navigate(`/invoices/${invoiceId}`);
+      }
     } catch {
       Toastr.error("Failed to add manual entry");
     }


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Redirect-to-invoice-page-after-marking-payments-as-paid-ebd1dfe5590241aa86f2f1e5e2525a10)

## Description
- Redirect to the invoice page after marking payments as paid

## Preview
Before:

https://user-images.githubusercontent.com/57438322/235937567-47b27934-812d-4c56-944b-282cf2e0deaa.mp4

After:

https://user-images.githubusercontent.com/57438322/235936901-6fe31b2e-598f-4382-b27e-e98d4ad026b5.mp4

