### PR TITLE
Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,3 +37,5 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 /public/assets
+/public/packs
+/public/packs-test


### PR DESCRIPTION
What
- Updated `dockeignore`  to include `public/packs` and `public/packs/test`

Why
- To reduce the size of build images
