### PR TITLE
Default logo added for email notification

### DIFF
--- a/app/views/mailers/client_payment_mailer/payment.html.erb
+++ b/app/views/mailers/client_payment_mailer/payment.html.erb
@@ -32,7 +32,11 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% if @company_logo.present? %>
+                <%= image_tag @company_logo, height: 80, width: 80, style: "border-radius: 80px" %>
+            <% else %>
+              <div style="width:80px;height:80px;border-radius: 80px;text-align: center;background: #CDD6DF;font-size: 40px;justify-content:center;display: flex; align-items: center; color:white"><%= @invoice.company.name.slice(0) %></div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/mailers/payment_mailer/payment.html.erb
+++ b/app/views/mailers/payment_mailer/payment.html.erb
@@ -32,7 +32,11 @@
           style="padding: 30px 40px; background:white ;border-bottom: 2px solid #E1E6EC; text-align: center"
         >
           <div style="padding: 10px; display: inline-block; text-align: center;">
-            <%= image_tag @company_logo, height: 80 ,width: 80, :style => "border-radius: 80px" %>
+            <% if @company_logo.present? %>
+                <%= image_tag @company_logo, height: 80, width: 80, style: "border-radius: 80px" %>
+            <% else %>
+              <div style="width:80px;height:80px;border-radius: 80px;text-align: center;background: #CDD6DF;font-size: 40px;justify-content:center;display: flex; align-items: center; color:white"><%= @invoice.company.name.slice(0) %></div>
+            <% end %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### **Notion :**
- https://www.notion.so/saeloun/Frontend-Integration-Once-payment-is-received-from-client-through-Stripe-send-email-notification-t-e80c022d040447b8a1ad8b47d19803c4?pvs=4 (review comments in this ticket)
### **What :**
- Added default logo if company logo is not present.
### **Why :**
- Earlier broken img was being displayed if company logo is not uploaded. 
### **Preview :**
<img width="1062" alt="Screenshot 2023-05-15 at 11 20 53 AM" src="https://github.com/saeloun/miru-web/assets/72149587/799d34fc-0a01-42dc-9ce7-99feb1779cfc">

### **Todos** (for testing):
- Tested the payment receipt and payment conformation page.