### PR TITLE
Use text fields to show error

### DIFF
--- a/app/javascript/src/apis/authentication.ts
+++ b/app/javascript/src/apis/authentication.ts
@@ -1,19 +1,28 @@
 import axios from "./api";
 
-const signin = payload => axios.post("/users/login", { user: payload });
+const authApi = axios.create({
+  baseURL: "/internal_api/v1",
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-CSRF-TOKEN": document
+      .querySelector('[name="csrf-token"]')
+      .getAttribute("content"),
+  },
+});
 
-const signup = payload => axios.post("/users/signup", { user: payload });
+const signin = payload => authApi.post("/users/login", { user: payload });
 
-const logout = () => axios.delete("/users/logout");
+const signup = payload => authApi.post("/users/signup", { user: payload });
 
 const forgotPassword = payload =>
-  axios.post("/users/forgot_password", { user: payload });
+  authApi.post("/users/forgot_password", { user: payload });
 
 const resetPassword = payload =>
-  axios.put("/users/reset_password", { user: payload });
+  authApi.put("/users/reset_password", { user: payload });
 
 const sendEmailConfirmation = payload =>
-  axios.post(`/users/resend_confirmation_email`, { user: payload });
+  authApi.post(`/users/resend_confirmation_email`, { user: payload });
 
 const googleAuth = () =>
   axios
@@ -31,7 +40,6 @@ const authenticationApi = {
   forgotPassword,
   resetPassword,
   googleAuth,
-  logout,
   sendEmailConfirmation,
 };
 

--- a/app/javascript/src/apis/authentication.ts
+++ b/app/javascript/src/apis/authentication.ts
@@ -22,7 +22,7 @@ const resetPassword = payload =>
   authApi.put("/users/reset_password", { user: payload });
 
 const sendEmailConfirmation = payload =>
-  authApi.post(`/users/resend_confirmation_email`, { user: payload });
+  axios.post(`/users/resend_confirmation_email`, { user: payload });
 
 const googleAuth = () =>
   axios

--- a/app/javascript/src/apis/companies.ts
+++ b/app/javascript/src/apis/companies.ts
@@ -1,10 +1,20 @@
 import axios from "./api";
 
 const path = "/companies";
+const authApi = axios.create({
+  baseURL: "/internal_api/v1",
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-CSRF-TOKEN": document
+      .querySelector('[name="csrf-token"]')
+      .getAttribute("content"),
+  },
+});
 
 const index = async () => axios.get(`${path}`);
 
-const create = payload => axios.post(path, payload);
+const create = payload => authApi.post(path, payload);
 
 const update = (id, payload) => axios.put(`${path}/${id}`, payload);
 

--- a/app/javascript/src/apis/logoutApi.ts
+++ b/app/javascript/src/apis/logoutApi.ts
@@ -1,0 +1,3 @@
+import axios from "./api";
+
+export const logoutApi = () => axios.delete("/users/logout");

--- a/app/javascript/src/components/Authentication/ForgotPassword/index.tsx
+++ b/app/javascript/src/components/Authentication/ForgotPassword/index.tsx
@@ -26,11 +26,15 @@ const ForgotPassword = () => {
     setEmailToSendResetPasswordLink("");
   }, []);
 
-  const handlePasswordFormSubmit = async values => {
+  const handlePasswordFormSubmit = async (values, { setFieldError }) => {
     const email = values?.email?.trim();
-    if (email) {
-      await authenticationApi.forgotPassword({ email });
-      setEmailToSendResetPasswordLink(email);
+    try {
+      if (email) {
+        await authenticationApi.forgotPassword({ email });
+        setEmailToSendResetPasswordLink(email);
+      }
+    } catch (error) {
+      setFieldError("email", error.response.data.error);
     }
   };
 

--- a/app/javascript/src/components/Authentication/ResetPassword/index.tsx
+++ b/app/javascript/src/components/Authentication/ResetPassword/index.tsx
@@ -22,18 +22,22 @@ interface ResetPasswordFormValues {
 const ResetPassword = () => {
   const searchParams = new URLSearchParams(document.location.search);
 
-  const handleResetPasswordFormSubmit = async values => {
+  const handleResetPasswordFormSubmit = async (values, { setFieldError }) => {
     const { password, confirm_password } = values;
     const payload = {
       reset_password_token: searchParams.get("reset_password_token"),
       password,
       password_confirmation: confirm_password,
     };
-    const res = await authenticationApi.resetPassword(payload);
-    if (res.status == 200) {
-      setTimeout(() => {
-        window.location.assign(`${window.location.origin}`);
-      }, 500);
+    try {
+      const res = await authenticationApi.resetPassword(payload);
+      if (res.status == 200) {
+        setTimeout(() => {
+          window.location.assign(`${window.location.origin}`);
+        }, 500);
+      }
+    } catch (error) {
+      setFieldError("confirm_password", error.response.data.error);
     }
   };
 

--- a/app/javascript/src/components/Authentication/ResetPassword/utils.ts
+++ b/app/javascript/src/components/Authentication/ResetPassword/utils.ts
@@ -7,13 +7,13 @@ export const resetPasswordFormInitialValues = {
 
 export const resetPasswordFormValidationSchema = Yup.object().shape({
   password: Yup.string()
-    .matches(/^\S.*\S$/, "Password can not start or end with a blank space")
+    .matches(/^\S.*\S$/, "Password cannot start or end with a blank space")
     .matches(
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s\x00-\x1F\x7F])[\S\s]{8,}$/, // eslint-disable-line
       "Must Contain at least 8 Characters, One Uppercase, One Lowercase, One Number and One Special Character"
     )
-    .required("Password can not be blank"),
+    .required("Password cannot be blank"),
   confirm_password: Yup.string()
     .oneOf([Yup.ref("password"), null], "Passwords must match")
-    .required("Confirm Password can not be blank"),
+    .required("Confirm Password cannot be blank"),
 });

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState } from "react";
 import { Formik, Form, FormikProps } from "formik";
 import { GoogleSVG, MiruLogoSVG } from "miruIcons";
 import { useNavigate } from "react-router-dom";
+import { Toastr } from "StyledComponents";
 
 import authenticationApi from "apis/authentication";
 import { InputErrors, InputField } from "common/FormikFields";
@@ -50,6 +51,7 @@ const SignInForm = () => {
     } catch (error) {
       if (error?.response?.data?.unconfirmed) {
         navigate(`/email_confirmation?email=${values.email}`);
+        Toastr.error(error.response.data.error);
       } else if (error?.response?.data?.error) {
         setFieldError("password", error.response.data.error);
       }

--- a/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
+++ b/app/javascript/src/components/Authentication/SignIn/SignInForm.tsx
@@ -23,7 +23,6 @@ interface SignInFormValues {
 const SignInForm = () => {
   const [privacyModal, setPrivacyModal] = useState(false);
   const [termsOfServiceModal, setTermsOfServiceModal] = useState(false);
-
   const authDispatch = useAuthDispatch();
   const navigate = useNavigate();
 
@@ -32,7 +31,7 @@ const SignInForm = () => {
     .querySelector('[name="csrf-token"]')
     .getAttribute("content");
 
-  const handleSignInFormSubmit = async (values: any) => {
+  const handleSignInFormSubmit = async (values: any, { setFieldError }) => {
     try {
       const res = await authenticationApi.signin(values);
       //@ts-expect-error for authDispatch initial values
@@ -51,6 +50,8 @@ const SignInForm = () => {
     } catch (error) {
       if (error?.response?.data?.unconfirmed) {
         navigate(`/email_confirmation?email=${values.email}`);
+      } else if (error?.response?.data?.error) {
+        setFieldError("password", error.response.data.error);
       }
     }
   };

--- a/app/javascript/src/components/Authentication/SignIn/utils.ts
+++ b/app/javascript/src/components/Authentication/SignIn/utils.ts
@@ -9,5 +9,5 @@ export const signInFormValidationSchema = Yup.object().shape({
   email: Yup.string()
     .email("Invalid email ID")
     .required("Email ID cannot be blank"),
-  password: Yup.string().required("Password can not be blank"),
+  password: Yup.string().required("Password cannot be blank"),
 });

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -34,17 +34,23 @@ const SignUpForm = () => {
     .querySelector('[name="csrf-token"]')
     .getAttribute("content");
 
-  const handleSignUpFormSubmit = async (values: any) => {
-    const { firstName, lastName, email, password, confirm_password } = values;
-    const payload = {
-      first_name: firstName,
-      last_name: lastName,
-      email,
-      password,
-      password_confirmation: confirm_password,
-    };
-    const res = await authenticationApi.signup(payload);
-    navigate(`/email_confirmation?email=${res.data.email}`);
+  const handleSignUpFormSubmit = async (values: any, { setFieldError }) => {
+    try {
+      const { firstName, lastName, email, password, confirm_password } = values;
+      const payload = {
+        first_name: firstName,
+        last_name: lastName,
+        email,
+        password,
+        password_confirmation: confirm_password,
+      };
+      const res = await authenticationApi.signup(payload);
+      navigate(`/email_confirmation?email=${res.data.email}`);
+    } catch (error) {
+      if (error?.response?.data?.error?.email) {
+        setFieldError("email", error.response.data.error.email[0]);
+      }
+    }
   };
 
   const showPasswordCriteria = (errors, touched) => {

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -16,8 +16,8 @@ import { signUpFormInitialValues, signUpFormValidationSchema } from "./utils";
 import FooterLinks from "../FooterLinks";
 
 interface SignUpFormValues {
-  firstName: string;
-  lastName: string;
+  first_name: string;
+  last_name: string;
   email: string;
   isAgreedTermsOfServices: boolean;
   password: string;
@@ -36,10 +36,12 @@ const SignUpForm = () => {
 
   const handleSignUpFormSubmit = async (values: any, { setFieldError }) => {
     try {
-      const { firstName, lastName, email, password, confirm_password } = values;
+      const { first_name, last_name, email, password, confirm_password } =
+        values;
+
       const payload = {
-        first_name: firstName,
-        last_name: lastName,
+        first_name,
+        last_name,
         email,
         password,
         password_confirmation: confirm_password,
@@ -47,8 +49,12 @@ const SignUpForm = () => {
       const res = await authenticationApi.signup(payload);
       navigate(`/email_confirmation?email=${res.data.email}`);
     } catch (error) {
-      if (error?.response?.data?.error?.email) {
-        setFieldError("email", error.response.data.error.email[0]);
+      if (error?.response?.data?.error) {
+        const errorData = error.response.data.error;
+        Object.keys(errorData).forEach(key => {
+          const errorMessages = errorData[key];
+          setFieldError(key, errorMessages[0]);
+        });
       }
     }
   };
@@ -76,15 +82,15 @@ const SignUpForm = () => {
 
   const isBtnDisabled = (values: SignUpFormValues, errors) =>
     !(
-      values?.firstName?.trim() &&
-      values?.lastName?.trim() &&
+      values?.first_name?.trim() &&
+      values?.last_name?.trim() &&
       values.email?.trim() &&
       values?.password?.trim() &&
       values?.confirm_password?.trim() &&
       values?.password?.trim() == values?.confirm_password?.trim()
     ) ||
-    errors?.firstName ||
-    errors?.lastName?.trim() ||
+    errors?.first_name ||
+    errors?.last_name?.trim() ||
     errors.email?.trim() ||
     errors?.password?.trim() ||
     errors?.confirm_password?.trim();
@@ -127,32 +133,32 @@ const SignUpForm = () => {
                   <div className="flex justify-between">
                     <div className="field relative mr-2 w-1/2 md:mr-6 lg:w-168">
                       <InputField
-                        hasError={errors.firstName && touched.firstName}
-                        id="firstName"
+                        hasError={errors.first_name && touched.first_name}
+                        id="first_name"
                         label="First Name"
                         labelClassName="p-0"
-                        name="firstName"
+                        name="first_name"
                         setFieldError={setFieldError}
                         setFieldValue={setFieldValue}
                       />
                       <InputErrors
-                        fieldErrors={errors.firstName}
-                        fieldTouched={touched.firstName}
+                        fieldErrors={errors.first_name}
+                        fieldTouched={touched.first_name}
                       />
                     </div>
                     <div className="field relative w-1/2 lg:w-168">
                       <InputField
-                        hasError={errors.lastName && touched.lastName}
-                        id="lastName"
+                        hasError={errors.last_name && touched.last_name}
+                        id="last_name"
                         label="Last Name"
                         labelClassName="p-0"
-                        name="lastName"
+                        name="last_name"
                         setFieldError={setFieldError}
                         setFieldValue={setFieldValue}
                       />
                       <InputErrors
-                        fieldErrors={errors.lastName}
-                        fieldTouched={touched.lastName}
+                        fieldErrors={errors.last_name}
+                        fieldTouched={touched.last_name}
                       />
                     </div>
                   </div>

--- a/app/javascript/src/components/Authentication/SignUp/utils.ts
+++ b/app/javascript/src/components/Authentication/SignUp/utils.ts
@@ -13,29 +13,29 @@ export const signUpFormValidationSchema = Yup.object().shape({
   firstName: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid first name")
     .max(20, "Maximum 20 characters are allowed")
-    .required("First name can not be blank"),
+    .required("First name cannot be blank"),
   lastName: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid last name")
     .max(20, "Maximum 20 characters are allowed")
-    .required("Last name can not be blank"),
+    .required("Last name cannot be blank"),
   email: Yup.string()
     .email("Invalid email ID")
     .required("Email ID cannot be blank"),
   password: Yup.string()
-    .matches(/^\S.*\S$/, "Password can not start or end with a blank space")
+    .matches(/^\S.*\S$/, "Password cannot start or end with a blank space")
     .matches(
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s\x00-\x1F\x7F])[\S\s]{8,}$/, // eslint-disable-line
       "Must Contain at least 8 Characters, One Uppercase, One Lowercase, One Number and One Special Character"
     )
-    .required("Password can not be blank"),
+    .required("Password cannot be blank"),
   confirm_password: Yup.string()
-    .matches(/^\S.*\S$/, "Password can not start or end with a blank space")
+    .matches(/^\S.*\S$/, "Password cannot start or end with a blank space")
     .matches(
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s\x00-\x1F\x7F])[\S\s]{8,}$/, // eslint-disable-line
       "Must Contain at least 8 Characters, One Uppercase, One Lowercase, One Number and One Special Character"
     )
     .oneOf([Yup.ref("password"), null], "Passwords must match")
-    .required("Password can not be blank"),
+    .required("Password cannot be blank"),
   isAgreedTermsOfServices: Yup.boolean().oneOf(
     [true],
     "Please agree to the terms and privacy policy to continue"

--- a/app/javascript/src/components/Authentication/SignUp/utils.ts
+++ b/app/javascript/src/components/Authentication/SignUp/utils.ts
@@ -1,8 +1,8 @@
 import * as Yup from "yup";
 
 export const signUpFormInitialValues = {
-  firstName: "",
-  lastName: "",
+  first_name: "",
+  last_name: "",
   email: "",
   isAgreedTermsOfServices: false,
   password: "",
@@ -10,11 +10,11 @@ export const signUpFormInitialValues = {
 };
 
 export const signUpFormValidationSchema = Yup.object().shape({
-  firstName: Yup.string()
+  first_name: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid first name")
     .max(20, "Maximum 20 characters are allowed")
     .required("First name cannot be blank"),
-  lastName: Yup.string()
+  last_name: Yup.string()
     .matches(/^[A-Za-z ]*$/, "Please enter valid last name")
     .max(20, "Maximum 20 characters are allowed")
     .required("Last name cannot be blank"),

--- a/app/javascript/src/components/Clients/ClientForm/formValidationSchema.ts
+++ b/app/javascript/src/components/Clients/ClientForm/formValidationSchema.ts
@@ -13,23 +13,23 @@ export const clientSchema = Yup.object().shape({
     .email("Invalid email ID")
     .required("Email ID cannot be blank"),
   phone: Yup.string()
-    .required("Business phone number can not be blank")
+    .required("Business phone number cannot be blank")
     .matches(phoneRegExp, "Please enter a valid business phone number"),
   address1: Yup.string()
-    .required("Address line can not be blank")
+    .required("Address line cannot be blank")
     .max(50, "Maximum 50 characters are allowed"),
   address2: Yup.string().max(50, "Maximum 50 characters are allowed"),
   country: Yup.object().shape({
-    value: Yup.string().required("Country can not be blank"),
+    value: Yup.string().required("Country cannot be blank"),
   }),
   state: Yup.object().shape({
-    value: Yup.string().required("State can not be blank"),
+    value: Yup.string().required("State cannot be blank"),
   }),
   city: Yup.object().shape({
-    value: Yup.string().required("City can not be blank"),
+    value: Yup.string().required("City cannot be blank"),
   }),
   zipcode: Yup.string()
-    .required("Zipcode line can not be blank")
+    .required("Zipcode line cannot be blank")
     .max(10, "Maximum 10 characters are allowed"),
 });
 

--- a/app/javascript/src/components/Navbar/UserActions.tsx
+++ b/app/javascript/src/components/Navbar/UserActions.tsx
@@ -6,7 +6,7 @@ import { SettingIcon, SignOutIcon, Switcher } from "miruIcons";
 import { NavLink } from "react-router-dom";
 import { Avatar, Tooltip } from "StyledComponents";
 
-import authenticationApi from "apis/authentication";
+import { logoutApi } from "apis/logoutApi";
 import WorkspaceApi from "apis/workspaces";
 import { LocalStorageKeys } from "constants/index";
 import { useAuthDispatch } from "context/auth";
@@ -65,7 +65,7 @@ const UserActions = setVisiblity => {
   };
 
   const handleLogout = async () => {
-    await authenticationApi.logout();
+    await logoutApi();
     Object.values(LocalStorageKeys).forEach(key => {
       localStorage.removeItem(key);
     });

--- a/app/javascript/src/components/OrganizationSetup/CompanyDetailsForm/utils.ts
+++ b/app/javascript/src/components/OrganizationSetup/CompanyDetailsForm/utils.ts
@@ -7,26 +7,26 @@ const phoneRegExp =
 
 export const companyDetailsFormValidationSchema = Yup.object().shape({
   company_name: Yup.string()
-    .required("Company name can not be blank")
+    .required("Company name cannot be blank")
     .max(30, "Maximum 30 characters are allowed"),
   business_phone: Yup.string()
-    .required("Business phone number can not be blank")
+    .required("Business phone number cannot be blank")
     .matches(phoneRegExp, "Please enter a valid business phone number"),
   address_line_1: Yup.string()
-    .required("Address line can not be blank")
+    .required("Address line cannot be blank")
     .max(50, "Maximum 50 characters are allowed"),
   address_line_2: Yup.string().max(50, "Maximum 50 characters are allowed"),
   country: Yup.object().shape({
-    value: Yup.string().required("Country can not be blank"),
+    value: Yup.string().required("Country cannot be blank"),
   }),
   state: Yup.object().shape({
-    value: Yup.string().required("State can not be blank"),
+    value: Yup.string().required("State cannot be blank"),
   }),
   city: Yup.object().shape({
-    value: Yup.string().required("City can not be blank"),
+    value: Yup.string().required("City cannot be blank"),
   }),
   zipcode: Yup.string()
-    .required("Zipcode line can not be blank")
+    .required("Zipcode line cannot be blank")
     .max(10, "Maximum 10 characters are allowed"),
 });
 

--- a/app/javascript/src/components/OrganizationSetup/FinancialDetailsForm/utils.ts
+++ b/app/javascript/src/components/OrganizationSetup/FinancialDetailsForm/utils.ts
@@ -4,18 +4,18 @@ import { currencyList } from "constants/currencyList";
 
 export const financialDetailsFormValidationSchema = Yup.object().shape({
   base_currency: Yup.object().shape({
-    value: Yup.string().required("Base currency end can not be blank"),
+    value: Yup.string().required("Base currency end cannot be blank"),
   }),
   standard_rate: Yup.number().min(
     0,
     "Standard rate(per hour) must be greater than or equal to 0"
   ),
   year_end: Yup.object().shape({
-    value: Yup.string().required("Fiscal year end can not be blank"),
+    value: Yup.string().required("Fiscal year end cannot be blank"),
   }),
 
   date_format: Yup.object().shape({
-    value: Yup.string().required("Date format can not be blank"),
+    value: Yup.string().required("Date format cannot be blank"),
   }),
 });
 

--- a/app/javascript/src/components/PlanDetails/index.tsx
+++ b/app/javascript/src/components/PlanDetails/index.tsx
@@ -13,9 +13,9 @@ const PlanDetails = () => {
 
   const membersCountSchema = Yup.object().shape({
     membersCount: Yup.number()
-      .moreThan(0, "Team members can not be 0")
+      .moreThan(0, "Team members cannot be 0")
       .typeError("Enter valid data")
-      .required("Field can not be empty"),
+      .required("Field cannot be empty"),
   });
 
   const handleCountChange = value => {

--- a/app/javascript/src/components/Profile/UserDetail/Edit/validationSchema.ts
+++ b/app/javascript/src/components/Profile/UserDetail/Edit/validationSchema.ts
@@ -26,7 +26,7 @@ export const userSchema = {
     is: true,
     then: Yup.string()
       .required("Please enter password")
-      .matches(/^\S.*\S$/, "Password can not start or end with a blank space")
+      .matches(/^\S.*\S$/, "Password cannot start or end with a blank space")
       .matches(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s\x00-\x1F\x7F])[\S\s]{8,}$/, // eslint-disable-line
         "Must Contain at least 8 Characters, One Uppercase, One Lowercase, One Number and One Special Character"
@@ -40,7 +40,7 @@ export const userSchema = {
   confirmPassword: Yup.string().when("changePassword", {
     is: true,
     then: Yup.string()
-      .matches(/^\S.*\S$/, "Password can not start or end with a blank space")
+      .matches(/^\S.*\S$/, "Password cannot start or end with a blank space")
       .matches(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s\x00-\x1F\x7F])[\S\s]{8,}$/, // eslint-disable-line
         "Must Contain at least 8 Characters, One Uppercase, One Lowercase, One Number and One Special Character"

--- a/spec/system/companies/create_spec.rb
+++ b/spec/system/companies/create_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Create company", type: :system do
           fill_in "zipcode", with: address.pin
           click_button "Next", disabled: true
 
-          expect(page).to have_content("Company name can not be blank")
+          expect(page).to have_content("Company name cannot be blank")
         end
       end
 

--- a/spec/system/users/email_confirmations_spec.rb
+++ b/spec/system/users/email_confirmations_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe "Email confirmations", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user2.first_name
-        fill_in "lastName", with: user2.last_name
+        fill_in "first_name", with: user2.first_name
+        fill_in "last_name", with: user2.last_name
         fill_in "email", with: user2.email
         fill_in "password", with: user2.password
         fill_in "confirm_password", with: user2.password

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: user.email
         fill_in "password", with: user.password
         fill_in "confirm_password", with: user.password
@@ -29,8 +29,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: user.email
         fill_in "password", with: "wohXyq-cusgoz-fexde0"
         fill_in "confirm_password", with: "wohXyq-cusgoz-fexde0"
@@ -47,8 +47,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: user.email
         fill_in "password", with: "My password with spaces@2023"
         fill_in "confirm_password", with: "My password with spaces@2023"
@@ -65,8 +65,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: user.email
         fill_in "password", with: user.password
         fill_in "confirm_password", with: user.password
@@ -92,8 +92,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: user.password
         fill_in "confirm_password", with: user.password
@@ -111,8 +111,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "Pass@1"
         fill_in "confirm_password", with: "Pass@1"
@@ -128,8 +128,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "password@2023"
         fill_in "confirm_password", with: "password@2023"
@@ -145,8 +145,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "PASSWORD@2023"
         fill_in "confirm_password", with: "PASSWORD@2023"
@@ -162,8 +162,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "@Password"
         fill_in "confirm_password", with: "@Password"
@@ -179,8 +179,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "Password2023"
         fill_in "confirm_password", with: "Password2023"
@@ -196,8 +196,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "Password 2023"
         fill_in "confirm_password", with: "Password 2023"
@@ -213,8 +213,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: " Password@2023"
         fill_in "confirm_password", with: " Password@2023"
@@ -230,8 +230,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "Password@2023 "
         fill_in "confirm_password", with: "Password@2023 "
@@ -247,8 +247,8 @@ RSpec.describe "User Signup", type: :system do
       with_forgery_protection do
         visit "/signup"
 
-        fill_in "firstName", with: user.first_name
-        fill_in "lastName", with: user.last_name
+        fill_in "first_name", with: user.first_name
+        fill_in "last_name", with: user.last_name
         fill_in "email", with: existing_user.email
         fill_in "password", with: "Welcome@123"
         fill_in "confirm_password", with: "HelloWorld@123"

--- a/spec/system/users/signup_spec.rb
+++ b/spec/system/users/signup_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "User Signup", type: :system do
 
         click_on "Sign Up"
 
-        expect(page).to have_content "Password can not start or end with a blank space"
+        expect(page).to have_content "Password cannot start or end with a blank space"
       end
     end
 
@@ -239,7 +239,7 @@ RSpec.describe "User Signup", type: :system do
 
         click_on "Sign Up"
 
-        expect(page).to have_content "Password can not start or end with a blank space"
+        expect(page).to have_content "Password cannot start or end with a blank space"
       end
     end
 


### PR DESCRIPTION
Notion https://www.notion.so/saeloun/The-error-message-should-be-displayed-on-the-sign-up-sign-in-form-instead-of-toast-message-for-the--3ee59dd5453e46c091074ea8c39f83a3
What
- Changed the text on all error messages to "cannot" instead of can not
- Displaying errors below the field when a user enters invalid credentials on the sign-in page
- Displaying errors below the field when a user enters an already registered email on the sign-up page
- Removed toasts from email confirmation and after creating company

<img width="1785" alt="Screenshot 2023-05-31 at 4 33 59 PM" src="https://github.com/saeloun/miru-web/assets/18750194/dbd69679-70af-45fd-b9b0-8d1007d094ca">
<img width="1782" alt="Screenshot 2023-05-31 at 4 34 18 PM" src="https://github.com/saeloun/miru-web/assets/18750194/3b421885-f090-430b-a151-6818dd1535b8">
<img width="1786" alt="Screenshot 2023-05-31 at 4 34 51 PM" src="https://github.com/saeloun/miru-web/assets/18750194/e1a1f058-6771-49d7-b18a-7abf947f731c">
<img width="1161" alt="Screenshot 2023-06-02 at 2 09 54 PM" src="https://github.com/saeloun/miru-web/assets/18750194/0b5b8744-bef6-4549-a1d3-b228b7042763">
<img width="1169" alt="Screenshot 2023-06-02 at 4 07 57 PM" src="https://github.com/saeloun/miru-web/assets/18750194/96729c01-e9bc-49d3-8e6f-7b3db47e57a2">
