### PR TITLE
Fix spacing b/w roles

### DIFF
--- a/app/javascript/src/components/Team/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Team/List/Table/TableRow.tsx
@@ -34,6 +34,10 @@ const TableRow = ({ item }) => {
     }
   };
 
+  const formattedRole = role
+    .split("_")
+    .map(word => word.charAt(0) + word.slice(1))
+    .join("");
   if (isDesktop) {
     return (
       <tr
@@ -47,7 +51,7 @@ const TableRow = ({ item }) => {
           {email}
         </td>
         <td className="table__data table__text p-6 text-sm font-medium capitalize">
-          {role}
+          {formattedRole}
         </td>
         {isAdminUser && (
           <Fragment>
@@ -102,7 +106,7 @@ const TableRow = ({ item }) => {
           </dl>
         </td>
         <td className="table__data table__text p-6 text-right text-sm font-medium capitalize">
-          {role}
+          {formattedRole}
           {status && (
             <dl className="mt-3 max-h-32 overflow-auto whitespace-pre-wrap break-words">
               <Badge

--- a/app/javascript/src/components/Team/modals/AddEditMember.tsx
+++ b/app/javascript/src/components/Team/modals/AddEditMember.tsx
@@ -247,7 +247,7 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                                   htmlFor="role-3"
                                 >
                                   <i className="custom__radio-text" />
-                                  <span className="text-sm">Book Keeper</span>
+                                  <span className="text-sm">BookKeeper</span>
                                 </label>
                               </div>
                             </div>

--- a/app/javascript/src/components/Team/modals/AddEditMember.tsx
+++ b/app/javascript/src/components/Team/modals/AddEditMember.tsx
@@ -247,7 +247,7 @@ const EditClient = ({ user = {}, isEdit = false }: Props) => {
                                   htmlFor="role-3"
                                 >
                                   <i className="custom__radio-text" />
-                                  <span className="text-sm">BookKeeper</span>
+                                  <span className="text-sm">Bookkeeper</span>
                                 </label>
                               </div>
                             </div>

--- a/app/javascript/src/components/Team/modals/TeamForm.tsx
+++ b/app/javascript/src/components/Team/modals/TeamForm.tsx
@@ -117,7 +117,7 @@ const TeamForm = ({
                     />
                     <CustomRadioButton
                       classNameLabel="font-medium text-sm leading-5 text-miru-dark-purple-1000"
-                      classNameWrapper="px-5 py-3"
+                      classNameWrapper="pl-5 py-3"
                       defaultCheck={values.role == "employee"}
                       groupName="roles"
                       id="Employee"
@@ -135,7 +135,7 @@ const TeamForm = ({
                       groupName="roles"
                       id="Book Keeper"
                       key="Book Keeper"
-                      label="Book Keeper"
+                      label="BookKeeper"
                       value={values.role == "book_keeper" ? "book_keeper" : ""}
                       handleOnChange={() => {
                         setFieldValue("role", "book_keeper", true);

--- a/app/javascript/src/components/Team/modals/TeamForm.tsx
+++ b/app/javascript/src/components/Team/modals/TeamForm.tsx
@@ -135,7 +135,7 @@ const TeamForm = ({
                       groupName="roles"
                       id="Book Keeper"
                       key="Book Keeper"
-                      label="BookKeeper"
+                      label="Bookkeeper"
                       value={values.role == "book_keeper" ? "book_keeper" : ""}
                       handleOnChange={() => {
                         setFieldValue("role", "book_keeper", true);

--- a/spec/system/teams/edit_spec.rb
+++ b/spec/system/teams/edit_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe "Editing team memeber details", type: :system do
 
           el = all(:css, "#editMember", visible: false).last.hover
           el.click
-          choose "Book Keeper"
+          choose "Bookkeeper"
           click_button "SAVE CHANGES"
 
-          expect(page).to have_content("Book Keeper")
+          expect(page).to have_content("Bookkeeper")
         end
       end
     end


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=b4528f26f4424af7beaf036262796cb3&p=feb08cd71f3144349e6951d6a7109cc9&pm=s

What
- Fix spacing b/w roels on team modal mobile view
- Changed the spelling from "Book Keeper" to "BookKeeper"
- Show Bookkeeper on list page instead of Book_Keeper
Preview
<img width="694" alt="Screenshot 2023-05-10 at 12 34 56 PM" src="https://github.com/saeloun/miru-web/assets/18750194/ea0f12ad-e1eb-4d80-a293-4fa7969f6152">
<img width="410" alt="Screenshot 2023-05-10 at 12 35 18 PM" src="https://github.com/saeloun/miru-web/assets/18750194/1653e62e-abf1-4ac9-a9d2-6ad14c08c469">
<img width="1428" alt="Screenshot 2023-05-10 at 12 34 47 PM" src="https://github.com/saeloun/miru-web/assets/18750194/d38e0b2e-54a4-4976-bbe4-7da5beba0ee6">
