### PR TITLE
Fix: Invoice reports page bugs

### DIFF
--- a/app/javascript/src/components/Reports/OutstandingInvoiceReport/Container/Table/TableRow.tsx
+++ b/app/javascript/src/components/Reports/OutstandingInvoiceReport/Container/Table/TableRow.tsx
@@ -34,7 +34,7 @@ const TableRow = ({ currency, reportData, logo }) => {
         </span>
         <dl className="text-left text-xs leading-5 lg:hidden">
           <dt className="mt-3 font-medium text-miru-dark-purple-400">
-            issued on <span className="font-bold">{issueDate}</span>
+            Issued on <span className="font-bold">{issueDate}</span>
           </dt>
         </dl>
       </td>

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -136,7 +136,7 @@ class Client < ApplicationRecord
       .order(issue_date: :desc)
       .includes(:company)
       .select { |invoice| outstanding_overdue_statuses.include?(invoice.status) }
-    status_and_amount = invoices.group(:status).sum(:amount)
+    status_and_amount = invoices.kept.group(:status).sum(:amount)
     status_and_amount.default = 0
 
     {

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -132,7 +132,7 @@ class Client < ApplicationRecord
 
   def outstanding_and_overdue_invoices
     outstanding_overdue_statuses = ["overdue", "sent", "viewed"]
-    filtered_invoices = invoices
+    filtered_invoices = invoices.kept
       .order(issue_date: :desc)
       .includes(:company)
       .select { |invoice| outstanding_overdue_statuses.include?(invoice.status) }

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ProjectPolicy, type: :policy do
     context "when user is an admin/owner" do
       it "returns the list of allowed projects" do
         result = ProjectPolicy::Scope.new(admin, company).resolve
-        expect(result.pluck(:id)).to eq([project.id, project_2.id])
+        expect(result.pluck(:id)).to contain_exactly(project.id, project_2.id)
       end
     end
 


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Invoice-reports-page-bugs-70f98a0b76444e9a8b683a8d2ffeb0fa)

## Description
- Fixed the word `issued` casing on the mobile view.
- Fixed the bug where the deleted invoice would still be visible on the invoices reports page.
- Fixed flaky test

## Preview
Before:
![Screenshot_20230509-203546](https://github.com/saeloun/miru-web/assets/57438322/8428d979-3903-4f68-9e63-07aad2df9822)

https://github.com/saeloun/miru-web/assets/57438322/6a61f61d-dae6-41fc-8450-5673f3a87ac9

After:
<img width="398" alt="Screenshot 2023-05-12 at 12 05 54 PM" src="https://github.com/saeloun/miru-web/assets/57438322/51bb6abf-9cee-4095-8810-d80a6e03b7a0">

https://github.com/saeloun/miru-web/assets/57438322/80ab9470-0d2d-4877-b8bf-971d9b5f48b8
