### PR TITLE
Fix: phone number not getting deleted for a user

### DIFF
--- a/app/javascript/src/components/Profile/UserDetail/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/Edit/index.tsx
@@ -260,7 +260,9 @@ const UserDetailsEdit = () => {
               .utc(profileSettings.date_of_birth, profileSettings.date_format)
               .toISOString()
           : null,
-        phone: profileSettings.phone_number,
+        phone: profileSettings.phone_number
+          ? profileSettings.phone_number
+          : null,
         personal_email_id: profileSettings.email_id,
         social_accounts: {
           linkedin_url: profileSettings.linkedin,


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Phone-number-not-getting-deleted-for-a-user-f9477cdc76734cf78f19b64190fd813b)

## Description
- Fixed the issue where after removing the phone number while updating the profile was not getting deleted and instead retained the old value.

## Preview
Before -

https://github.com/saeloun/miru-web/assets/57438322/c65acabb-3e55-41b4-8d7d-df7be1b674cc


After -

https://github.com/saeloun/miru-web/assets/57438322/5547bc91-d68a-4525-8b16-5c417aa43e1b
