### PR TITLE
Default logo for mail view

### DIFF
--- a/app/views/mailers/invoice_mailer/invoice.html.erb
+++ b/app/views/mailers/invoice_mailer/invoice.html.erb
@@ -32,7 +32,11 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% if @company_logo.present? %>
+                <%= image_tag @company_logo, height: 80, width: 80, style: "border-radius: 80px" %>
+            <% else %>
+              <div style="width:80px;height:80px;border-radius: 80px;text-align: center;background: #CDD6DF;font-size: 40px;justify-content:center;display: flex; align-items: center; color:white"><%= @invoice.company.name.slice(0) %></div>
+            <% end %>
           </div>
           <div>
             <span style='font-weight:bold'><%= @invoice.company.name %></span>


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Show-default-image-or-placeholder-image-on-invoices-when-image-is-not-attached-to-an-org-e6f5c2374c284bffafc6809d6fd8a5ab
### **What :**
- Added default client logo for email view.
### **Why :**
- Earlier it was showing broken img
### **Preview :**
Before:
<img width="752" alt="Screenshot 2023-05-08 at 6 21 34 PM" src="https://user-images.githubusercontent.com/72149587/236828948-2f263905-1c40-4c29-b7f7-3284ec142071.png">

After:
<img width="885" alt="Screenshot 2023-05-08 at 6 16 04 PM" src="https://user-images.githubusercontent.com/72149587/236828768-6cfb16c4-3691-4ab7-888a-ec3995cca0c8.png">
