### PR TITLE
Amount notation updated revenue report

### DIFF
--- a/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
@@ -1,9 +1,8 @@
 import React, { Fragment } from "react";
 
-import { cashFormatter, currencySymbol } from "helpers"; // TODO: Formatter
+import { SummaryDashboard } from "StyledComponents";
 
 import EmptyStates from "common/EmptyStates";
-import TotalHeader from "common/TotalHeader";
 import { useEntry } from "components/Reports/context/EntryContext";
 import { useUserContext } from "context/UserContext";
 
@@ -49,24 +48,44 @@ const TableHeader = () => (
 
 const Container = () => {
   const { revenueByClientReport } = useEntry();
-  const currencySymb = currencySymbol(revenueByClientReport.currency);
   const { isDesktop } = useUserContext();
+
+  const summaryList = isDesktop
+    ? [
+        {
+          label: "TOTAL PENDING AMOUNT",
+          value: revenueByClientReport.summary.totalOutstandingAmount,
+        },
+        {
+          label: "TOTAL PAID AMOUNT",
+          value: revenueByClientReport.summary.totalPaidAmount,
+        },
+        {
+          label: "TOTAL REVENUE",
+          value: revenueByClientReport.summary.totalRevenue,
+        },
+      ]
+    : [
+        {
+          label: "PENDING",
+          value: revenueByClientReport.summary.totalOutstandingAmount,
+        },
+        {
+          label: "PAID",
+          value: revenueByClientReport.summary.totalPaidAmount,
+        },
+        {
+          label: "REVENUE",
+          value: revenueByClientReport.summary.totalRevenue,
+        },
+      ];
 
   return revenueByClientReport.clientList.length ? (
     <Fragment>
-      <TotalHeader
-        firstTitle={isDesktop ? "TOTAL PENDING AMOUNT" : "PENDING"}
-        secondTitle={isDesktop ? "TOTAL PAID AMOUNT" : "PAID"}
-        thirdTitle={isDesktop ? "TOTAL REVENUE" : "TOTAL"}
-        firstAmount={`${currencySymb}${cashFormatter(
-          revenueByClientReport.summary.totalOutstandingAmount
-        )}`}
-        secondAmount={`${currencySymb}${cashFormatter(
-          revenueByClientReport.summary.totalPaidAmount
-        )}`}
-        thirdAmount={`${currencySymb}${cashFormatter(
-          revenueByClientReport.summary.totalRevenue
-        )}`}
+      <SummaryDashboard
+        currency={revenueByClientReport.currency}
+        summaryList={summaryList}
+        wrapperClassName="mt-3 lg:mb-9 mx-4 lg:mx-0"
       />
       <div />
       {isDesktop ? (

--- a/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/Container/index.tsx
@@ -9,6 +9,8 @@ import { useUserContext } from "context/UserContext";
 import MobileRow from "./MobileRow";
 import TableRow from "./TableRow";
 
+import { summaryList } from "../util";
+
 const TableHeader = () => (
   <thead>
     <tr className="flex flex-row items-center">
@@ -50,41 +52,11 @@ const Container = () => {
   const { revenueByClientReport } = useEntry();
   const { isDesktop } = useUserContext();
 
-  const summaryList = isDesktop
-    ? [
-        {
-          label: "TOTAL PENDING AMOUNT",
-          value: revenueByClientReport.summary.totalOutstandingAmount,
-        },
-        {
-          label: "TOTAL PAID AMOUNT",
-          value: revenueByClientReport.summary.totalPaidAmount,
-        },
-        {
-          label: "TOTAL REVENUE",
-          value: revenueByClientReport.summary.totalRevenue,
-        },
-      ]
-    : [
-        {
-          label: "PENDING",
-          value: revenueByClientReport.summary.totalOutstandingAmount,
-        },
-        {
-          label: "PAID",
-          value: revenueByClientReport.summary.totalPaidAmount,
-        },
-        {
-          label: "REVENUE",
-          value: revenueByClientReport.summary.totalRevenue,
-        },
-      ];
-
   return revenueByClientReport.clientList.length ? (
     <Fragment>
       <SummaryDashboard
         currency={revenueByClientReport.currency}
-        summaryList={summaryList}
+        summaryList={summaryList(revenueByClientReport, isDesktop)}
         wrapperClassName="mt-3 lg:mb-9 mx-4 lg:mx-0"
       />
       <div />

--- a/app/javascript/src/components/Reports/RevenueByClientReport/util.ts
+++ b/app/javascript/src/components/Reports/RevenueByClientReport/util.ts
@@ -1,1 +1,35 @@
 export const REVENUE_REPORT_PAGE = "Revenue Report";
+
+export const summaryList = (revenueByClientReport, isDesktop) => {
+  if (isDesktop) {
+    return [
+      {
+        label: "TOTAL PENDING AMOUNT",
+        value: revenueByClientReport.summary.totalOutstandingAmount,
+      },
+      {
+        label: "TOTAL PAID AMOUNT",
+        value: revenueByClientReport.summary.totalPaidAmount,
+      },
+      {
+        label: "TOTAL REVENUE",
+        value: revenueByClientReport.summary.totalRevenue,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: "PENDING",
+      value: revenueByClientReport.summary.totalOutstandingAmount,
+    },
+    {
+      label: "PAID",
+      value: revenueByClientReport.summary.totalPaidAmount,
+    },
+    {
+      label: "REVENUE",
+      value: revenueByClientReport.summary.totalRevenue,
+    },
+  ];
+};


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/The-amounts-should-be-displayed-in-thousands-instead-of-millions-on-revenue-report-21674c24866c4e86b9058aa2acada61d?pvs=4
### **What :**
- Updated the amount notation to thousands(K).
- Currently, the amounts displayed on the top section of revenue report are in millions (M)
### **Why :**
- In other reports & invoices pages the amounts are displayed in thousands. (K)
### **Preview :**
<img width="1425" alt="Screenshot 2023-07-03 at 3 42 49 PM" src="https://github.com/saeloun/miru-web/assets/72149587/01f07ed8-1025-4c59-80cd-b3b9d91df5a1">

### **Todos** (for testing):
- Tested if amount shown is in thousands on both mobile and desktop view 