### PR TITLE
Time tracking week view alignment

### DIFF
--- a/app/javascript/src/components/Navbar/Options.tsx
+++ b/app/javascript/src/components/Navbar/Options.tsx
@@ -3,6 +3,6 @@ import React from "react";
 import { getNavOptions } from "./utils";
 
 const Options = ({ companyRole }) => (
-  <ul className="mt-8">{getNavOptions(companyRole)}</ul>
+  <ul className="mt-2 xl:mt-8">{getNavOptions(companyRole)}</ul>
 );
 export default Options;

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -104,7 +104,7 @@ const UserActions = setVisiblity => {
   );
 
   return (
-    <ul className="w-full">
+    <ul className="w-full lg:mb-2 xl:mb-6">
       <li className="flex border-b border-miru-gray-100 last:border-b-0 hover:bg-miru-gray-100 lg:justify-start lg:border-b-0">
         <NavLink
           to={isDesktop ? "/profile/edit" : "/profile/edit/option"}

--- a/app/javascript/src/components/Navbar/UserInfo.tsx
+++ b/app/javascript/src/components/Navbar/UserInfo.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { NavAvatarSVG } from "miruIcons";
 
 const UserInfo = ({ user }) => (
-  <div className="overflow-XIcon-auto flex h-16 w-full items-center bg-miru-gray-100 p-4 lg:mt-6">
+  <div className="overflow-XIcon-auto flex h-16 w-full items-center bg-miru-gray-100 p-4">
     <img alt="avatar" className="mr-2" src={NavAvatarSVG} />
     <div className="overflow-XIcon-auto flex flex-col">
       <span className="pt-1 text-base font-bold leading-5">{`${user.first_name} ${user.last_name}`}</span>

--- a/app/javascript/src/components/Navbar/index.tsx
+++ b/app/javascript/src/components/Navbar/index.tsx
@@ -7,14 +7,12 @@ import UserInfo from "./UserInfo";
 
 const Navbar = ({ user, companyRole }) => (
   <div className="fixed top-0 bottom-0 left-0 flex h-full w-1/6 flex-col justify-between shadow-2xl">
-    <div>
-      <Header />
+    <Header />
+    <div className="flex h-full flex-col justify-between overflow-y-auto">
       <Options companyRole={companyRole} />
-    </div>
-    <div>
       <UserActions />
-      <UserInfo user={user} />
     </div>
+    <UserInfo user={user} />
   </div>
 );
 

--- a/app/javascript/src/components/TimeTracking/WeeklyEntriesCard.tsx
+++ b/app/javascript/src/components/TimeTracking/WeeklyEntriesCard.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 
 import { minFromHHMM, minToHHMM, validateTimesheetEntry } from "helpers";
 import Logger from "js-logger";
-import { CheckedCheckboxSVG, UncheckedCheckboxSVG, EditSVG } from "miruIcons";
+import { CheckedCheckboxSVG, UncheckedCheckboxSVG, EditIcon } from "miruIcons";
 import { TimeInput, Toastr } from "StyledComponents";
 
 import timesheetEntryApi from "apis/timesheet-entry";
@@ -168,10 +168,10 @@ const WeeklyEntriesCard = ({
 
   return (
     <div className="week-card mt-4 w-full rounded-lg p-6 shadow-xl">
-      <div className="flex w-full items-center">
-        <div className="mr-2 flex w-auto overflow-scroll xl:mr-10">
+      <div className="flex w-full items-center justify-between">
+        <div className="mr-2 flex w-1/15 flex-wrap items-center justify-start xl:mr-10">
           <p className="text-xs xl:text-sm xxl:text-lg">{client}</p>
-          <p className="mx-auto text-xs xl:text-sm xxl:text-lg">•</p>
+          <p className="ml-2 mr-auto text-xs xl:text-sm xxl:text-lg">•</p>
           <p className="text-xs xl:text-sm xxl:text-lg">{project}</p>
         </div>
         <div className="flex w-1/60 items-center justify-between">
@@ -206,11 +206,11 @@ const WeeklyEntriesCard = ({
         <div className="w-1/10 text-center text-base font-bold xl:text-xl">
           {minToHHMM(weeklyTotalHours)}
         </div>
-        <div className="flex w-1/10 justify-around">
-          <img
-            alt="edit"
-            className="icon-hover ml-8 h-4 w-4 cursor-pointer"
-            src={EditSVG}
+        <div className="flex w-1/10 items-center justify-center">
+          <EditIcon
+            className="cursor-pointer text-miru-han-purple-1000"
+            size={16}
+            weight="bold"
             onClick={() => {
               if (!isWeeklyEditing) setProjectSelected(false);
             }}


### PR DESCRIPTION
### **Notion :**
NA
### **What :**
- Fixed alignment of week view
- Added scroll bar to side navigation if screen is small.
### **Why :**
- UI was not aligned for week view
- We were not able to see overflowing options on side navigation. 
### **Preview :**
Before:
<img width="1383" alt="Screenshot 2023-05-25 at 4 15 00 PM" src="https://github.com/saeloun/miru-web/assets/72149587/32bea0b6-dd24-475a-8c9e-5044385970b2">

After:
<img width="1464" alt="Screenshot 2023-05-25 at 4 07 07 PM" src="https://github.com/saeloun/miru-web/assets/72149587/a0da44a1-6702-4288-a81c-95a3c6e95e90">

<img width="1147" alt="Screenshot 2023-05-25 at 4 06 57 PM" src="https://github.com/saeloun/miru-web/assets/72149587/1d4311ce-2d9c-48f8-bb93-4f81010ff63a">


### **Todos** (for testing):
- Tested on different screen sizes