### PR TITLE
Outsideclick added for client page modals

### DIFF
--- a/app/javascript/src/components/Clients/Modals/AddProject.tsx
+++ b/app/javascript/src/components/Clients/Modals/AddProject.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
+import { useOutsideClick } from "helpers";
 import { XIcon } from "miruIcons";
 import { useNavigate } from "react-router-dom";
 
@@ -11,6 +12,11 @@ const AddProject = ({ setShowProjectModal, clientDetails }) => {
   const [projectType, setProjectType] = useState<any>("Billable");
 
   const navigate = useNavigate();
+  const wrapperRef = useRef();
+
+  useOutsideClick(wrapperRef, () => {
+    setShowProjectModal(false);
+  });
 
   const handleSubmit = async () => {
     await projectApi.create({
@@ -29,7 +35,7 @@ const AddProject = ({ setShowProjectModal, clientDetails }) => {
       className="modal__modal main-modal"
       style={{ background: "rgba(29, 26, 49,0.6)" }}
     >
-      <div className="modal__container modal-container">
+      <div className="modal__container modal-container" ref={wrapperRef}>
         <div className="modal__content modal-content">
           <div className="modal__position">
             <h6 className="modal__title"> Add New Project </h6>

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -375,15 +375,19 @@ const ClientForm = ({
                   handleOnChange={e => {
                     setCurrentCountryDetails(e);
                     setFieldValue("country", e);
+                    setFieldValue("state", "");
+                    setFieldValue("city", "");
+                    setFieldValue("zipcode", "");
                   }}
                 />
               </div>
               <div className="flex w-1/2 flex-col pl-2">
                 <CustomReactSelect
+                  id="state"
                   isErr={!!errors.state && touched.state}
                   label="State"
                   name="state"
-                  value={values.state.value ? values.state : null}
+                  value={values.state ? values.state : null}
                   handleOnChange={state => {
                     setFieldValue("state", state);
                     const cities = City.getCitiesOfState(
@@ -408,7 +412,7 @@ const ClientForm = ({
               <div className="flex w-1/2 flex-col pr-2" id="city">
                 <CustomReactSelect
                   handleOnChange={city => setFieldValue("city", city)}
-                  id="city_select"
+                  id="city"
                   isErr={!!errors.city && touched.city}
                   label="City"
                   name="city"

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -63,9 +63,9 @@ const ClientForm = ({
 
   const assignCountries = async allCountries => {
     const countryData = await allCountries.map(country => ({
-      value: country.isoCode,
+      value: country?.isoCode && country.isoCode,
       label: country.name,
-      code: country.isoCode,
+      code: country?.isoCode && country?.isoCode,
     }));
     setCountries(countryData);
   };
@@ -79,19 +79,19 @@ const ClientForm = ({
     State.getStatesOfCountry(countryCode).map(state => ({
       label: state.name,
       value: state.name,
-      code: state.isoCode,
+      code: state?.isoCode && state.isoCode,
       ...state,
     }));
 
   const updatedCities = values => {
     const allStates = State.getAllStates();
     const currentCity = allStates.filter(
-      state => state.name == values.state.code
+      state => state.name == values.state.label
     );
 
     const cities = City.getCitiesOfState(
       values.country.code,
-      currentCity[0].isoCode
+      currentCity[0] && currentCity[0].isoCode
     ).map(city => ({
       label: city.name,
       value: city.name,
@@ -399,6 +399,8 @@ const ClientForm = ({
                   value={values.state ? values.state : null}
                   handleOnChange={state => {
                     setFieldValue("state", state);
+                    setFieldValue("city", "");
+                    setFieldValue("zipcode", "");
                     updatedCities(values);
                   }}
                   options={updatedStates(

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -401,9 +401,7 @@ const ClientForm = ({
                     setCurrentCityList(cities);
                   }}
                   options={updatedStates(
-                    currentCountryDetails.code
-                      ? currentCountryDetails.code
-                      : "US"
+                    values.country.code ? values.country.code : "US"
                   )}
                 />
               </div>

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -58,16 +58,8 @@ const ClientForm = ({
   setApiError,
   setShowEditDialog,
 }: IClientForm) => {
-  const initialSelectValue = {
-    label: "",
-    value: "",
-    code: "",
-  };
   const [fileUploadError, setFileUploadError] = useState<string>("");
   const [countries, setCountries] = useState([]);
-  const [currentCountryDetails, setCurrentCountryDetails] =
-    useState(initialSelectValue);
-  const [currentCityList, setCurrentCityList] = useState([]);
 
   const assignCountries = async allCountries => {
     const countryData = await allCountries.map(country => ({
@@ -90,6 +82,24 @@ const ClientForm = ({
       code: state.isoCode,
       ...state,
     }));
+
+  const updatedCities = values => {
+    const allStates = State.getAllStates();
+    const currentCity = allStates.filter(
+      state => state.name == values.state.code
+    );
+
+    const cities = City.getCitiesOfState(
+      values.country.code,
+      currentCity[0].isoCode
+    ).map(city => ({
+      label: city.name,
+      value: city.name,
+      ...city,
+    }));
+
+    return cities;
+  };
 
   const onLogoChange = e => {
     const file = e.target.files[0];
@@ -373,7 +383,6 @@ const ClientForm = ({
                   options={countries}
                   value={values.country.value ? values.country : null}
                   handleOnChange={e => {
-                    setCurrentCountryDetails(e);
                     setFieldValue("country", e);
                     setFieldValue("state", "");
                     setFieldValue("city", "");
@@ -390,15 +399,7 @@ const ClientForm = ({
                   value={values.state ? values.state : null}
                   handleOnChange={state => {
                     setFieldValue("state", state);
-                    const cities = City.getCitiesOfState(
-                      currentCountryDetails.code,
-                      state.code
-                    ).map(city => ({
-                      label: city.name,
-                      value: city.name,
-                      ...city,
-                    }));
-                    setCurrentCityList(cities);
+                    updatedCities(values);
                   }}
                   options={updatedStates(
                     values.country.code ? values.country.code : "US"
@@ -414,7 +415,7 @@ const ClientForm = ({
                   isErr={!!errors.city && touched.city}
                   label="City"
                   name="city"
-                  options={currentCityList}
+                  options={updatedCities(values)}
                   value={values.city.value ? values.city : null}
                 />
               </div>

--- a/app/javascript/src/components/Clients/Modals/ClientForm.tsx
+++ b/app/javascript/src/components/Clients/Modals/ClientForm.tsx
@@ -276,6 +276,7 @@ const ClientForm = ({
               <InputField
                 autoFocus
                 resetErrorOnChange
+                hasError={errors.name && touched.name}
                 id="name"
                 label="Name"
                 name="name"
@@ -290,6 +291,7 @@ const ClientForm = ({
               <div className="field relative">
                 <InputField
                   resetErrorOnChange
+                  hasError={errors.email && touched.email}
                   id="email"
                   label="Email"
                   name="email"
@@ -334,6 +336,7 @@ const ClientForm = ({
               <div className="field relative">
                 <InputField
                   resetErrorOnChange
+                  hasError={errors.address1 && touched.address1}
                   id="address1"
                   label="Address line 1"
                   name="address1"
@@ -349,6 +352,7 @@ const ClientForm = ({
               <div className="field relative mb-5">
                 <InputField
                   resetErrorOnChange
+                  hasError={errors.address2 && touched.address2}
                   id="address2"
                   label="Address line 2 (optional)"
                   name="address2"
@@ -415,6 +419,7 @@ const ClientForm = ({
               <div className="flex w-1/2 flex-col pl-2">
                 <InputField
                   resetErrorOnChange
+                  hasError={errors.zipcode && touched.zipcode}
                   id="zipcode"
                   label="Zipcode"
                   name="zipcode"

--- a/app/javascript/src/components/Clients/Modals/DeleteClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/DeleteClient.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useRef } from "react";
 
+import { useOutsideClick } from "helpers";
 import { useNavigate } from "react-router-dom";
 
 import clientApi from "apis/clients";
@@ -11,6 +12,11 @@ interface IProps {
 
 const DeleteClient = ({ client, setShowDeleteDialog }: IProps) => {
   const navigate = useNavigate();
+  const wrapperRef = useRef();
+
+  useOutsideClick(wrapperRef, () => {
+    setShowDeleteDialog(false);
+  });
 
   const deleteClient = async client => {
     await clientApi.destroy(client.id);
@@ -27,7 +33,10 @@ const DeleteClient = ({ client, setShowDeleteDialog }: IProps) => {
         }}
       >
         <div className="relative h-full w-full px-4 xsm:flex xsm:flex-col xsm:items-center xsm:justify-center xsm:p-8 md:flex md:items-center md:justify-center">
-          <div className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all xsm:w-full xsm:min-w-0 sm:max-w-md sm:align-middle">
+          <div
+            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all xsm:w-full xsm:min-w-0 sm:max-w-md sm:align-middle"
+            ref={wrapperRef}
+          >
             <div className="my-8 flex-col">
               <h6 className="mb-2 text-2xl font-bold">Delete Client</h6>
               <p className="mt-2 font-normal xsm:text-sm">

--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -42,7 +42,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
           <div
             className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
             ref={wrapperRef}

--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -42,7 +42,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
           <div
             className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
             ref={wrapperRef}

--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
+import { useOutsideClick } from "helpers";
 import { XIcon } from "miruIcons";
 
 import { useUserContext } from "context/UserContext";
@@ -20,6 +21,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
   const [clientLogo, setClientLogo] = useState("");
   const [submitting, setSubmitting] = useState<boolean>(false);
   const { isDesktop } = useUserContext();
+  const wrapperRef = useRef();
 
   const handleDeleteLogo = event => {
     event.preventDefault();
@@ -27,6 +29,10 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
     setClientLogo("");
     setClientLogoUrl("");
   };
+
+  useOutsideClick(wrapperRef, () => {
+    setShowEditDialog(false);
+  });
 
   return isDesktop ? (
     <div className="flex items-center justify-center px-4">
@@ -37,7 +43,10 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
         }}
       >
         <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
-          <div className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle">
+          <div
+            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
+            ref={wrapperRef}
+          >
             <div className="mt-6 flex items-center justify-between">
               <h6 className="text-base font-extrabold">Edit Client Details</h6>
               <button

--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -42,9 +42,9 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-full w-full overflow-y-auto px-4 py-2/100 md:flex md:items-center md:justify-center xl:overflow-visible">
           <div
-            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
+            className="modal-width h-full transform overflow-y-auto rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:h-auto xl:overflow-visible"
             ref={wrapperRef}
           >
             <div className="mt-6 flex items-center justify-between">

--- a/app/javascript/src/components/Clients/Modals/EditClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/EditClient.tsx
@@ -44,7 +44,7 @@ const EditClient = ({ setShowEditDialog, client }: IEditClient) => {
       >
         <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
           <div
-            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
+            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
             ref={wrapperRef}
           >
             <div className="mt-6 flex items-center justify-between">

--- a/app/javascript/src/components/Clients/Modals/NewClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/NewClient.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
+import { useOutsideClick } from "helpers";
 import { XIcon } from "miruIcons";
 
 import { useUserContext } from "context/UserContext";
@@ -19,13 +20,17 @@ const NewClient = ({
 }) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [apiError, setApiError] = useState<string>("");
-
+  const wrapperRef = useRef();
   const handleDeleteLogo = () => {
     setClientLogo("");
     setClientLogoUrl("");
   };
 
   const { isDesktop } = useUserContext();
+
+  useOutsideClick(wrapperRef, () => {
+    setShowDialog(false);
+  });
 
   return isDesktop ? (
     <div className="flex items-center justify-center px-4">
@@ -36,7 +41,10 @@ const NewClient = ({
         }}
       >
         <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
-          <div className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle">
+          <div
+            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
+            ref={wrapperRef}
+          >
             <div className="mt-6 flex items-center justify-between">
               <h6 className="text-base font-extrabold">Add New Client</h6>
               <button

--- a/app/javascript/src/components/Clients/Modals/NewClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/NewClient.tsx
@@ -42,7 +42,7 @@ const NewClient = ({
       >
         <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
           <div
-            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
+            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
             ref={wrapperRef}
           >
             <div className="mt-6 flex items-center justify-between">

--- a/app/javascript/src/components/Clients/Modals/NewClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/NewClient.tsx
@@ -40,7 +40,7 @@ const NewClient = ({
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
           <div
             className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
             ref={wrapperRef}

--- a/app/javascript/src/components/Clients/Modals/NewClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/NewClient.tsx
@@ -40,9 +40,9 @@ const NewClient = ({
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-full w-full overflow-y-auto px-4 py-2/100 md:flex md:items-center md:justify-center xl:overflow-visible">
           <div
-            className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:overflow-visible"
+            className="modal-width h-full transform overflow-y-auto rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle xl:h-auto xl:overflow-visible"
             ref={wrapperRef}
           >
             <div className="mt-6 flex items-center justify-between">

--- a/app/javascript/src/components/Clients/Modals/NewClient.tsx
+++ b/app/javascript/src/components/Clients/Modals/NewClient.tsx
@@ -40,7 +40,7 @@ const NewClient = ({
           backgroundColor: "rgba(29, 26, 49, 0.6)",
         }}
       >
-        <div className="relative h-full w-full px-4 md:flex md:items-center md:justify-center">
+        <div className="relative h-auto w-full px-4 md:flex md:items-center md:justify-center">
           <div
             className="modal-width transform rounded-lg bg-white px-6 pb-6 shadow-xl transition-all sm:max-w-md sm:align-middle"
             ref={wrapperRef}

--- a/app/javascript/src/components/Projects/Modals/AddEditProject.tsx
+++ b/app/javascript/src/components/Projects/Modals/AddEditProject.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
+import { useOutsideClick } from "helpers";
 import Logger from "js-logger";
 import { XIcon } from "miruIcons";
 
@@ -15,6 +16,7 @@ const AddEditProject = ({
   const [projectName, setProjectName] = useState<string>("");
   const [projectType, setProjectType] = useState<string>("Billable");
   const [clientList, setClientList] = useState<[]>([]);
+  const wrapperRef = useRef();
 
   const projectId =
     (projectData && projectData["id"]) ||
@@ -24,6 +26,10 @@ const AddEditProject = ({
   const isEdit = !!projectId;
   const isFormFilled = client && projectName && projectType;
   const showEditModal = isEdit && editProjectData?.members;
+
+  useOutsideClick(wrapperRef, () => {
+    setShowProjectModal(false);
+  });
 
   const getClientList = async () => {
     try {
@@ -110,7 +116,7 @@ const AddEditProject = ({
       className="modal__modal main-modal"
       style={{ background: "rgba(29, 26, 49,0.6)" }}
     >
-      <div className="modal__container modal-container">
+      <div className="modal__container modal-container" ref={wrapperRef}>
         <div className="modal__content modal-content">
           <div className="modal__position">
             <h6 className="modal__title">


### PR DESCRIPTION
What: 
- Outside click functionality added for client page modals.
- Modal Height updated. (now scrollable)

Why:
- Outside click functionality was not present.
- On small screen sizes desktop modal height was not appropriate. Was unable to see close button.

Preview:
Before:
<img width="1792" alt="Screenshot 2023-05-16 at 5 21 36 PM" src="https://github.com/saeloun/miru-web/assets/72149587/46a248a5-f2b9-4364-ba2c-942457e2a388">
 After:
<img width="1792" alt="Screenshot 2023-05-16 at 5 19 59 PM" src="https://github.com/saeloun/miru-web/assets/72149587/e3cb21fd-3391-453f-bd7a-5978ddcf4838">

<img width="1792" alt="Screenshot 2023-05-16 at 5 19 50 PM" src="https://github.com/saeloun/miru-web/assets/72149587/58efa1fd-ca17-4be0-8f76-c170b162e173">
