### PR TITLE
Fix: Send payment receipt to client bugs

### DIFF
--- a/app/views/mailers/client_payment_mailer/payment.html.erb
+++ b/app/views/mailers/client_payment_mailer/payment.html.erb
@@ -32,7 +32,11 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% if @company_logo.blank? %>
+              <%= image_tag attachments["miruLogoWithText.png"].url, height: 70 ,width: "120px", :style => "border-radius: 80px" %>
+            <% else %>
+              <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% end %>
           </div>
         </div>
       </div>
@@ -66,11 +70,11 @@
           <tr style="width: 100%; margin-top: 15px">
             <td>
               <div style=' font-weight:normal; font-size:16px;'>Issued To</div>
-              <div style="font-weight:normal; font-size:20px;"><%= @company.name %></div>
+              <div style="font-weight:normal; font-size:20px;"><%= @invoice.client.name %></div>
             </td>
             <td align="right">
               <div style=' font-weight:normal; font-size:16px;'>Amount</div>
-              <div style="font-weight:normal; font-size:28px;"><%= @invoice.amount %></div>
+              <div style="font-weight:normal; font-size:28px;"><%= @amount %></div>
             </td>
           </tr>
         </table>
@@ -160,12 +164,12 @@
         <div>
           <p style="font-family: 'Manrope'; margin: 0px; padding: 0px;">Amount Paid</p>
           <p style="font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;">
-            <%= @invoice.amount_paid %>
+            <%= @amount %>
           </p>
         </div>
         <div>
           <p style="font-family: 'Manrope'; margin: 0px; padding: 0px;">Issued to</p>
-          <p style="font-family: 'Manrope' font-style: normal; font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;"><%= @company.name %></p>
+          <p style="font-family: 'Manrope' font-style: normal; font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;"><%= @invoice.client.name %></p>
         </div>
       </div>
       <div id="footer">

--- a/app/views/mailers/client_payment_mailer/payment.html.erb
+++ b/app/views/mailers/client_payment_mailer/payment.html.erb
@@ -32,10 +32,10 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <% if @company_logo.blank? %>
-              <%= image_tag attachments["miruLogoWithText.png"].url, height: 70 ,width: "120px", :style => "border-radius: 80px" %>
+            <% if @company_logo.present? %>
+                <%= image_tag @company_logo, height: 80, width: 80, style: "border-radius: 80px" %>
             <% else %>
-              <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+              <div style="width:80px;height:80px;border-radius: 80px;text-align: center;background: #CDD6DF;font-size: 40px;justify-content:center;display: flex; align-items: center; color:white"><%= @invoice.company.name.slice(0) %></div>
             <% end %>
           </div>
         </div>

--- a/app/views/mailers/payment_mailer/client_payment_mailer.html.erb
+++ b/app/views/mailers/payment_mailer/client_payment_mailer.html.erb
@@ -32,10 +32,10 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <% if @company_logo.blank? %>
-              <%= image_tag attachments["miruLogoWithText.png"].url, height: 80 ,width: 135, :style => "border-radius: 80px" %>
+            <% if @company_logo.present? %>
+                <%= image_tag @company_logo, height: 80, width: 80, style: "border-radius: 80px" %>
             <% else %>
-              <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+              <div style="width:80px;height:80px;border-radius: 80px;text-align: center;background: #CDD6DF;font-size: 40px;justify-content:center;display: flex; align-items: center; color:white"><%= @invoice.company.name.slice(0) %></div>
             <% end %>
           </div>
         </div>

--- a/app/views/mailers/payment_mailer/client_payment_mailer.html.erb
+++ b/app/views/mailers/payment_mailer/client_payment_mailer.html.erb
@@ -32,7 +32,11 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% if @company_logo.blank? %>
+              <%= image_tag attachments["miruLogoWithText.png"].url, height: 80 ,width: 135, :style => "border-radius: 80px" %>
+            <% else %>
+              <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% end %>
           </div>
         </div>
       </div>
@@ -66,11 +70,11 @@
           <tr style="width: 100%; margin-top: 15px">
             <td>
               <div style=' font-weight:normal; font-size:16px;'>Issued To</div>
-              <div style="font-weight:normal; font-size:20px;"><%= @company.name %></div>
+              <div style="font-weight:normal; font-size:20px;"><%= @invoice.client.name %></div>
             </td>
             <td align="right">
               <div style=' font-weight:normal; font-size:16px;'>Amount</div>
-              <div style="font-weight:normal; font-size:28px;"><%= @invoice.amount %></div>
+              <div style="font-weight:normal; font-size:28px;"><%= @amount %></div>
             </td>
           </tr>
         </table>
@@ -160,12 +164,12 @@
         <div>
           <p style="font-family: 'Manrope'; margin: 0px; padding: 0px;">Amount Paid</p>
           <p style="font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;">
-            <%= @invoice.amount_paid %>
+            <%= @amount %>
           </p>
         </div>
         <div>
           <p style="font-family: 'Manrope'; margin: 0px; padding: 0px;">Issued to</p>
-          <p style="font-family: 'Manrope' font-style: normal; font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;"><%= @company.name %></p>
+          <p style="font-family: 'Manrope' font-style: normal; font-size: 16px; font-style: normal; font-weight: 400; line-height: 22px; color: #1D1A31; margin: 0px; padding: 4px 0px 16px 0px;"><%= @invoice.client.name %></p>
         </div>
       </div>
       <div id="footer">

--- a/spec/mailers/previews/client_payment_mailer_preview.rb
+++ b/spec/mailers/previews/client_payment_mailer_preview.rb
@@ -2,7 +2,7 @@
 
 class ClientPaymentMailerPreview < ActionMailer::Preview
   def payment
-    invoice = Invoice.find("10")
+    invoice = Invoice.last
     ClientPaymentMailer.with(
       invoice:,
       subject: "Payment Receipt of Invoice #{invoice.invoice_number} from #{invoice.company.name}").payment


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Frontend-Once-payment-is-received-from-client-and-invoice-is-marked-as-paid-on-Miru-send-a-paymen-ab4b1d1366a947de830ffdd38fd2dfaa)

## Description
- Added default logo when no company logo was present.
- Show a currency symbol in front of the amount paid's amount.
- Show the client name in the issued to column instead of a company name.

## Preview
Before -
<img width="662" alt="Screenshot 2023-05-12 at 4 31 01 PM" src="https://github.com/saeloun/miru-web/assets/57438322/1294d7d2-4aa5-44cd-abd4-46b6c84e603a">

After -
<img width="663" alt="Screenshot 2023-05-12 at 4 25 03 PM" src="https://github.com/saeloun/miru-web/assets/57438322/5d7a495a-472b-459c-8990-15109e1a8817">

<img width="654" alt="Screenshot 2023-05-12 at 4 32 51 PM" src="https://github.com/saeloun/miru-web/assets/57438322/4906afec-40b1-4fe0-a63a-cc799379e7ad">
