### PR TITLE
Fix overflowing client address

### DIFF
--- a/app/javascript/src/components/Invoices/Generate/MobileView/Container/MenuContainer/InvoiceDetails.tsx
+++ b/app/javascript/src/components/Invoices/Generate/MobileView/Container/MenuContainer/InvoiceDetails.tsx
@@ -100,7 +100,7 @@ const InvoiceDetails = ({
                 wrapperClassName="h-full"
                 value={
                   selectedClient && (
-                    <div>
+                    <div className="h-full overflow-y-scroll">
                       <p className="text-sm font-medium text-miru-dark-purple-1000">
                         {selectedClient.label}
                       </p>

--- a/app/javascript/src/components/Invoices/Generate/MobileView/Container/MenuContainer/InvoiceDetails.tsx
+++ b/app/javascript/src/components/Invoices/Generate/MobileView/Container/MenuContainer/InvoiceDetails.tsx
@@ -95,16 +95,16 @@ const InvoiceDetails = ({
             >
               <CustomAdvanceInput
                 id="Billed to"
-                inputBoxClassName="min-h-80"
+                inputBoxClassName="min-h-80 max-h-20v overflow-y-scroll"
                 label="Billed to"
                 wrapperClassName="h-full"
                 value={
                   selectedClient && (
-                    <div className="h-full overflow-y-scroll">
+                    <div>
                       <p className="text-sm font-medium text-miru-dark-purple-1000">
                         {selectedClient.label}
                       </p>
-                      <p className="w-52 text-xs font-medium text-miru-dark-purple-600">
+                      <p className="w-52 py-2 text-xs font-medium text-miru-dark-purple-600">
                         {`${address_line_1}${
                           address_line_2 ? `, ${address_line_2}` : ""
                         }\n ${

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -79,7 +79,7 @@ const ClientSelection = ({
           wrapperClassName="h-full cursor-pointer"
           value={
             isOptionSelected && (
-              <div>
+              <div className="h-full overflow-y-scroll">
                 <p className="text-base font-bold text-miru-dark-purple-1000">
                   {selectedClient.label}
                 </p>


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Client-address-overflows-from-the-billed-to-box-on-invoices-pages-58bc5e184aad4c13a48d41f7f36195c2?pvs=4
### **What :**
- Fixed client address height on invoice page desktop and mobile view. 
### **Why :**
- Earlier the long client address was overflowing the container.
### **Preview :**
Before:
<img width="647" alt="Screenshot 2023-05-08 at 11 37 49 AM" src="https://user-images.githubusercontent.com/72149587/236747035-b143eea2-ec1f-4c80-9e79-c322a0b864f6.png">

After:
<img width="617" alt="Screenshot 2023-05-08 at 11 38 32 AM" src="https://user-images.githubusercontent.com/72149587/236747100-6bcf7ceb-fd78-4475-85ef-29c3a4672b59.png">

Testing: 
- Tested on mobile view also.