### PR TITLE
Fixed client info view on invoices

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/ClientInfo.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/ClientInfo.tsx
@@ -9,11 +9,11 @@ const ClientInfo = ({ client }) => {
       <p className="absolute left-2 -top-2 bg-miru-gray-100 px-2 text-xs font-medium text-miru-dark-purple-1000">
         Billed to
       </p>
-      <div>
+      <div className="h-full overflow-y-scroll">
         <p className="text-xl font-bold leading-7 text-miru-dark-purple-1000">
           {client.name}
         </p>
-        <p className="truncateOverflowText w-52 text-sm font-normal text-miru-dark-purple-600">
+        <p className="w-52 text-sm font-normal text-miru-dark-purple-600">
           {`${address_line_1}${address_line_2 ? `, ${address_line_2}` : ""}${
             address_line_2 ? "," : ""
           }\n ${city}, ${state}, ${country},\n ${pin}`}


### PR DESCRIPTION
### Notion
https://www.notion.so/Bugs-after-deployment-7752310dde324ef897c44dd7eee12ebb

### What
- On the invoice, we can view the complete client info by scrolling inside the info `div`. Earlier it got truncated due to which the client info is kind of broken

### Before

https://github.com/saeloun/miru-web/assets/52771571/912398eb-52f3-478f-b04e-cf5eafe731ed

### After

https://github.com/saeloun/miru-web/assets/52771571/416b7346-a570-466a-b8fc-e9d6dc13fb48
