### PR TITLE
Color changed for dates outside month.

### DIFF
--- a/app/javascript/stylesheets/react-calendar.scss
+++ b/app/javascript/stylesheets/react-calendar.scss
@@ -154,4 +154,7 @@
     // background-color: transparent;
     border-bottom: none;
   }
+  .react-datepicker__day--outside-month{
+    color: #A5A3AD
+  }
 }


### PR DESCRIPTION
### **Notion :**
NA
### **What :**
- Color updated for dates which are outside the selected month
### **Why :**
- UX improvement 
- Asked by Sonam
### **Preview :**
Before:
<img width="353" alt="Screenshot 2023-05-12 at 1 46 17 PM" src="https://github.com/saeloun/miru-web/assets/72149587/757f735a-5ca7-40f1-8bd0-3e0502c9db96">

After:
<img width="361" alt="Screenshot 2023-05-12 at 1 38 44 PM" src="https://github.com/saeloun/miru-web/assets/72149587/0bc57b7f-3bd4-453a-a57e-133fd616ea1e">

### **Todos** (for testing):