### PR TITLE
Fixed mobile navigation on Miru logo

### DIFF
--- a/app/javascript/src/components/Navbar/Mobile/Header.tsx
+++ b/app/javascript/src/components/Navbar/Mobile/Header.tsx
@@ -24,17 +24,17 @@ const Header = ({ selectedTab }) => {
         url = Paths.PAYMENTS;
         break;
       case Roles.OWNER:
-        url = "invoices";
+        url = "/invoices";
         break;
       case Roles.CLIENT:
-        url = "invoices";
+        url = "/invoices";
         break;
       default:
         url = Paths.TIME_TRACKING;
         break;
     }
 
-    return `/${url}`;
+    return url;
   };
 
   const getHeaderContent = () => {


### PR DESCRIPTION
### What
- Whenever the user clicks on the Miru logo on the mobile screen it should redirect to the root path based on the user role.