### PR TITLE
Fix: Authentication required to see if stripe was connected on view invoice page

### DIFF
--- a/app/controllers/internal_api/v1/invoices/view_controller.rb
+++ b/app/controllers/internal_api/v1/invoices/view_controller.rb
@@ -9,19 +9,25 @@ class InternalApi::V1::Invoices::ViewController < InternalApi::V1::ApplicationCo
   def show
     invoice.viewed! if invoice.sent?
     Invoices::EventTrackerService.new("view", invoice, params).process
-    render :show, locals: { invoice: }
+    render :show, locals: { invoice:, stripe_connected_account: }
   end
 
-  def invoice
-    @_invoice ||= find_invoice_by_external_view_key
-    @_invoice ? @_invoice : render_invoice_not_found
-  end
+  private
 
-  def find_invoice_by_external_view_key
-    Invoice.kept.includes(:client, :invoice_line_items).find_by(external_view_key: params[:id])
-  end
+    def invoice
+      @_invoice ||= find_invoice_by_external_view_key
+      @_invoice ? @_invoice : render_invoice_not_found
+    end
 
-  def render_invoice_not_found
-    render json: { error: "No invoice found" }, status: :unprocessable_entity
-  end
+    def find_invoice_by_external_view_key
+      Invoice.kept.includes(:client, :invoice_line_items).find_by(external_view_key: params[:id])
+    end
+
+    def render_invoice_not_found
+      render json: { error: "No invoice found" }, status: :unprocessable_entity
+    end
+
+    def stripe_connected_account
+      invoice.company.stripe_connected_account
+    end
 end

--- a/app/javascript/src/components/InvoiceEmail/index.tsx
+++ b/app/javascript/src/components/InvoiceEmail/index.tsx
@@ -2,10 +2,8 @@ import React, { useEffect, useState } from "react";
 
 import { InstagramSVG, TwitterSVG, MiruLogoWithTextSVG } from "miruIcons";
 import { useParams } from "react-router-dom";
-import { Toastr } from "StyledComponents";
 
 import invoicesApi from "apis/invoices";
-import paymentSettings from "apis/payment-settings";
 import Loader from "common/Loader";
 import MobileView from "components/ClientInvoices/Details/MobileView";
 import ConnectPaymentGateway from "components/Invoices/popups/ConnectPaymentGateway";
@@ -27,22 +25,13 @@ const InvoiceEmail = () => {
 
   useEffect(() => {
     fetchViewInvoice();
-    fetchPaymentSettings();
   }, []);
 
   const fetchViewInvoice = async () => {
     const res = await invoicesApi.viewInvoice(params.id);
     setData(res.data);
+    setIsStripeConnected(res.data.stripe_connected_account);
     setLoading(false);
-  };
-
-  const fetchPaymentSettings = async () => {
-    try {
-      const res = await paymentSettings.get();
-      setIsStripeConnected(res.data.providers.stripe.connected);
-    } catch {
-      Toastr.error("ERROR! CONNECTING TO PAYMENTS");
-    }
   };
 
   if (loading) {

--- a/app/views/internal_api/v1/invoices/view/show.json.jbuilder
+++ b/app/views/internal_api/v1/invoices/view/show.json.jbuilder
@@ -4,6 +4,7 @@ json.url new_invoice_payment_url(invoice)
 json.invoice invoice
 json.logo invoice.company.company_logo
 json.lineItems invoice.invoice_line_items
+json.stripe_connected_account stripe_connected_account.present? ? true : false
 json.company do
   json.partial! "internal_api/v1/partial/company", locals: { company: invoice.company }
 end


### PR DESCRIPTION
## Description
- Fixed the issue where authentication was required while fetching payment settings to see if a payment gateway was connected.