### PR TITLE
Update revenue report

### DIFF
--- a/app/javascript/src/components/Reports/RevenueByClientReport/Container/TableRow.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Container/TableRow.tsx
@@ -18,7 +18,7 @@ const TableRow = ({ currency, report }) => {
 
   return (
     <tr className="flex flex-row items-center" key={id}>
-      <td className="w-3/5 whitespace-nowrap py-4 pr-6 text-left">
+      <td className="w-4/12 whitespace-nowrap py-4 pr-6 text-left">
         <span className="flex items-center">
           <Avatar classNameImg="mr-2 lg:mr-6" url={logo} />
           <p className="whitespace-normal text-base font-normal text-miru-dark-purple-1000">
@@ -26,18 +26,18 @@ const TableRow = ({ currency, report }) => {
           </p>
         </span>
       </td>
-      <td className="w-2/5 whitespace-pre-wrap px-0 py-4 text-right text-base font-normal text-miru-dark-purple-1000">
+      <td className="w-2/12 whitespace-pre-wrap px-0 py-4 text-right text-base font-normal text-miru-dark-purple-1000">
         {currencyFormat(currency, overdueAmount)}
       </td>
-      <td className="w-2/5 whitespace-pre-wrap px-0 py-4 text-right text-base font-normal text-miru-dark-purple-1000">
+      <td className="w-2/12 whitespace-pre-wrap px-0 py-4 text-right text-base font-normal text-miru-dark-purple-1000">
         {currencyFormat(currency, outstandingAmount)}
       </td>
-      <td className="w-1/5 whitespace-nowrap px-6 py-4 text-right">
+      <td className="w-2/12 whitespace-nowrap px-6 py-4 text-right">
         <p className="text-base	 font-normal text-miru-dark-purple-1000">
           {currencyFormat(currency, paidAmount)}
         </p>
       </td>
-      <td className="w-1/5 whitespace-nowrap py-4 pl-0 text-right text-xl font-bold text-miru-dark-purple-1000">
+      <td className="w-2/12 whitespace-nowrap py-4 pl-0 text-right text-xl font-bold text-miru-dark-purple-1000">
         {currencyFormat(currency, totalAmount)}
       </td>
     </tr>

--- a/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
@@ -14,34 +14,34 @@ const TableHeader = () => (
   <thead>
     <tr className="flex flex-row items-center">
       <th
-        className="w-3/5 py-5 pr-6 text-left text-xs font-normal tracking-widest text-miru-dark-purple-600"
+        className="w-4/12 py-5 pr-6 text-left text-xs font-normal tracking-widest text-miru-dark-purple-600"
         scope="col"
       >
         CLIENT
       </th>
       <th
-        className="w-2/5 px-0 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
+        className="w-2/12 px-0 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
         scope="col"
       >
-        OVERDUE AMOUNT
+        OVERDUE <br /> AMOUNT
       </th>
       <th
-        className="w-2/5 px-0 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
+        className="w-2/12 px-0 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
         scope="col"
       >
-        OUTSTANDING AMOUNT
+        OUTSTANDING <br /> AMOUNT
       </th>
       <th
-        className="w-1/5 px-6 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
+        className="w-2/12 px-6 py-5 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
         scope="col"
       >
-        PAID AMOUNT
+        PAID <br /> AMOUNT
       </th>
       <th
-        className="w-1/5 py-5 pl-6 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
+        className="w-2/12 py-5 pl-6 text-right text-xs font-normal tracking-widest text-miru-dark-purple-600"
         scope="col"
       >
-        TOTAL REVENUE
+        TOTAL <br /> REVENUE
       </th>
     </tr>
   </thead>
@@ -55,7 +55,7 @@ const Container = () => {
   return revenueByClientReport.clientList.length ? (
     <Fragment>
       <TotalHeader
-        firstTitle={isDesktop ? "TOTAL OUTSTANDING AMOUNT" : "OUTSTANDING"}
+        firstTitle={isDesktop ? "TOTAL PENDING AMOUNT" : "PENDING"}
         secondTitle={isDesktop ? "TOTAL PAID AMOUNT" : "PAID"}
         thirdTitle={isDesktop ? "TOTAL REVENUE" : "TOTAL"}
         firstAmount={`${currencySymb}${cashFormatter(
@@ -70,7 +70,7 @@ const Container = () => {
       />
       <div />
       {isDesktop ? (
-        <table className="mt-4 min-w-full divide-y divide-gray-200">
+        <table className="mt-4 min-w-full table-auto divide-y divide-gray-200">
           <TableHeader />
           <tbody className="divide-y divide-gray-200 bg-white">
             {revenueByClientReport.clientList.length &&

--- a/app/javascript/src/components/Reports/RevenueByClientReport/Filters/filterOptions.ts
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Filters/filterOptions.ts
@@ -40,6 +40,7 @@ const getDateRangeOptions = () => {
     { value: "this_year", label: "This Year" },
     { value: "last_year", label: "Last Year" },
     { value: "custom", label: "Custom" },
+    { value: "all_time", label: "All Time" },
   ];
 };
 

--- a/app/javascript/src/components/Reports/RevenueByClientReport/Filters/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Filters/index.tsx
@@ -202,7 +202,7 @@ const FilterSideBar = ({
 
   const defaultDateRange = () => {
     const { value } = filters.dateRange;
-    if (value == "all") {
+    if (value == "all_time") {
       return true;
     } else if (value == "custom" && !customDate) {
       return true;
@@ -213,7 +213,7 @@ const FilterSideBar = ({
 
   const setDefaultDateRange = () => ({
     ...filters,
-    ["dateRange"]: { value: "all", label: "All", from: "", to: "" },
+    ["dateRange"]: { value: "all_time", label: "All Time", from: "", to: "" },
   });
 
   const resetCustomDatePicker = () => {

--- a/app/javascript/src/components/Reports/RevenueByClientReport/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/index.tsx
@@ -18,7 +18,7 @@ import Header from "../Header";
 const RevenueByClientReport = () => {
   const filterIntialValues = {
     // TODO: fix typo filterInitialValues
-    dateRange: { label: "All", value: "all", from: "", to: "" },
+    dateRange: { label: "All Time", value: "all_time", from: "", to: "" },
     clients: [{ label: "All Clients", value: "" }],
   };
 

--- a/app/services/reports/client_revenues/index_service.rb
+++ b/app/services/reports/client_revenues/index_service.rb
@@ -26,7 +26,7 @@ module Reports::ClientRevenues
 
       def summary
         total_paid_amount = clients.pluck(:paid_amount).sum
-        total_outstanding_amount = clients.pluck(:outstanding_amount).sum
+        total_outstanding_amount = clients.pluck(:outstanding_amount).sum + clients.pluck(:overdue_amount).sum
         {
           total_paid_amount:,
           total_outstanding_amount:,

--- a/spec/requests/internal_api/v1/reports/client_revenue/index_spec.rb
+++ b/spec/requests/internal_api/v1/reports/client_revenue/index_spec.rb
@@ -80,8 +80,10 @@ RSpec.describe "InternalApi::V1::Reports::ClientRevenuesController::#index", typ
       it "returns the summary of all clients" do
         expected_summary = {
           totalPaidAmount: @client1_paid_amount + @client2_paid_amount,
-          totalOutstandingAmount: @client1_unpaid_amount + @client2_unpaid_amount,
-          totalRevenue: @client1_paid_amount + @client2_paid_amount + @client1_unpaid_amount + @client2_unpaid_amount
+          totalOutstandingAmount: @client1_unpaid_amount + @client2_unpaid_amount + @client1_overdue_amount +
+                                  @client2_overdue_amount,
+          totalRevenue: @client1_paid_amount + @client2_paid_amount + @client1_unpaid_amount + @client2_unpaid_amount +
+                        @client1_overdue_amount + @client2_overdue_amount
         }
         expect(json_response["summary"]).to eq(JSON.parse(expected_summary.to_json))
       end
@@ -125,8 +127,8 @@ RSpec.describe "InternalApi::V1::Reports::ClientRevenuesController::#index", typ
       it "returns the summary of first client" do
         expected_summary = {
           totalPaidAmount: @client1_paid_amount,
-          totalOutstandingAmount: @client1_unpaid_amount,
-          totalRevenue: @client1_paid_amount + @client1_unpaid_amount
+          totalOutstandingAmount: @client1_unpaid_amount + @client1_overdue_amount,
+          totalRevenue: @client1_paid_amount + @client1_unpaid_amount + @client1_overdue_amount
         }
         expect(json_response["summary"]).to eq(JSON.parse(expected_summary.to_json))
       end


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Update-Revenue-Report-so-that-as-an-owner-and-admin-user-I-can-view-the-exact-Revenue-amount-c0d1f0d901d648bf9f2644358732eb4d)

## Description
- Updated Revenue Report so that as an owner and admin user I can view the exact Revenue amount.
- Updated calculations for the total revenue amount.
- Renamed `Total Overdue Amount` to `Total Pending Amount`.
- Updated designs to match with Figma designs.

## Preview
_Before_:
<img width="1495" alt="Screenshot 2023-06-19 at 12 08 28 PM" src="https://github.com/saeloun/miru-web/assets/57438322/74e427ab-58f8-4d74-be65-e7a904da8320">

<img width="1493" alt="Screenshot 2023-06-19 at 12 08 50 PM" src="https://github.com/saeloun/miru-web/assets/57438322/dec82ef8-6bc1-475d-89d4-b0b91508d0f3">


_After_:
<img width="1493" alt="Screenshot 2023-06-19 at 12 06 17 PM" src="https://github.com/saeloun/miru-web/assets/57438322/15ead583-4cdd-41f7-af04-79f309671291">

<img width="1494" alt="Screenshot 2023-06-19 at 12 06 49 PM" src="https://github.com/saeloun/miru-web/assets/57438322/7b7c2db8-8963-4ded-8f44-73deb18a7289">