### PR TITLE
Raise exception on google auth if user is not saved

### DIFF
--- a/lib/authentication/google.rb
+++ b/lib/authentication/google.rb
@@ -29,7 +29,7 @@ module Authentication
             password: Devise.friendly_token[0, 20]
           )
           user.skip_confirmation!
-          user.save
+          user.save!
           user.identities.create(provider: PROVIDER, uid: google_id)
         end
         user


### PR DESCRIPTION
### What
- Raise exception on Google auth if the user is not saved