### PR TITLE
Sign up password field criteria

### DIFF
--- a/app/javascript/src/common/FormikFields/InputField/index.tsx
+++ b/app/javascript/src/common/FormikFields/InputField/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/exports-last */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import classNames from "classnames";
 import { Field } from "formik";
@@ -31,8 +31,11 @@ const InputField = ({
   resetErrorOnChange,
   setFieldError,
   setFieldValue,
+  marginBottom,
 }) => {
   const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [defaultMarginBottom, setDefaultMarginBottom] =
+    useState<string>(marginBottom);
 
   const handleTogglePasswordVisibility = () => {
     setShowPassword(!showPassword);
@@ -60,6 +63,14 @@ const InputField = ({
     }
   };
 
+  useEffect(() => {
+    if (hasError) {
+      setDefaultMarginBottom("mb-2");
+    } else {
+      setDefaultMarginBottom(marginBottom);
+    }
+  }, [hasError]);
+
   const optionalFieldProps =
     resetErrorOnChange || onChange ? { onChange: e => handleChange(e) } : {};
 
@@ -67,8 +78,9 @@ const InputField = ({
     <div
       className={classNames(
         defaultWrapperClassName,
-        "field relative mb-2 xsm:mb-6",
-        wrapperClassName
+        "field relative",
+        wrapperClassName,
+        defaultMarginBottom
       )}
     >
       <Field
@@ -129,6 +141,7 @@ InputField.defaultProps = {
   resetErrorOnChange: true,
   setFieldError: null,
   setFieldValue: null,
+  marginBottom: "mb-2 xsm:mb-6",
 };
 
 export default InputField;

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -83,7 +83,7 @@ const SignInForm = () => {
           />
         </a>
       </div>
-      <div className="mx-auto mt-auto md:w-1/2 lg:w-352">
+      <div className="mx-auto w-full md:w-1/2 lg:mt-auto lg:w-352">
         <h1 className="text-center font-manrope text-2xl font-extrabold text-miru-han-purple-1000 md:text-3xl lg:text-4.5xl">
           Welcome back!
         </h1>

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -198,7 +198,7 @@ const SignUpForm = () => {
                     ) : (
                       (errors.confirm_password || errors.password) && (
                         <InputErrors
-                          fieldErrors="Passwords don't match"
+                          fieldErrors="Passwords must match"
                           fieldTouched={
                             touched.confirm_password || touched.password
                           }

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -86,8 +86,8 @@ const SignUpForm = () => {
         </h1>
         <div className="pt-2vh lg:pt-5vh">
           <Formik
+            validateOnBlur
             initialValues={signUpFormInitialValues}
-            validateOnBlur={false}
             validateOnChange={false}
             validationSchema={signUpFormValidationSchema}
             onSubmit={handleSignUpFormSubmit}
@@ -161,10 +161,7 @@ const SignUpForm = () => {
                       setFieldError={setFieldError}
                       setFieldValue={setFieldValue}
                       type="password"
-                    />
-                    <InputErrors
-                      fieldErrors={errors.password}
-                      fieldTouched={touched.password}
+                      wrapperClassName="mb-6"
                     />
                   </div>
                   <div className="field">
@@ -172,6 +169,7 @@ const SignUpForm = () => {
                       id="confirm_password"
                       label="Confirm Password"
                       labelClassName="p-0"
+                      marginBottom="mb-2"
                       name="confirm_password"
                       setFieldError={setFieldError}
                       setFieldValue={setFieldValue}
@@ -180,10 +178,27 @@ const SignUpForm = () => {
                         errors.confirm_password && touched.confirm_password
                       }
                     />
-                    <InputErrors
-                      fieldErrors={errors.confirm_password}
-                      fieldTouched={touched.confirm_password}
-                    />
+                    {!errors.confirm_password && !errors.password && (
+                      <p className="text-xs font-medium leading-4 text-miru-dark-purple-400">
+                        Min. 8 characters, 1 uppercase, 1 lowercase, 1 number
+                        and 1 special character
+                      </p>
+                    )}
+                    {errors.confirm_password == errors.password ? (
+                      <InputErrors
+                        fieldErrors={errors.confirm_password}
+                        fieldTouched={touched.confirm_password}
+                      />
+                    ) : (
+                      (errors.confirm_password || errors.password) && (
+                        <InputErrors
+                          fieldErrors="Passwords don't match"
+                          fieldTouched={
+                            touched.confirm_password || touched.password
+                          }
+                        />
+                      )
+                    )}
                   </div>
                   <div className="my-6 flex text-xs font-normal leading-4 text-miru-dark-purple-1000">
                     <div className="mt-2 flex">

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -60,14 +60,20 @@ const SignUpForm = () => {
     setTermsOfServiceModal(true);
   };
 
-  const isBtnDisabled = (values: SignUpFormValues) =>
+  const isBtnDisabled = (values: SignUpFormValues, errors) =>
     !(
       values?.firstName?.trim() &&
       values?.lastName?.trim() &&
       values.email?.trim() &&
       values?.password?.trim() &&
-      values?.confirm_password?.trim()
-    );
+      values?.confirm_password?.trim() &&
+      values?.password?.trim() == values?.confirm_password?.trim()
+    ) ||
+    errors?.firstName ||
+    errors?.lastName?.trim() ||
+    errors.email?.trim() ||
+    errors?.password?.trim() ||
+    errors?.confirm_password?.trim();
 
   return (
     <div className="relative flex w-full flex-col items-center justify-center px-8 pt-5vh md:px-0 lg:w-1/2">
@@ -243,7 +249,7 @@ const SignUpForm = () => {
                     <button
                       type="submit"
                       className={`form__button whitespace-nowrap ${
-                        isBtnDisabled(values)
+                        isBtnDisabled(values, errors)
                           ? "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
                           : "cursor-pointer"
                       }`}


### PR DESCRIPTION
### **Notion :**
- https://www.notion.so/saeloun/Signin-Signup-review-mobile-fc999aac28374cb0921d200822fdf718?pvs=4
- https://www.notion.so/saeloun/Mobile-Fix-the-spacing-b-w-logo-and-text-on-sign-in-page-d8dda2a6aa3543c7931dd5d517199f33?pvs=4
### **What :**
- Password field criteria added and conditions added for error field.
- Sign In mobile view page spacing fixed between logo and welcome back text.
### **Why :**
- User should know the password criteria beforehand
- We were showing same error for password and confirm password field (bad UI/UX)  
- Too much space between logo and welcome back text.
### **Preview :**
Sign In page before:
<img width="432" alt="Screenshot 2023-05-11 at 1 04 03 PM" src="https://github.com/saeloun/miru-web/assets/72149587/c6939543-9572-4e3d-90d1-86cf3d64f124">

Sign In page After:
<img width="463" alt="Screenshot 2023-05-11 at 12 37 50 PM" src="https://github.com/saeloun/miru-web/assets/72149587/1c8ba007-8327-4300-b301-3c010c3cfc4e">

Signup page:
Desktop:
<img width="761" alt="Screenshot 2023-05-11 at 12 50 19 PM" src="https://github.com/saeloun/miru-web/assets/72149587/eedc3f30-ec5c-40ae-826c-fbe96de9a8a9">

<img width="853" alt="Screenshot 2023-05-11 at 1 05 43 PM" src="https://github.com/saeloun/miru-web/assets/72149587/e4a31ff8-d32a-44af-a8ad-43ee0954c4dd">


Mobile:
<img width="468" alt="Screenshot 2023-05-11 at 12 38 17 PM" src="https://github.com/saeloun/miru-web/assets/72149587/974f4ff2-31b4-4afe-8d35-701e06a0cfff">

<img width="399" alt="Screenshot 2023-05-11 at 12 49 42 PM" src="https://github.com/saeloun/miru-web/assets/72149587/e9cb94ae-3c75-4108-ab0d-d4e35f8c3d91">

### **Todos** (for testing):
