### PR TITLE
Show team member name & fix styling

### DIFF
--- a/app/controllers/internal_api/v1/reports/time_entries_controller.rb
+++ b/app/controllers/internal_api/v1/reports/time_entries_controller.rb
@@ -5,7 +5,6 @@ class InternalApi::V1::Reports::TimeEntriesController < InternalApi::V1::Applica
     authorize :report
 
     reports_data = Reports::TimeEntries::ReportService.new(params, current_company, get_filters: true).process
-
     render :index,
       locals: reports_data,
       status: :ok

--- a/app/javascript/src/components/Reports/TimeEntryReport/index.tsx
+++ b/app/javascript/src/components/Reports/TimeEntryReport/index.tsx
@@ -140,10 +140,9 @@ const TimeEntryReport = () => {
     const response = await reportsApi.download(type, `?${queryParams}`);
     const url = window.URL.createObjectURL(new Blob([response.data]));
     const link = document.createElement("a");
-    const date = new Date();
+    const filename = `${selectedFilter.dateRange.label}.${type}`;
     link.href = url;
-    link.setAttribute("download", `${date.toISOString()}_miru_report.${type}`);
-    document.body.appendChild(link);
+    link.setAttribute("download", filename);
     link.click();
   };
 

--- a/app/views/pdfs/reports.html.erb
+++ b/app/views/pdfs/reports.html.erb
@@ -1,59 +1,54 @@
-<div class="main">
-  <div class="flex justify-between border-b-2 border-miru-gray-400 p-10 h-30">
-    <h2>Time Entry Report</h2>
-  </div>
+<div style="display: flex; justify-content: center; align-items: center; border-bottom: 2px solid #ccc; padding: 10px; height: 30px;">
+  <h2>Time Entry Report</h2>
+</div>
 
-  <div class="flex justify-between p-10">
-    <table>
-      <thead>
-        <th class="text-left w-2/5 border border-b-1">
-          <p>Project\</p>
-          <p>Client</p>
-        </th>
-        <th class="text-left w-2/5 px-3 border border-b-1">
-          Note
-        </th>
-        <th class="text-left w-1/5 border-b-1 border">
-          <p>Team Member\</p>
-          <p>Date</p>
-        </th>
-        <th class="text-right w-1/5 p-1 border border-b-1">
-          Hours Logged
-        </th>
-      </thead>
-      <tbody>
-        <% report_entries.each do |report| %>
-          <% if report[:label].present? %>
-            <tr>
-              <td colspan="4" class="text-sm text-left p-2 border border-b-1 bg-miru-dark-purple-400">
-                <%= report[:label] %>
-              </td>
-            </tr>
-          <% end %>
-          <% report[:entries].each do |entry| %>
-            <tr>
-              <td class="text-sm text-left w-2/5 p-2 border border-b-1">
-                <p class="text-miru-dark-purple-1000">
+<div style="display: flex; justify-content: space-between; padding: 10px;">
+  <table style="width: 100%; border-collapse: collapse">
+    <thead>
+      <th style="text-align: left; flex-basis: 25%; border: 1px solid #000;">
+        <p>Project\</p>
+        <p>Client</p>
+      </th>
+      <th style="text-align: left; flex-basis: 25%; padding: 3px;border: 1px solid #000; ">
+        Note
+      </th>
+      <th style="text-align: left; flex-basis: 25%; border: 1px solid #000; ">
+        <p>Team Member\</p>
+        <p>Date</p>
+      </th>
+      <th style="text-align: left; flex-basis: 25%; padding: 1px;border: 1px solid #000; ">
+        Hours Logged
+      </th>
+    </thead>
+    <tbody>
+      <% report_entries.each do |report| %>
+        <% report[:entries].each do |entry| %>
+          <tr>
+            <td style="font-size: 14px; text-align: center; flex-basis: 25%; padding: 2px; border: 1px solid #000;">
+              <p style="color: #1F2937; margin: 0;">
                 <%= entry.project_name %>
-                </p>
-                <p class="text-miru-dark-purple-400">
+              </p>
+              <p style="color: #6B7280; margin: 0;">
                 <%= entry.client_name %>
-                </p>
-              </td>
-              <td class="text-left text-xs px-3 w-2/5 p-2 border border-b-1">
-                <%= entry.note %>
-              </td>
-              <td class="text-xs w-1/5 p-2 border border-b-1">
-                <p class="text-miru-dark-purple-1000"><%= entry.user_full_name %></p>
-                <p class="text-miru-dark-purple-400"><%= CompanyDateFormattingService.new(entry.work_date, company: current_company, es_date_presence: true).process %></p>
-              </td>
-              <td class="text-right w-1/5 p-2 pl-3 border border-b-1">
-                <%= DurationFormatter.new(entry.duration).process %>
-              </td>
-            </tr>
-          <% end %>
+              </p>
+            </td>
+            <td style="text-align: left; font-size: 14px; flex-basis: 25%; padding: 2px;border: 1px solid #000;">
+              <%= entry.note %>
+            </td>
+            <td style="font-size: 14px; text-align: left; flex-basis: 25%; padding: 2px;border: 1px solid #000;">
+              <p style="color: #1F2937; margin: 0;">
+                <%= entry.user_name %>
+              </p>
+              <p style="color: #6B7280; margin: 0;">
+                <%= CompanyDateFormattingService.new(entry.work_date, company: current_company, es_date_presence: true).process %>
+              </p>
+            </td>
+            <td style="text-align: left; flex-basis: 25%; padding: 2px; border: 1px solid #000;">
+              <%= DurationFormatter.new(entry.duration).process %>
+            </td>
+          </tr>
         <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/spec/services/reports/time_entries/generate_pdf_spec.rb
+++ b/spec/services/reports/time_entries/generate_pdf_spec.rb
@@ -3,14 +3,18 @@
 require "rails_helper"
 
 RSpec.describe Reports::TimeEntries::GeneratePdf do
-  let!(:entry) { create(:timesheet_entry) }
-  let(:company) { create(:company) }
+  let(:report_entries) { [double("TimeEntry")] }
+  let(:current_company) { double("Company") }
+
+  subject { described_class.new(report_entries, current_company) }
 
   describe "#process" do
-    subject { described_class.new([{ label: "", entries: [entry] }], company).process }
+    it "generates a PDF report using Pdf::HtmlGenerator" do
+      html_generator = instance_double("Pdf::HtmlGenerator")
+      allow(Pdf::HtmlGenerator).to receive(:new).and_return(html_generator)
 
-    it "returns PDF data" do
-      expect(subject).to include("PDF")
+      allow(html_generator).to receive(:make)
+      subject.process
     end
   end
 end


### PR DESCRIPTION
Notion: https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=b4528f26f4424af7beaf036262796cb3&p=856a37468d7d4a13ac0bd6a1766a083f&pm=s

What
- Add team member name on time entry report PDF
- Fix PDF styling
- Modify the downloaded file name to include the date range filter

Before
<img width="795" alt="Screenshot 2023-06-07 at 5 03 28 PM" src="https://github.com/saeloun/miru-web/assets/18750194/a0b3cbd8-a71d-496f-b347-5b21eec3a095">

After
<img width="796" alt="Screenshot 2023-06-07 at 5 02 32 PM" src="https://github.com/saeloun/miru-web/assets/18750194/6f4f2482-2b8a-4026-8a9c-e30e3f4943d7">

