### PR TITLE
Fix: Add close button on Send invoice modal on mobile view.

### DIFF
--- a/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from "react";
 
 import { currencyFormat, useDebounce } from "helpers";
-import { ArrowLeftIcon, DotsThreeVerticalIcon } from "miruIcons";
+import { ArrowLeftIcon, DotsThreeVerticalIcon, XIcon } from "miruIcons";
 import { useNavigate } from "react-router-dom";
 import { Avatar, Badge, Button, Tooltip } from "StyledComponents";
 
@@ -182,6 +182,13 @@ const TableRow = ({
               <div className="flex h-12 w-full items-center justify-center bg-miru-han-purple-1000 px-3 text-white">
                 Send Invoice
               </div>
+              <button
+                className="mr-4 text-miru-gray-1000"
+                type="button"
+                onClick={() => setIsSending(false)}
+              >
+                <XIcon size={16} weight="bold" />
+              </button>
             </div>
             <div className="flex flex-1">
               <SendInvoiceContainer


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Mobile-Add-close-button-on-Send-invoice-modal-28139e02112e4123aa32b7fd6f3a75f3)

## Description
- Added a close button on send invoice modal for the mobile view.

## Preview
Before:
<img width="421" alt="Screenshot 2023-05-04 at 11 28 07 AM" src="https://user-images.githubusercontent.com/57438322/236122841-c5f6c01f-b7ad-416c-bab3-25f4890ac2ce.png">

After:
<img width="413" alt="Screenshot 2023-05-04 at 11 27 24 AM" src="https://user-images.githubusercontent.com/57438322/236122731-d624175f-926e-43bd-a442-b36bbb612983.png">
