### PR TITLE
Fix: Unable to load cities unless user starts typing.

### DIFF
--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -10,7 +10,6 @@ import flags from "react-phone-number-input/flags";
 import { Avatar } from "StyledComponents";
 
 import clientApi from "apis/clients";
-import { CustomAsyncSelect } from "common/CustomAsyncSelect";
 import CustomReactSelect from "common/CustomReactSelect";
 import { InputErrors, InputField } from "common/FormikFields";
 import Toastr from "common/Toastr";
@@ -92,21 +91,6 @@ const ClientForm = ({
       code: state.isoCode,
       ...state,
     }));
-
-  const filterCities = (inputValue: string) => {
-    const city = currentCityList.filter(i =>
-      i.label.toLowerCase().includes(inputValue.toLowerCase())
-    );
-
-    return city.length ? city : [{ label: inputValue, value: inputValue }];
-  };
-
-  const promiseOptions = (inputValue: string) =>
-    new Promise(resolve => {
-      setTimeout(() => {
-        resolve(filterCities(inputValue));
-      }, 1000);
-    });
 
   const onLogoChange = e => {
     const file = e.target.files[0];
@@ -415,22 +399,20 @@ const ClientForm = ({
             </div>
             <div className="flex flex-row">
               <div className="flex w-1/2 flex-col pr-2" id="city">
-                <CustomAsyncSelect
+                <CustomReactSelect
+                  handleOnChange={city => setFieldValue("city", city)}
                   isErr={!!errors.city && touched.city}
                   label="City"
-                  loadOptions={promiseOptions}
                   name="city"
+                  options={currentCityList}
                   value={values.city.value ? values.city : null}
-                  handleOnChange={city => {
-                    setFieldValue("city", city);
-                  }}
                 />
               </div>
               <div className="flex w-1/2 flex-col pl-2">
                 <InputField
                   resetErrorOnChange
                   id="zipcode"
-                  label="zipcode"
+                  label="Zipcode"
                   name="zipcode"
                   setFieldValue={setFieldValue}
                 />

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -401,6 +401,7 @@ const ClientForm = ({
               <div className="flex w-1/2 flex-col pr-2" id="city">
                 <CustomReactSelect
                   handleOnChange={city => setFieldValue("city", city)}
+                  id="city_select"
                   isErr={!!errors.city && touched.city}
                   label="City"
                   name="city"

--- a/app/javascript/src/components/Clients/Modals/MobileClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/MobileClientForm.tsx
@@ -459,23 +459,12 @@ const MobileClientForm = ({
                 <div className="flex flex-row">
                   <div className="flex w-1/2 flex-col pr-2" id="city">
                     <CustomReactSelect
+                      handleOnChange={city => setFieldValue("city", city)}
                       isErr={!!errors.city && touched.city}
                       label="City"
                       name="city"
                       options={currentCityList}
                       value={values.city.value ? values.city : null}
-                      handleOnChange={city => {
-                        setFieldValue("city", city);
-                        const cities = City.getCitiesOfState(
-                          currentCountryDetails.code,
-                          city.code
-                        ).map(city => ({
-                          label: city.name,
-                          value: city.name,
-                          ...city,
-                        }));
-                        setCurrentCityList(cities);
-                      }}
                     />
                   </div>
                   <div className="flex w-1/2 flex-col pl-2">

--- a/spec/system/clients/create_spec.rb
+++ b/spec/system/clients/create_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Create client", type: :system do
 
     within("div#city") do
       find(".react-select-filter__control.css-digfch-control").click
-      fill_in "react-select-4-input", with: "Skita"
       find("#react-select-4-option-0").click
     end
   end

--- a/spec/system/clients/edit_spec.rb
+++ b/spec/system/clients/edit_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Edit client", type: :system do
 
     within("div#city") do
       find(".react-select-filter__control.css-digfch-control").click
-      fill_in "react-select-4-input", with: "Skita"
       find("#react-select-4-option-0").click
     end
   end


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/List-of-cities-loads-only-when-the-user-starts-typing-in-the-city-field-faa25b40658b4351b84239275848dfe2)

## Description
- Fixed the issue where the list of cities loads only when the user starts typing in the city field.

## Preview
Before:

https://github.com/saeloun/miru-web/assets/57438322/d800568d-1f33-48f1-863c-5b27db7fdc83

After:

https://github.com/saeloun/miru-web/assets/57438322/cb5f5a54-234f-4a5c-9ba2-e4797110cb67