### PR TITLE
Fixed devise shared links template error

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -24,7 +24,7 @@
                 </div>
               <% end %>
 
-              <%= render "devise/shared/links" %>
+              <%# <%= render "devise/shared/links" %>
             </div>
           </div>
         </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -13,4 +13,4 @@
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%# <%= render "devise/shared/links" %>


### PR DESCRIPTION
###What
- This PR, fixes
```
ActionView::Template::Error
undefined method `new_user_session_path' for #<ActionDispatch::Routing::RoutesProxy:0x00007f7b62cc3b68 @scope=#<Devise::PasswordsController:0x00000000080bb0>, @routes=#<ActionDispatch::Routing::RouteSet:0x00007f7b62fe42e8>, @helpers=#<Module:0x00007f7b64f7e108>, @script_namer=nil> (ActionView::Template::Error)
```
```
NoMethodError
undefined method `new_user_session_path' for #<ActionDispatch::Routing::RoutesProxy:0x00007f7b62cc3b68 @scope=#<Devise::PasswordsController:0x00000000080bb0>, @routes=#<ActionDispatch::Routing::RouteSet:0x00007f7b62fe42e8>, @helpers=#<Module:0x00007f7b64f7e108>, @script_namer=nil> (NoMethodError)
```

```
Crashed in non-app: actionpack (7.0.4.3) lib/action_dispatch/routing/routes_proxy.rb in method_missing
System
app/views/devise/shared/_links.html.erb at line 11
In App

Called from: actionview (7.0.4.3) lib/action_view/base.rb in public_send
```