### PR TITLE
Fixed invalid issue date on invoices search

### DIFF
--- a/app/javascript/src/components/ClientInvoices/InvoiceSearch/SearchedDataRow.tsx
+++ b/app/javascript/src/components/ClientInvoices/InvoiceSearch/SearchedDataRow.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 
-import dayjs from "dayjs";
 import { currencyFormat } from "helpers";
 import { useNavigate } from "react-router-dom";
 
 import getStatusCssClass from "utils/getBadgeStatus";
-
-const formattedDate = (date, format) => dayjs(date).format(format);
 
 const SearchDataRow = ({ invoice }) => {
   const navigate = useNavigate();
@@ -15,6 +12,8 @@ const SearchDataRow = ({ invoice }) => {
     navigate(`/invoices/${invoice.externalViewKey}`);
   };
 
+  const { client, invoiceNumber, company, amount, issueDate, status } = invoice;
+
   return (
     <div
       className="group flex cursor-pointer items-center py-2 last:border-b-0 hover:bg-miru-gray-100"
@@ -22,25 +21,21 @@ const SearchDataRow = ({ invoice }) => {
     >
       <div className="w-5/12 p-0 font-medium tracking-wider">
         <div className="pb-1 text-sm font-medium capitalize text-miru-dark-purple-1000">
-          {invoice.client.name}
+          {client.name}
         </div>
         <div className="text-sm font-normal text-miru-dark-purple-400">
-          {invoice.invoiceNumber}
+          {invoiceNumber}
         </div>
       </div>
       <div className="w-4/12 px-2/100 font-bold tracking-wider">
-        {currencyFormat(invoice.company.baseCurrency, invoice.amount)}
+        {currencyFormat(company.baseCurrency, amount)}
         <div className="text-sm font-normal text-miru-dark-purple-400">
-          {formattedDate(invoice.issueDate, invoice.company.dateFormat)}
+          {issueDate}
         </div>
       </div>
       <div className="w-3/12 pl-2/100 text-right font-medium">
-        <span
-          className={`${getStatusCssClass(
-            invoice.status
-          )} uppercase tracking-2`}
-        >
-          {invoice.status}
+        <span className={`${getStatusCssClass(status)} uppercase tracking-2`}>
+          {status}
         </span>
       </div>
     </div>

--- a/app/javascript/src/components/Invoices/List/InvoiceSearch/SearchedDataRow.tsx
+++ b/app/javascript/src/components/Invoices/List/InvoiceSearch/SearchedDataRow.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 
-import dayjs from "dayjs";
 import { currencyFormat } from "helpers";
 import { useNavigate } from "react-router-dom";
 
 import getStatusCssClass from "utils/getBadgeStatus";
-
-const formattedDate = (date, format) => dayjs(date).format(format);
 
 const SearchDataRow = ({ invoice }) => {
   const navigate = useNavigate();
@@ -15,6 +12,8 @@ const SearchDataRow = ({ invoice }) => {
     navigate(`/invoices/${invoice.id}`);
   };
 
+  const { client, invoiceNumber, company, amount, issueDate, status } = invoice;
+
   return (
     <div
       className="group flex cursor-pointer items-center py-2 last:border-b-0 hover:bg-miru-gray-100"
@@ -22,25 +21,21 @@ const SearchDataRow = ({ invoice }) => {
     >
       <div className="w-5/12 p-0 font-medium tracking-wider">
         <div className="pb-1 text-sm font-medium capitalize text-miru-dark-purple-1000">
-          {invoice.client.name}
+          {client.name}
         </div>
         <div className="text-sm font-normal text-miru-dark-purple-400">
-          {invoice.invoiceNumber}
+          {invoiceNumber}
         </div>
       </div>
       <div className="w-4/12 px-2/100 font-bold tracking-wider">
-        {currencyFormat(invoice.company.baseCurrency, invoice.amount)}
+        {currencyFormat(company.baseCurrency, amount)}
         <div className="text-sm font-normal text-miru-dark-purple-400">
-          {formattedDate(invoice.issueDate, invoice.company.dateFormat)}
+          {issueDate}
         </div>
       </div>
       <div className="w-3/12 pl-2/100 text-right font-medium">
-        <span
-          className={`${getStatusCssClass(
-            invoice.status
-          )} uppercase tracking-2`}
-        >
-          {invoice.status}
+        <span className={`${getStatusCssClass(status)} uppercase tracking-2`}>
+          {status}
         </span>
       </div>
     </div>


### PR DESCRIPTION
### What
- When the organization date format is `MM:DD:YYYY` issue date on the invoices search turns into an invalid date due to the date format. Fixed it by removing the formatting as the backend response already formats the issue date according to the organization.