### PR TITLE
client page mobile view fixes

### DIFF
--- a/app/javascript/src/common/Table/index.tsx
+++ b/app/javascript/src/common/Table/index.tsx
@@ -128,7 +128,7 @@ const Table = ({
             >
               {row.cells.map((cell, idx) => (
                 <td
-                  className={`table__cell ${!isDesktop && "xsm:p-1"} md:w-1/3`}
+                  className="table__cell md:w-1/3"
                   {...cell.getCellProps()}
                   key={idx}
                 >
@@ -137,7 +137,7 @@ const Table = ({
               ))}
               {hasRowIcons && isDesktop && (
                 <td className="table__cell md:w-1/5">
-                  <div className="iconWrapper invisible">
+                  <div className="iconWrapper invisible flex items-center justify-evenly">
                     <button
                       onClick={e => {
                         e.preventDefault();

--- a/app/javascript/src/components/Clients/Details/Header.tsx
+++ b/app/javascript/src/components/Clients/Details/Header.tsx
@@ -61,13 +61,17 @@ const Header = ({ clientDetails, setShowProjectModal }) => {
   const menuBackground = isHeaderMenuVisible ? "bg-miru-gray-1000" : "";
 
   return (
-    <div className="my-6">
-      <div className="flex min-w-0 items-center justify-between">
+    <div className="lg:my-6">
+      <div className="flex h-12 min-w-0 items-center justify-between shadow-c1 lg:h-auto lg:shadow-none">
         <div className="flex items-center">
           <button className="button-icon__back" onClick={handleBackButtonClick}>
-            <ArrowLeftIcon color="#5b34ea" size={20} weight="bold" />
+            <ArrowLeftIcon
+              className="text-miru-dark-purple-1000"
+              size={20}
+              weight="bold"
+            />
           </button>
-          <h2 className="mr-6 py-1 text-3xl font-extrabold text-gray-900 sm:truncate sm:text-4xl">
+          <h2 className="mr-6 py-1 text-base font-medium text-miru-dark-purple-1000 sm:truncate lg:text-4xl lg:font-extrabold">
             {clientDetails.name}
           </h2>
           <button onClick={handleClientDetails}>
@@ -80,7 +84,7 @@ const Header = ({ clientDetails, setShowProjectModal }) => {
             id="kebabMenu"
             onClick={handleMenuVisibility}
           >
-            <DotsThreeVerticalIcon color="#000000" size={20} />
+            <DotsThreeVerticalIcon color="#000000" size={20} weight="bold" />
           </button>
           {isHeaderMenuVisible && (
             <ul className="menuButton__wrapper">

--- a/app/javascript/src/components/Clients/Details/index.tsx
+++ b/app/javascript/src/components/Clients/Details/index.tsx
@@ -48,7 +48,7 @@ const getTableData = (clients, isDesktop) => {
   } else if (clients && !isDesktop) {
     return clients.map(client => ({
       col1: (
-        <div className="table__cell text-base font-medium capitalize text-miru-dark-purple-1000">
+        <div className="text-base font-medium capitalize text-miru-dark-purple-1000">
           {client.name}
           <br />
           <div className="w-57.5">

--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -73,7 +73,7 @@ const getTableData = (
   } else if (clients && !isDesktop) {
     return clients.map(client => ({
       col1: (
-        <div className="table__cell text-base capitalize">
+        <div className="text-base capitalize">
           <Avatar classNameImg="mr-4 w-8 h-8" url={client.logo} />
           <span
             className="my-auto overflow-hidden truncate whitespace-nowrap text-sm font-medium capitalize text-miru-dark-purple-1000"
@@ -329,7 +329,7 @@ const Clients = ({ isAdminUser }) => {
             totalMinutes={totalMinutes}
           />
         )}
-        <div className="mx-auto flex w-full flex-col px-4">
+        <div className="mx-auto flex w-full flex-col lg:px-4">
           <div className="-my-2 w-full lg:-mx-8">
             <div className="mx-auto inline-block min-w-full py-2 align-middle lg:px-8">
               <div className="overflow-hidden">


### PR DESCRIPTION
### **Notion :**
- https://www.notion.so/saeloun/Mobile-Fix-the-header-design-of-client-details-2c7c45de01b14ab7b35af38ff2ef2304?pvs=4
### **What :**
- Client details page mobile view header updated as per the design
- Fixed horizontal table scroll scroll on details page (overflowing table) on all scree sizes
- Fixed padding of row items on client list page table 
### **Why :**
- UI fixes
### **Preview :**
Before:
<img width="484" alt="Screenshot 2023-05-12 at 9 59 57 AM" src="https://github.com/saeloun/miru-web/assets/72149587/8e6cb505-c537-4fca-9608-61da8e7adc15">

<img width="588" alt="Screenshot 2023-05-12 at 10 00 03 AM" src="https://github.com/saeloun/miru-web/assets/72149587/460fa56a-23e2-413c-9def-a7288a62c738">

After:
<img width="420" alt="Screenshot 2023-05-12 at 9 58 52 AM" src="https://github.com/saeloun/miru-web/assets/72149587/e42ee087-63cd-4c1c-8f05-2fdd9ca82b62">

<img width="500" alt="Screenshot 2023-05-12 at 9 58 02 AM" src="https://github.com/saeloun/miru-web/assets/72149587/67f21918-f989-4278-90e4-a4a3e39521c7">


### **Todos** (for testing):