### PR TITLE
Fix: Invalid Date on changing date format to DD-MM-YYYY

### DIFF
--- a/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/utils.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/utils.tsx
@@ -19,8 +19,9 @@ export const emailBody = (invoice: any): string => {
     invoice.amount
   );
 
-  const dueDate =
-    invoice.dueDate || dayjs(invoice.dueDate).format("DD.MM.YYYY");
+  const dueDate = isNaN(Date.parse(invoice.dueDate))
+    ? dayjs(invoice.dueDate).format(invoice.company.dateFormat || "DD.MM.YYYY")
+    : invoice.dueDate;
 
   return `${invoice.company.name} has sent you an invoice (${invoice.invoiceNumber}) for ${formattedAmount} that's due on ${dueDate}.`;
 };

--- a/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/utils.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/SendInvoice/utils.tsx
@@ -19,9 +19,8 @@ export const emailBody = (invoice: any): string => {
     invoice.amount
   );
 
-  const dueDate = dayjs(invoice.dueDate).format(
-    invoice.company.dateFormat || "DD.MM.YYYY"
-  );
+  const dueDate =
+    invoice.dueDate || dayjs(invoice.dueDate).format("DD.MM.YYYY");
 
   return `${invoice.company.name} has sent you an invoice (${invoice.invoiceNumber}) for ${formattedAmount} that's due on ${dueDate}.`;
 };


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Invalid-Date-on-changing-date-format-to-DD-MM-YYYY-b9f26d19368742f6870950e690b9f347)

## Description
- To fix the issue wherein after changing the date format to `DD-MM-YYYY` it showed the date as invalid for some of the invoices.

## Preview
- Could not reproduce it locally, but based on https://github.com/saeloun/miru-web/pull/1124 got to know about the reason why was it happening.

## NOTE
- I've removed formatting the due date from the frontend from the `emailBody` utility file as the date was already coming in as formatted from the backend.