### PR TITLE
Send invoice section is automatic close

### DIFF
--- a/app/javascript/src/components/Invoices/Generate/MobileView/Container/SendInvoiceContainer/index.tsx
+++ b/app/javascript/src/components/Invoices/Generate/MobileView/Container/SendInvoiceContainer/index.tsx
@@ -19,7 +19,11 @@ import {
 } from "components/Invoices/common/InvoiceForm/SendInvoice/utils";
 import { ApiStatus as InvoiceStatus } from "constants/index";
 
-const SendInvoiceContainer = ({ invoice, handleSaveSendInvoice }) => {
+const SendInvoiceContainer = ({
+  invoice,
+  handleSaveSendInvoice,
+  setIsSending,
+}) => {
   const Recipient: React.FC<{ email: string; handleClick: any }> = ({
     email,
     handleClick,
@@ -94,6 +98,7 @@ const SendInvoiceContainer = ({ invoice, handleSaveSendInvoice }) => {
         } = await invoicesApi.sendInvoice(invoice.id, payload);
         Toastr.success(message);
       }
+      setIsSending(false);
     } catch {
       setStatus(InvoiceStatus.ERROR);
     }

--- a/app/javascript/src/components/Invoices/Generate/MobileView/Container/index.tsx
+++ b/app/javascript/src/components/Invoices/Generate/MobileView/Container/index.tsx
@@ -232,6 +232,7 @@ const Container = ({
           showSendInvoiceModal && (
             <SendInvoiceContainer
               handleSaveSendInvoice={handleSaveSendInvoice}
+              setIsSending={setShowSendInvoiceModal}
               invoice={{
                 id: invoiceId,
                 client: selectedClient,

--- a/app/javascript/src/components/Invoices/Invoice/index.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/index.tsx
@@ -91,6 +91,7 @@ const Invoice = () => {
           <SendInvoiceContainer
             handleSaveSendInvoice={null}
             invoice={invoice}
+            setIsSending={setShowSendInvoiceModal}
           />
         </div>
       </div>

--- a/app/javascript/src/components/Invoices/List/Header.tsx
+++ b/app/javascript/src/components/Invoices/List/Header.tsx
@@ -65,7 +65,7 @@ const Header = ({
   };
 
   return (
-    <div className="mt-6 mb-3 flex flex-wrap items-center justify-around lg:justify-between">
+    <div className="mt-6 mb-3 flex flex-wrap items-center justify-between">
       {isDesktop && <h2 className="header__title">Invoices</h2>}
       <div className="header__searchWrap">
         <div className="header__searchInnerWrapper relative">
@@ -93,7 +93,7 @@ const Header = ({
           </div>
         </div>
         <button
-          className="relative ml-7 h-10 w-10 rounded p-3 hover:bg-miru-gray-1000"
+          className="relative ml-auto h-10 w-10 rounded p-3 hover:bg-miru-gray-1000"
           onClick={() => setIsFilterVisible(true)}
         >
           {appliedFilterCount > 0 && (

--- a/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Invoices/List/Table/TableRow.tsx
@@ -194,6 +194,7 @@ const TableRow = ({
               <SendInvoiceContainer
                 handleSaveSendInvoice={null}
                 invoice={invoice}
+                setIsSending={setIsSending}
               />
             </div>
           </div>


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Close-Send-invoice-modal-automatically-on-mobile-2eadc0f9402142fabc4fe49d11f3506c?pvs=4
### **What :**
- Now the send Invoice section is closing automatically on mobile view when invoice is sent.
### **Why :**
- Earlier it was not closing even if the email is sent and delivered.
### **Preview :**
https://www.loom.com/share/d4bb7a5cc9ab490eb3b20d4f1ded59a0
### **Todos** (for testing):
- Checked if all Send Invoice sections are closing after sending email.