### PR TITLE
Add length validation for first and last name for user model

### DIFF
--- a/app/javascript/src/components/Authentication/SignUp/utils.ts
+++ b/app/javascript/src/components/Authentication/SignUp/utils.ts
@@ -12,9 +12,11 @@ export const signUpFormInitialValues = {
 export const signUpFormValidationSchema = Yup.object().shape({
   firstName: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid first name")
+    .max(20, "Maximum 20 characters are allowed")
     .required("First name can not be blank"),
   lastName: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid last name")
+    .max(20, "Maximum 20 characters are allowed")
     .required("Last name can not be blank"),
   email: Yup.string()
     .email("Invalid email ID")

--- a/app/javascript/src/components/Profile/UserDetail/Edit/validationSchema.ts
+++ b/app/javascript/src/components/Profile/UserDetail/Edit/validationSchema.ts
@@ -1,8 +1,12 @@
 import * as Yup from "yup";
 
 export const userSchema = {
-  first_name: Yup.string().required("Please enter first name"),
-  last_name: Yup.string().required("Please enter last name"),
+  first_name: Yup.string()
+    .required("Please enter first name")
+    .max(20, "Maximum 20 characters are allowed"),
+  last_name: Yup.string()
+    .required("Please enter last name")
+    .max(20, "Maximum 20 characters are allowed"),
   addresses: Yup.object().shape({
     address_line_1: Yup.string().required("Please enter address line 1"),
     country: Yup.string().required("Please enter country"),

--- a/app/javascript/src/components/Team/Details/PersonalDetails/Edit/validationSchema.ts
+++ b/app/javascript/src/components/Team/Details/PersonalDetails/Edit/validationSchema.ts
@@ -1,8 +1,12 @@
 import * as Yup from "yup";
 
 export const userSchema = {
-  first_name: Yup.string().required("Please enter first name"),
-  last_name: Yup.string().required("Please enter last name"),
+  first_name: Yup.string()
+    .required("Please enter first name")
+    .max(20, "Maximum 20 characters are allowed"),
+  last_name: Yup.string()
+    .required("Please enter last name")
+    .max(20, "Maximum 20 characters are allowed"),
   addresses: Yup.object().shape({
     address_line_1: Yup.string().required("Please enter address line 1"),
     country: Yup.string().required("Please enter country"),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   validates :first_name, :last_name,
     presence: true,
     format: { with: /\A[a-zA-Z\s]+\z/ },
-    length: { maximum: 50 }
+    length: { maximum: 20 }
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/db/migrate/20230510115137_truncate_user_name_to_user.rb
+++ b/db/migrate/20230510115137_truncate_user_name_to_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TruncateUserNameToUser < ActiveRecord::Migration[7.0]
+  def change
+    User.find_each do |user|
+      user.update(first_name: user.first_name[0..19], last_name: user.last_name[0..19])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_064958) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_104809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe User, type: :model do
     it { is_expected.not_to allow_value("foo&23423").for(:first_name) }
     it { is_expected.to allow_value("foo").for(:last_name) }
     it { is_expected.not_to allow_value("foo&23423").for(:last_name) }
-    it { is_expected.to validate_length_of(:first_name).is_at_most(50) }
-    it { is_expected.to validate_length_of(:last_name).is_at_most(50) }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(20) }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(20) }
   end
 
   describe "Callbacks" do


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/Fixing-the-character-limit-on-all-the-fields-44d95ff2103948c28baf69c0a97c5364

What
- Added 20 characters length validation for first_name and last_name on user model
- Added script to truncate  first name and last name of  existing record to 20 characters
- Added formik validations for signup, personal details and team details