### PR TITLE
Overflowing time entries fixed

### DIFF
--- a/app/javascript/src/components/Reports/Container/ReportRow.tsx
+++ b/app/javascript/src/components/Reports/Container/ReportRow.tsx
@@ -33,7 +33,7 @@ const ReportRow = ({ timeEntry }) => {
         </div>
       </div>
       <div className="col-span-2 ">
-        <div className="flex h-full items-center whitespace-pre-wrap break-words px-6 py-2.5 font-manrope text-sm font-normal text-miru-dark-purple-1000">
+        <div className="flex h-full items-center whitespace-pre-wrap break-all px-6 py-2.5 font-manrope text-sm font-normal text-miru-dark-purple-1000">
           {note?.trim()}
         </div>
       </div>

--- a/app/javascript/src/components/Reports/Header/index.tsx
+++ b/app/javascript/src/components/Reports/Header/index.tsx
@@ -122,6 +122,7 @@ const Header = ({
                 className="flex items-center py-2 text-sm text-miru-han-purple-1000"
                 onClick={() => {
                   setIsFilterVisible(!isFilterVisible);
+                  setShowMoreOptions(false);
                 }}
               >
                 <FilterIcon className="mr-4" color="#7C5DEE" size={16} />{" "}

--- a/app/javascript/src/components/Reports/TimeEntryReport/ReportMobileRow.tsx
+++ b/app/javascript/src/components/Reports/TimeEntryReport/ReportMobileRow.tsx
@@ -49,7 +49,7 @@ const ReportMobileRow = ({ timeEntry, clientLogo }) => {
       </div>
       <div className="flex flex-row pb-4">
         <div className="col-span-4 overflow-hidden pt-3">
-          <div className="h-full items-center whitespace-pre-wrap break-words font-manrope text-xs font-normal text-miru-dark-purple-400">
+          <div className="h-full items-center whitespace-pre-wrap break-all font-manrope text-xs font-normal text-miru-dark-purple-400">
             {note?.trim()}
           </div>
         </div>


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Notes-of-some-entries-getting-into-team-member-column-e4427e5c37ef4595a598e295f632d29c?pvs=4

### **What :**
- Fixed overflowing time entries
- More options menu is now closing after clicking on filters option(Mobile view)
- ### **Why :**
- In some entries, the notes are getting into the column of name and date on the time entry report
- More options menu not closing after clicking on filters option bug fixed (mobile view)
### **Preview :**
Before:
<img width="1395" alt="Screenshot 2023-06-14 at 5 48 27 PM" src="https://github.com/saeloun/miru-web/assets/72149587/1d95dca7-5490-4021-81a4-2e532ac8c1ae">

After:

<img width="1398" alt="Screenshot 2023-06-14 at 6 02 10 PM" src="https://github.com/saeloun/miru-web/assets/72149587/3c0b495b-164a-467e-9b32-2a39db296a91">

