### PR TITLE
Client email changes

### DIFF
--- a/app/controllers/internal_api/v1/clients_controller.rb
+++ b/app/controllers/internal_api/v1/clients_controller.rb
@@ -3,12 +3,8 @@
 class InternalApi::V1::ClientsController < InternalApi::V1::ApplicationController
   def index
     authorize Client
-    query = current_company.clients.kept.ransack({ name_or_email_cont: params[:q] })
-    clients = query.result(distinct: true)
-    client_details = clients.map { |client| client.client_detail(params[:time_frame]) }
-    total_minutes = (client_details.map { |client| client[:minutes_spent] }).sum
-    overdue_outstanding_amount = current_company.overdue_and_outstanding_and_draft_amount
-    render json: { client_details:, total_minutes:, overdue_outstanding_amount: }, status: :ok
+    data = Clients::IndexService.new(current_company, params).process
+    render json: data, status: :ok
   end
 
   def create

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -6,7 +6,7 @@
 #  id           :bigint           not null, primary key
 #  address      :string
 #  discarded_at :datetime
-#  email        :string
+#  email        :string           default([]), is an Array
 #  name         :string           not null
 #  phone        :string
 #  created_at   :datetime         not null
@@ -16,10 +16,9 @@
 #
 # Indexes
 #
-#  index_clients_on_company_id            (company_id)
-#  index_clients_on_discarded_at          (discarded_at)
-#  index_clients_on_email_and_company_id  (email,company_id) UNIQUE
-#  index_clients_on_name_and_company_id   (name,company_id) UNIQUE
+#  index_clients_on_company_id           (company_id)
+#  index_clients_on_discarded_at         (discarded_at)
+#  index_clients_on_name_and_company_id  (name,company_id) UNIQUE
 #
 # Foreign Keys
 #
@@ -42,13 +41,17 @@ class Client < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 },
     uniqueness: { scope: :company_id, case_sensitive: false, message: "The client %{value} already exists" }
   validates :phone, length: { maximum: 15 }
-  validates :email, presence: true, uniqueness: { scope: :company_id }, format: { with: Devise.email_regexp }
+  validates :emails, presence: true, length: { maximum: 5, message: "Only 5 emails are allowed." }
+  validate :validate_email_format
 
   after_discard :discard_projects
   after_commit :reindex_projects
+  after_commit :refresh_client_index
 
   accepts_nested_attributes_for :addresses, reject_if: :address_attributes_blank?, allow_destroy: true
   scope :with_ids, -> (client_ids) { where(id: client_ids) if client_ids.present? }
+
+  searchkick text_middle: [:name, :email]
 
   def reindex_projects
     projects.reindex
@@ -144,6 +147,18 @@ class Client < ApplicationRecord
       total_outstanding_amount: status_and_amount["sent"] + status_and_amount["viewed"],
       total_overdue_amount: status_and_amount["overdue"]
     }
+  end
+
+  def validate_email_format
+    invalid_email = []
+    emails.each do |mail_id|
+      invalid_email << mail_id unless mail_id.match?(Devise.email_regexp)
+    end
+    errors.add(:emails, "Invalid email ID") if invalid_email.present?
+  end
+
+  def refresh_client_index
+    Client.search_index.refresh
   end
 
   def address_attributes_blank?(attributes)

--- a/app/policies/client_policy.rb
+++ b/app/policies/client_policy.rb
@@ -49,7 +49,7 @@ class ClientPolicy < ApplicationPolicy
   def permitted_attributes
     [
       :name,
-      :email,
+      email: [],
       :phone,
       :logo,
       addresses_attributes: [:id, :address_line_1, :address_line_2, :city, :state, :country, :pin]

--- a/app/services/clients/index_service.rb
+++ b/app/services/clients/index_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Clients
+  class IndexService < ApplicationService
+    attr_reader :params, :current_company
+
+    def initialize(current_company, params)
+      @current_company = current_company
+      @params = params
+    end
+
+    def process
+      @_clients ||= clients
+
+      {
+        client_details:,
+        total_minutes:,
+        overdue_outstanding_amount:
+      }
+    end
+
+    private
+
+      def clients
+        if params[:query].present?
+          search_clients(search_term, where_clause)
+        else
+          current_company.clients
+        end
+      end
+
+      def search_term
+        @_search_term = params[:query].presence || "*"
+      end
+
+      def where_clause
+        { company_id: current_company.id }
+      end
+
+      def search_clients(search_term, where_clause)
+        Client.search(
+          search_term,
+          fields: [:name, :email],
+          match: :text_middle,
+          where: where_clause
+        )
+      end
+
+      def client_details
+        clients.map { |client| client.client_detail(params[:time_frame]) }
+      end
+
+      def total_minutes
+        (client_details.map { |client| client[:minutes_spent] }).sum
+      end
+
+      def overdue_outstanding_amount
+        current_company.overdue_and_outstanding_and_draft_amount
+      end
+  end
+end

--- a/db/migrate/20230526061644_add_emails_to_clients.rb
+++ b/db/migrate/20230526061644_add_emails_to_clients.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailsToClients < ActiveRecord::Migration[7.0]
+  def change
+    add_column :clients, :emails, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20230526061821_copy_client_email_to_emails_column.rb
+++ b/db/migrate/20230526061821_copy_client_email_to_emails_column.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CopyClientEmailToEmailsColumn < ActiveRecord::Migration[7.0]
+  def change
+    Client.find_each do |client|
+      client.update(emails: client.email) if client.email.present?
+    end
+  end
+end

--- a/db/migrate/20230526061908_remove_client_email.rb
+++ b/db/migrate/20230526061908_remove_client_email.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveClientEmail < ActiveRecord::Migration[7.0]
+  def change
+    # https://www.rubydoc.info/gems/strong_migrations/0.7.6
+    safety_assured { remove_column :clients, :email }
+  end
+end

--- a/db/migrate/20230526062007_rename_client_emails_to_email.rb
+++ b/db/migrate/20230526062007_rename_client_emails_to_email.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameClientEmailsToEmail < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { rename_column :clients, :emails, :email }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_125008) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_26_062007) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,16 +61,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_125008) do
   create_table "clients", force: :cascade do |t|
     t.bigint "company_id", null: false
     t.string "name", null: false
-    t.string "email"
     t.string "phone"
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
     t.string "stripe_id"
+    t.string "email", default: [], array: true
     t.index ["company_id"], name: "index_clients_on_company_id"
     t.index ["discarded_at"], name: "index_clients_on_discarded_at"
-    t.index ["email", "company_id"], name: "index_clients_on_email_and_company_id", unique: true
     t.index ["name", "company_id"], name: "index_clients_on_name_and_company_id", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,9 +47,11 @@ puts "Employment Created"
 
 microsoft_client = company.clients.create!(
   name: "Microsoft",
-  email: "support@example.com",
+  email: ["support@example.com"],
   phone: "+1 9999999991"
 )
+
+Client.reindex
 
 puts "Clients Created"
 

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :client do
     company
     name { Faker::Name.unique.name[0..30] }
-    email { Faker::Internet.unique.safe_email }
+    email { [Faker::Internet.unique.safe_email] }
     phone { Faker::PhoneNumber.phone_number_with_country_code.slice(0, 15) }
 
     after :create do |client|
@@ -27,6 +27,12 @@ FactoryBot.define do
         file_name = "test-image.png"
         file_path = Rails.root.join("spec", "support", "fixtures", file_name)
         client.logo.attach(io: File.open(file_path), filename: file_name, content_type: "image/png")
+      end
+    end
+
+    trait :reindex do
+      after(:create) do |client, _evaluator|
+        client.reindex(refresh: true)
       end
     end
   end

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe InvoiceMailer, type: :mailer do
     let(:company) { create :company, :with_logo }
     let(:client) { create :client, company: }
     let(:invoice) { create :invoice, client:, company: }
-    let(:recipients) { [invoice.client.email, "miru@example.com"] }
+    let(:recipients) { invoice.client.email << "miru@example.com" }
     let(:subject) { "Invoice (#{invoice.invoice_number}) due on #{invoice.due_date}" }
     let(:mail) { InvoiceMailer.with(invoice:, subject:, recipients:).invoice }
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Client, type: :model do
   subject { create(:client) }
 
+  let(:message) { "Only 5 emails are allowed." }
+
   describe "Validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:email) }
@@ -16,10 +18,12 @@ RSpec.describe Client, type: :model do
       expect(new_client.errors[:name]).to include("The client #{existing_client.name.upcase} already exists")
     end
 
-    it { is_expected.to validate_uniqueness_of(:email).scoped_to(:company_id) }
-    it { is_expected.to allow_value("valid@email.com").for(:email) }
-    it { is_expected.not_to allow_value("invalid@email").for(:email) }
+    it { is_expected.not_to allow_value([]).for(:email) }
+    it { is_expected.not_to allow_value("valid@email.com").for(:email) }
+    it { is_expected.to allow_value(["valid@email.com"]).for(:email) }
+    it { is_expected.not_to allow_value(["invalid@email"]).for(:email) }
     it { is_expected.to validate_length_of(:name).is_at_most(30) }
+    it { is_expected.not_to allow_value(Array.new(6, "abc@example.com")).for(:email).with_message(message) }
     it { is_expected.to validate_length_of(:phone).is_at_most(15) }
   end
 

--- a/spec/policies/client_policy_spec.rb
+++ b/spec/policies/client_policy_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe ClientPolicy, type: :policy do
     end
   end
 
+  describe "#permitted_attributes" do
+    subject { described_class.new(admin, company).permitted_attributes }
+
+    it "returns array of a permitted attributes" do
+      expect(subject).to match_array([:name, :phone, :address, :logo, email: []])
+    end
+  end
+
   describe "policy_scope" do
     let(:another_company) { create(:company) }
     let(:client_2) { create(:client, company:) }

--- a/spec/requests/internal_api/v1/clients/create_spec.rb
+++ b/spec/requests/internal_api/v1/clients/create_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "InternalApi::V1::Client#create", type: :request do
       it "throws 422 if the name doesn't exist" do
         send_request :post, internal_api_v1_clients_path(
           client: {
-            email: "test@client.com",
+            email: ["test@client.com"],
             description: "Rspec Test",
             phone: "7777777777",
             addresses_attributes: [attributes_for(:address)]
@@ -44,11 +44,36 @@ RSpec.describe "InternalApi::V1::Client#create", type: :request do
         expect(json_response["errors"]).to eq("can't be blank")
       end
 
+      it "throws 422 if the email doesn't exist" do
+        send_request :post, internal_api_v1_clients_path(
+          client: {
+            name: "First name",
+            description: "Rspec Test",
+            phone: "7777777777",
+            address: "Somewhere on Earth"
+          }), headers: auth_headers(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["errors"]).to eq("Email can't be blank")
+      end
+
+      it "throws 422 if the email is not an array" do
+        send_request :post, internal_api_v1_clients_path(
+          client: {
+            name: "First name",
+            email: "test@client.com",
+            description: "Rspec Test",
+            phone: "7777777777",
+            address: "Somewhere on Earth"
+          }), headers: auth_headers(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["errors"]).to eq("Email can't be blank")
+      end
+
       it "throws 422 if the address_line_1 is blank" do
         send_request :post, internal_api_v1_clients_path(
           client: {
             name: "ABC",
-            email: "test@client.com",
+            email: ["test@client.com"],
             description: "Rspec Test",
             phone: "7777777777",
             addresses_attributes: [invalid_address_attributes]

--- a/spec/requests/internal_api/v1/clients/index_spec.rb
+++ b/spec/requests/internal_api/v1/clients/index_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::Clients#index", type: :request do
-  let(:company) { create(:company) }
-  let(:user) { create(:user, current_workspace_id: company.id) }
-  let(:client_1) { create(:client, company:) }
-  let(:client_2) { create(:client, company:) }
-  let(:client_3) { create(:client, company:, name: "john") }
+  let!(:company) { create(:company) }
+  let!(:user) { create(:user, current_workspace_id: company.id) }
+  let!(:client_1) { create(:client, :reindex, name: "Microsoft", company:) }
+  let!(:client_2) { create(:client, :reindex, company:) }
+  let!(:client_3) { create(:client, :reindex, company:, name: "john") }
 
   let(:project_1) { create(:project, client: client_1) }
   let(:project_2) { create(:project, client: client_2) }
@@ -20,6 +20,8 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
       sign_in user
       create_list(:timesheet_entry, 5, user:, project: project_1)
       create_list(:timesheet_entry, 5, user:, project: project_2)
+      Client.search_index.refresh
+      Client.reindex
       send_request :get, internal_api_v1_clients_path, headers: auth_headers(user)
     end
 
@@ -48,7 +50,7 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
       end
     end
 
-    context "for ransack search" do
+    context "when ransack clients" do
       before do
         create(:employment, company:, user:)
         user.add_role :admin, company
@@ -61,17 +63,27 @@ RSpec.describe "InternalApi::V1::Clients#index", type: :request do
           id: client_1.id, name: client_1.name, email: client_1.email, phone: client_1.phone,
           address: client_1.current_address, minutes_spent: client_1.total_hours_logged(time_frame), logo: ""
         }]
+        send_request :get, internal_api_v1_clients_path, params: { q: client_1.name }, headers: auth_headers(user)
         expect(response).to have_http_status(:ok)
         expect(json_response["client_details"]).to eq(JSON.parse(client_details.to_json))
       end
     end
 
     it "returns all the clients when query params are empty" do
-      client_details = [{
-        id: client_1.id, name: client_1.name, email: client_1.email, phone: client_1.phone,
-        address: client_1.current_address, minutes_spent: client_1.total_hours_logged(time_frame), logo: ""
-      }, id: client_2.id, name: client_2.name, email: client_2.email, phone: client_2.phone,
-         address: client_2.current_address, minutes_spent: client_2.total_hours_logged(time_frame), logo: "" ]
+      client_details = [
+        {
+          id: client_1.id, name: client_1.name, email: client_1.email, phone: client_1.phone, address: client_1.address,
+          minutes_spent: client_1.total_hours_logged(time_frame), logo: ""
+        },
+        {
+          id: client_2.id, name: client_2.name, email: client_2.email, phone: client_2.phone, address: client_2.address,
+          minutes_spent: client_2.total_hours_logged(time_frame), logo: ""
+        },
+        {
+          id: client_3.id, name: client_3.name, email: client_3.email, phone: client_3.phone, address: client_3.address,
+          minutes_spent: client_3.total_hours_logged(time_frame), logo: ""
+        }
+      ]
 
       expect(response).to have_http_status(:ok)
       expect(json_response["client_details"]).to eq(JSON.parse(client_details.to_json))

--- a/spec/requests/internal_api/v1/clients/update_spec.rb
+++ b/spec/requests/internal_api/v1/clients/update_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
     create(
       :client,
       company:,
-      name: "Client", email: "client@example.com"
+      name: "Client", email: ["client@example.com"]
     )
   }
 
@@ -28,7 +28,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
             client: {
               id: client.id,
               name: "Test Client",
-              email: "test@example.com",
+              email: ["test@example.com"],
               phone: "Test phone",
               addresses_attributes: [{
                 id: client.current_address.id,
@@ -41,7 +41,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
       it "updates client" do
         client.reload
         expect(client.name).to eq("Test Client")
-        expect(client.email).to eq("test@example.com")
+        expect(client.email).to eq(["test@example.com"])
         expect(client.current_address.address_line_1).to eq("updated address")
       end
 
@@ -82,7 +82,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
           client: {
             id: client.id,
             name: "Test Client",
-            email: "test@example.com",
+            email: ["test@example.com"],
             phone: "Test phone",
             addresses_attributes: [attributes_for(:address)]
           }
@@ -105,7 +105,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
           client: {
             id: client.id,
             name: "Test Client",
-            email: "test@example.com",
+            email: ["test@example.com"],
             phone: "Test phone",
             addresses_attributes: [attributes_for(:address)]
           }
@@ -124,7 +124,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
           client: {
             id: client.id,
             name: "Test Client",
-            email: "test@example.com",
+            email: ["test@example.com"],
             phone: "Test phone",
             addresses_attributes: [attributes_for(:address)]
           }
@@ -147,7 +147,7 @@ RSpec.describe "InternalApi::V1::Clients#update", type: :request do
           client: {
             id: client.id,
             name: "Test Client",
-            email: "test@example.com",
+            email: ["test@example.com"],
             phone: "Test phone",
             addresses_attributes: [attributes_for(:address)]
           }


### PR DESCRIPTION
## Notion:
[Notion Card](https://www.notion.so/saeloun/Backend-Add-new-client-form-should-support-multiple-emails-d30681a5f0e94742a249de1950ada1f8)

## Description:
- Backend is allowing multiple emails for a client.
- Saving emails as an array in the database.
- Replaced Ransack with Searchkick for the Client.
- Added Searchkick in the client model.
- Updated test cases.

## Screenshots:

Note: Frontend changes are required. In this PR we handled backend changes.
# Note
- This PR contains the changes from this PR - https://github.com/saeloun/miru-web/pull/1183.