### PR TITLE
Fix: Send reminder modal ui and options UI

### DIFF
--- a/app/javascript/src/components/Invoices/Generate/MobileView/Container/SendInvoiceContainer/index.tsx
+++ b/app/javascript/src/components/Invoices/Generate/MobileView/Container/SendInvoiceContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 import cn from "classnames";
 import { Formik, Form, FormikProps } from "formik";
@@ -13,7 +13,6 @@ import { InputErrors } from "common/FormikFields";
 import {
   emailBody,
   emailSubject,
-  isEmailValid,
   buttonText,
   isDisabled,
 } from "components/Invoices/common/InvoiceForm/SendInvoice/utils";
@@ -53,12 +52,14 @@ const SendInvoiceContainer = ({
     message: emailBody(invoice, isSendReminder),
     recipients: [invoice.client.email],
   });
+  // eslint-disable-next-line no-unused-vars
   const [newRecipient, setNewRecipient] = useState<string>("");
+  // eslint-disable-next-line no-unused-vars
   const [width, setWidth] = useState<string>("10ch");
   const [status, setStatus] = useState<InvoiceStatus>(InvoiceStatus.IDLE);
-  const [height, setHeight] = useState<string>("h-0 py-0");
+  // const [height, setHeight] = useState<string>("h-0 py-0");
 
-  const input: React.RefObject<HTMLInputElement> = useRef();
+  // const input: React.RefObject<HTMLInputElement> = useRef();
   const navigate = useNavigate();
 
   const handleRemove = (recipient: string) => {
@@ -70,17 +71,17 @@ const SendInvoiceContainer = ({
     });
   };
 
-  const handleInput = event => {
-    const recipients = invoiceEmail.recipients;
+  // const handleInput = event => {
+  //   const recipients = invoiceEmail.recipients;
 
-    if (isEmailValid(newRecipient) && event.key === "Enter") {
-      setInvoiceEmail({
-        ...invoiceEmail,
-        recipients: recipients.concat(newRecipient),
-      });
-      setNewRecipient("");
-    }
-  };
+  //   if (isEmailValid(newRecipient) && event.key === "Enter") {
+  //     setInvoiceEmail({
+  //       ...invoiceEmail,
+  //       recipients: recipients.concat(newRecipient),
+  //     });
+  //     setNewRecipient("");
+  //   }
+  // };
 
   const handleSubmit = async event => {
     try {
@@ -168,7 +169,7 @@ const SendInvoiceContainer = ({
                             key={recipient}
                           />
                         ))}
-                        <input
+                        {/* <input
                           name="to"
                           ref={input}
                           style={{ width }}
@@ -185,10 +186,10 @@ const SendInvoiceContainer = ({
                           onChange={e => setNewRecipient(e.target.value.trim())}
                           onFocus={() => setHeight("h-6 py-2")}
                           onKeyDown={handleInput}
-                        />
+                        /> */}
                       </div>
                     }
-                    onClick={() => input.current.focus()}
+                    // onClick={() => input.current.focus()}
                   />
                   <InputErrors
                     fieldErrors={errors.recipients}

--- a/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
@@ -60,6 +60,7 @@ const InvoiceActions = ({
             invoice={invoice}
             markInvoiceAsPaid={markInvoiceAsPaid}
             sendInvoice={sendInvoice}
+            setIsMoreOptionsVisible={setIsMoreOptionsVisible}
             setIsSendReminder={setIsSendReminder}
             wavieInvoice={wavieInvoice}
           />

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -173,7 +173,7 @@ const SendInvoice: React.FC<any> = ({
                       key={recipient}
                     />
                   ))}
-                  <input
+                  {/* <input
                     name="to"
                     ref={input}
                     style={{ width }}
@@ -187,10 +187,10 @@ const SendInvoice: React.FC<any> = ({
                     )}
                     onChange={e => setNewRecipient(e.target.value.trim())}
                     onKeyDown={handleInput}
-                  />
+                  /> */}
                 </div>
               }
-              onClick={() => input.current.focus()}
+              // onClick={() => input.current.focus()}
             />
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -12,6 +12,9 @@ import { XIcon } from "miruIcons";
 import { Modal, Toastr } from "StyledComponents";
 
 import invoicesApi from "apis/invoices";
+import { CustomAdvanceInput } from "common/CustomAdvanceInput";
+import { CustomInputText } from "common/CustomInputText";
+import { CustomTextareaAutosize } from "common/CustomTextareaAutosize";
 import { ApiStatus as InvoiceStatus } from "constants/index";
 
 import {
@@ -32,7 +35,7 @@ const Recipient: React.FC<{ email: string; handleClick: any }> = ({
   email,
   handleClick,
 }) => (
-  <div className="m-0.5 flex w-fit items-center space-x-2 rounded-full border bg-miru-gray-400 px-2 py-1 text-sm">
+  <div className="space-XIcon-2 m-0.5 flex w-fit items-center rounded-full border bg-miru-gray-400 px-2 py-1 text-sm font-medium">
     <p>{email}</p>
     {/* <button
       className="text-miru-black-1000 hover:text-miru-red-400"
@@ -152,91 +155,74 @@ const SendInvoice: React.FC<any> = ({
         </div>
         <form className="space-y-4">
           <fieldset className="field_with_errors flex flex-col">
-            <div className="field relative">
-              <div className="outline relative h-12" />
-              <div
-                className={cn(
-                  "form__input flex h-16 w-full appearance-none flex-wrap border-miru-gray-1000 bg-white text-sm lg:text-base",
-                  {
+            <CustomAdvanceInput
+              id="Email ID"
+              label="Email ID"
+              wrapperClassName="h-full"
+              value={
+                <div
+                  className={cn("flex flex-wrap rounded", {
                     "h-9": !invoiceEmail.recipients,
-                  }
-                )}
-                // onClick={() => input.current.focus()}
-              >
-                {invoiceEmail.recipients.map(recipient => (
-                  <Recipient
-                    email={recipient}
-                    handleClick={() => handleRemove(recipient)}
-                    key={recipient}
-                  />
-                ))}
-                <label
-                  className="form__label relative bottom-4 right-44 z-1"
-                  htmlFor="to"
+                  })}
                 >
-                  Email
-                </label>
-                {/* <input
+                  {invoiceEmail.recipients.map(recipient => (
+                    <Recipient
+                      email={recipient}
+                      handleClick={() => handleRemove(recipient)}
+                      key={recipient}
+                    />
+                  ))}
+                  <input
                     name="to"
                     ref={input}
                     style={{ width }}
                     type="email"
                     value={newRecipient}
                     className={cn(
-                      "focus:outline-none mx-1.5 w-fit cursor-text rounded bg-miru-gray-100 py-2",
+                      "focus:outline-none mx-1.5 w-fit cursor-text",
                       {
                         "text-miru-red-400": !isEmailValid(newRecipient),
                       }
                     )}
                     onChange={e => setNewRecipient(e.target.value.trim())}
                     onKeyDown={handleInput}
-                  /> */}
-              </div>
-            </div>
+                  />
+                </div>
+              }
+              onClick={() => input.current.focus()}
+            />
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">
-            <div className="field relative">
-              <div className="outline relative h-12">
-                <input
-                  className="form__input block h-12 w-full appearance-none border-miru-gray-1000 bg-white p-4 text-sm lg:text-base"
-                  name="subject"
-                  type="text"
-                  value={invoiceEmail.subject}
-                  onChange={e =>
-                    setInvoiceEmail({
-                      ...invoiceEmail,
-                      subject: e.target.value,
-                    })
-                  }
-                />
-                <label
-                  className="form__label absolute top-0.5 z-1 h-6 origin-0 bg-white p-2 font-medium text-miru-dark-purple-200"
-                  htmlFor="subject"
-                >
-                  Subject
-                </label>
-              </div>
-            </div>
-          </fieldset>
-          <fieldset className="field_with_errors flex flex-col">
-            <textarea
-              className="rounded border border-miru-gray-1000 bg-white p-1.5"
-              name="body"
-              rows={5}
-              value={invoiceEmail.message}
+            <CustomInputText
+              id="subject"
+              inputBoxClassName="border focus:border-miru-han-purple-1000 cursor-pointer"
+              label="Subject"
+              name="subject"
+              type="text"
+              value={invoiceEmail.subject}
               onChange={e =>
                 setInvoiceEmail({
                   ...invoiceEmail,
-                  message: e.target.value,
+                  subject: e.target.value,
                 })
               }
             />
-            <label
-              className="form__label relative bottom-36 left-3 z-1"
-              htmlFor="body"
-            >
-              Message
-            </label>
+          </fieldset>
+          <fieldset className="field_with_errors flex flex-col">
+            <CustomTextareaAutosize
+              id="message"
+              label="Message"
+              maxRows={5}
+              name="message"
+              rows={5}
+              value={invoiceEmail.message}
+              onChange={e => {
+                setInvoiceEmail({
+                  ...invoiceEmail,
+                  message: e.target.value,
+                });
+              }}
+            />
           </fieldset>
           <div>
             <button

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -32,7 +32,7 @@ const Recipient: React.FC<{ email: string; handleClick: any }> = ({
   email,
   handleClick,
 }) => (
-  <div className="m-0.5 flex w-fit items-center space-x-2 rounded-full border bg-miru-gray-400 px-2 py-1">
+  <div className="m-0.5 flex w-fit items-center space-x-2 rounded-full border bg-miru-gray-400 px-2 py-1 text-sm">
     <p>{email}</p>
     {/* <button
       className="text-miru-black-1000 hover:text-miru-red-400"
@@ -133,7 +133,7 @@ const SendInvoice: React.FC<any> = ({
           <h6 className="form__title">
             {isSendReminder
               ? "Send Invoice Reminder"
-              : `Send Invoice #{${invoice.invoiceNumber}}`}
+              : `Send Invoice #${invoice.invoiceNumber}`}
           </h6>
           <button
             className="text-miru-gray-1000"
@@ -156,7 +156,7 @@ const SendInvoice: React.FC<any> = ({
               <div className="outline relative h-12" />
               <div
                 className={cn(
-                  "form__input flex h-12 w-full appearance-none flex-wrap border-miru-gray-1000 bg-white text-sm lg:text-base",
+                  "form__input flex h-16 w-full appearance-none flex-wrap border-miru-gray-1000 bg-white text-sm lg:text-base",
                   {
                     "h-9": !invoiceEmail.recipients,
                   }
@@ -171,7 +171,7 @@ const SendInvoice: React.FC<any> = ({
                   />
                 ))}
                 <label
-                  className="form__label relative bottom-4 right-48 z-1"
+                  className="form__label relative bottom-4 right-44 z-1"
                   htmlFor="to"
                 >
                   Email
@@ -210,7 +210,7 @@ const SendInvoice: React.FC<any> = ({
                   }
                 />
                 <label
-                  className="form__label absolute top-0.5 z-1 h-6 origin-0 bg-white p-2 text-sm font-medium text-miru-dark-purple-200 duration-300 lg:text-base"
+                  className="form__label absolute top-0.5 z-1 h-6 origin-0 bg-white p-2 font-medium text-miru-dark-purple-200"
                   htmlFor="subject"
                 >
                   Subject

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -152,62 +152,75 @@ const SendInvoice: React.FC<any> = ({
         </div>
         <form className="space-y-4">
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="to">
-              To
-            </label>
-            <div
-              className={cn("flex flex-wrap rounded bg-miru-gray-100 p-1.5", {
-                "h-9": !invoiceEmail.recipients,
-              })}
-              // onClick={() => input.current.focus()}
-            >
-              {invoiceEmail.recipients.map(recipient => (
-                <Recipient
-                  email={recipient}
-                  handleClick={() => handleRemove(recipient)}
-                  key={recipient}
-                />
-              ))}
-              {/* <input
-                name="to"
-                ref={input}
-                style={{ width }}
-                type="email"
-                value={newRecipient}
+            <div className="field relative">
+              <div className="outline relative h-12" />
+              <div
                 className={cn(
-                  "focus:outline-none mx-1.5 w-fit cursor-text rounded bg-miru-gray-100 py-2",
+                  "form__input flex h-12 w-full appearance-none flex-wrap border-miru-gray-1000 bg-white text-sm lg:text-base",
                   {
-                    "text-miru-red-400": !isEmailValid(newRecipient),
+                    "h-9": !invoiceEmail.recipients,
                   }
                 )}
-                onChange={e => setNewRecipient(e.target.value.trim())}
-                onKeyDown={handleInput}
-              /> */}
+                // onClick={() => input.current.focus()}
+              >
+                {invoiceEmail.recipients.map(recipient => (
+                  <Recipient
+                    email={recipient}
+                    handleClick={() => handleRemove(recipient)}
+                    key={recipient}
+                  />
+                ))}
+                <label
+                  className="form__label relative bottom-4 right-48 z-1"
+                  htmlFor="to"
+                >
+                  Email
+                </label>
+                {/* <input
+                    name="to"
+                    ref={input}
+                    style={{ width }}
+                    type="email"
+                    value={newRecipient}
+                    className={cn(
+                      "focus:outline-none mx-1.5 w-fit cursor-text rounded bg-miru-gray-100 py-2",
+                      {
+                        "text-miru-red-400": !isEmailValid(newRecipient),
+                      }
+                    )}
+                    onChange={e => setNewRecipient(e.target.value.trim())}
+                    onKeyDown={handleInput}
+                  /> */}
+              </div>
             </div>
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="subject">
-              Subject
-            </label>
-            <input
-              className="rounded bg-miru-gray-100 p-1.5"
-              name="subject"
-              type="text"
-              value={invoiceEmail.subject}
-              onChange={e =>
-                setInvoiceEmail({
-                  ...invoiceEmail,
-                  subject: e.target.value,
-                })
-              }
-            />
+            <div className="field relative">
+              <div className="outline relative h-12">
+                <input
+                  className="form__input block h-12 w-full appearance-none border-miru-gray-1000 bg-white p-4 text-sm lg:text-base"
+                  name="subject"
+                  type="text"
+                  value={invoiceEmail.subject}
+                  onChange={e =>
+                    setInvoiceEmail({
+                      ...invoiceEmail,
+                      subject: e.target.value,
+                    })
+                  }
+                />
+                <label
+                  className="form__label absolute top-0.5 z-1 h-6 origin-0 bg-white p-2 text-sm font-medium text-miru-dark-purple-200 duration-300 lg:text-base"
+                  htmlFor="subject"
+                >
+                  Subject
+                </label>
+              </div>
+            </div>
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="body">
-              Message
-            </label>
             <textarea
-              className="rounded bg-miru-gray-100 p-1.5"
+              className="rounded border border-miru-gray-1000 bg-white p-1.5"
               name="body"
               rows={5}
               value={invoiceEmail.message}
@@ -218,6 +231,12 @@ const SendInvoice: React.FC<any> = ({
                 })
               }
             />
+            <label
+              className="form__label relative bottom-36 left-3 z-1"
+              htmlFor="body"
+            >
+              Message
+            </label>
           </fieldset>
           <div>
             <button

--- a/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/List/SendInvoice/index.tsx
@@ -157,6 +157,7 @@ const SendInvoice: React.FC<any> = ({
           <fieldset className="field_with_errors flex flex-col">
             <CustomAdvanceInput
               id="Email ID"
+              inputBoxClassName="py-3"
               label="Email ID"
               wrapperClassName="h-full"
               value={
@@ -195,7 +196,7 @@ const SendInvoice: React.FC<any> = ({
           <fieldset className="field_with_errors flex flex-col">
             <CustomInputText
               id="subject"
-              inputBoxClassName="border focus:border-miru-han-purple-1000 cursor-pointer"
+              inputBoxClassName="border focus:border-miru-han-purple-1000"
               label="Subject"
               name="subject"
               type="text"

--- a/app/javascript/src/components/Invoices/common/MoreOptions.tsx
+++ b/app/javascript/src/components/Invoices/common/MoreOptions.tsx
@@ -13,7 +13,7 @@ const MoreOptions: FC<MoreOptionsProps> = ({
   setIsSendReminder,
   sendInvoice,
 }) => (
-  <ul className="absolute right-20 rounded border-2 border-miru-gray-200 bg-white py-2 drop-shadow">
+  <ul className="absolute right-20 z-max rounded border-2 border-miru-gray-200 bg-white py-2 drop-shadow">
     {downloadInvoice != null && invoice.status != "draft" && (
       <li
         className="flex cursor-pointer items-center py-2.5 px-4 text-miru-han-purple-1000 hover:bg-miru-gray-100"

--- a/app/javascript/src/components/Invoices/common/MoreOptions.tsx
+++ b/app/javascript/src/components/Invoices/common/MoreOptions.tsx
@@ -12,6 +12,7 @@ const MoreOptions: FC<MoreOptionsProps> = ({
   markInvoiceAsPaid = () => null,
   setIsSendReminder,
   sendInvoice,
+  setIsMoreOptionsVisible,
 }) => (
   <ul className="absolute right-20 z-max rounded border-2 border-miru-gray-200 bg-white py-2 drop-shadow">
     {downloadInvoice != null && invoice.status != "draft" && (
@@ -47,6 +48,7 @@ const MoreOptions: FC<MoreOptionsProps> = ({
         onClick={() => {
           setIsSendReminder(true);
           sendInvoice();
+          setIsMoreOptionsVisible(false);
         }}
       >
         <ReminderIcon className="mr-4" id="reminderIcon" size={16} />
@@ -71,6 +73,7 @@ interface MoreOptionsProps {
   markInvoiceAsPaid: (id: number) => void;
   setIsSendReminder: (value: boolean) => void;
   sendInvoice?: () => void;
+  setIsMoreOptionsVisible?: (value: boolean) => void;
 }
 
 export default MoreOptions;

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -14,6 +14,9 @@ import { useNavigate } from "react-router-dom";
 import { Modal, Toastr } from "StyledComponents";
 
 import invoicesApi from "apis/invoices";
+import { CustomAdvanceInput } from "common/CustomAdvanceInput";
+import { CustomInputText } from "common/CustomInputText";
+import { CustomTextareaAutosize } from "common/CustomTextareaAutosize";
 import { ApiStatus as InvoiceStatus } from "constants/index";
 
 import {
@@ -169,45 +172,49 @@ const SendInvoice: React.FC<any> = ({
         </div>
         <form className="space-y-4">
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="to">
-              To
-            </label>
-            <div
-              className={cn("flex flex-wrap rounded bg-miru-gray-100 p-1.5", {
-                "h-9": !invoiceEmail.recipients,
-              })}
-              // onClick={() => input.current.focus()}
-            >
-              {invoiceEmail.recipients.map(recipient => (
-                <Recipient
-                  email={recipient}
-                  handleClick={() => handleRemove(recipient)}
-                  key={recipient}
-                />
-              ))}
-              {/* <input
+            <CustomAdvanceInput
+              id="Email ID"
+              inputBoxClassName="py-3"
+              label="Email ID"
+              wrapperClassName="h-full"
+              value={
+                <div
+                  className={cn("flex flex-wrap rounded", {
+                    "h-9": !invoiceEmail.recipients,
+                  })}
+                >
+                  {invoiceEmail.recipients.map(recipient => (
+                    <Recipient
+                      email={recipient}
+                      handleClick={() => handleRemove(recipient)}
+                      key={recipient}
+                    />
+                  ))}
+                  <input
                     name="to"
                     ref={input}
                     style={{ width }}
                     type="email"
                     value={newRecipient}
                     className={cn(
-                      "focus:outline-none mx-1.5 w-fit cursor-text rounded bg-miru-gray-100 py-2",
+                      "focus:outline-none mx-1.5 w-fit cursor-text",
                       {
                         "text-miru-red-400": !isEmailValid(newRecipient),
                       }
                     )}
                     onChange={e => setNewRecipient(e.target.value.trim())}
                     onKeyDown={handleInput}
-                  /> */}
-            </div>
+                  />
+                </div>
+              }
+              onClick={() => input.current.focus()}
+            />
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="subject">
-              Subject
-            </label>
-            <input
-              className="rounded bg-miru-gray-100 p-1.5"
+            <CustomInputText
+              id="subject"
+              inputBoxClassName="border focus:border-miru-han-purple-1000"
+              label="Subject"
               name="subject"
               type="text"
               value={invoiceEmail.subject}
@@ -220,20 +227,19 @@ const SendInvoice: React.FC<any> = ({
             />
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">
-            <label className="form__label mb-2" htmlFor="body">
-              Message
-            </label>
-            <textarea
-              className="rounded bg-miru-gray-100 p-1.5"
-              name="body"
+            <CustomTextareaAutosize
+              id="message"
+              label="Message"
+              maxRows={5}
+              name="message"
               rows={5}
               value={invoiceEmail.message}
-              onChange={e =>
+              onChange={e => {
                 setInvoiceEmail({
                   ...invoiceEmail,
                   message: e.target.value,
-                })
-              }
+                });
+              }}
             />
           </fieldset>
           <div>

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -11,7 +11,7 @@ import cn from "classnames";
 import { useOutsideClick } from "helpers";
 import { XIcon } from "miruIcons";
 import { useNavigate } from "react-router-dom";
-import { Toastr } from "StyledComponents";
+import { Modal, Toastr } from "StyledComponents";
 
 import invoicesApi from "apis/invoices";
 import { ApiStatus as InvoiceStatus } from "constants/index";
@@ -133,69 +133,59 @@ const SendInvoice: React.FC<any> = ({
   }, [status]);
 
   return (
-    <div
-      aria-labelledby="modal-title"
-      aria-modal="true"
-      className="fixed inset-0 z-10 overflow-y-auto"
-      role="dialog"
+    <Modal
+      customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle"
+      isOpen={isSending}
+      onClose={() => {
+        if (isSendReminder) {
+          setIsSending(false);
+          setIsSendReminder(false);
+        } else {
+          setIsSending(false);
+        }
+      }}
     >
-      <div className="flex min-h-screen items-end justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        <div
-          aria-hidden="true"
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
-        />
-        <span
-          aria-hidden="true"
-          className="hidden sm:inline-block sm:h-screen sm:align-middle"
-        >
-          &#8203;
-        </span>
-        <div
-          className="relative inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle"
-          ref={modal}
-        >
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            <div className="mt-2 mb-6 flex items-center justify-between">
-              <h6 className="form__title">
-                {isSendReminder
-                  ? "Send Invoice Reminder"
-                  : `Send Invoice #{${invoice.invoiceNumber}}`}
-              </h6>
-              <button
-                className="text-miru-gray-1000"
-                type="button"
-                onClick={() => {
-                  if (isSendReminder) {
-                    setIsSending(false);
-                    setIsSendReminder(false);
-                  } else {
-                    setIsSending(false);
-                  }
-                }}
-              >
-                <XIcon size={16} weight="bold" />
-              </button>
-            </div>
-            <form className="space-y-4">
-              <fieldset className="field_with_errors flex flex-col">
-                <label className="form__label mb-2" htmlFor="to">
-                  To
-                </label>
-                <div
-                  className={cn(
-                    "flex flex-wrap rounded bg-miru-gray-100 p-1.5",
-                    { "h-9": !invoiceEmail.recipients }
-                  )}
-                  // onClick={() => input.current.focus()}
-                >
-                  {invoiceEmail.recipients.map(recipient => (
-                    <Recipient
-                      email={recipient}
-                      handleClick={() => handleRemove(recipient)}
-                      key={recipient}
-                    />
-                  ))}
-                  {/* <input
+      <div className="bg-white">
+        <div className="mt-2 mb-6 flex items-center justify-between">
+          <h6 className="form__title">
+            {isSendReminder
+              ? "Send Invoice Reminder"
+              : `Send Invoice #{${invoice.invoiceNumber}}`}
+          </h6>
+          <button
+            className="text-miru-gray-1000"
+            type="button"
+            onClick={() => {
+              if (isSendReminder) {
+                setIsSending(false);
+                setIsSendReminder(false);
+              } else {
+                setIsSending(false);
+              }
+            }}
+          >
+            <XIcon size={16} weight="bold" />
+          </button>
+        </div>
+        <form className="space-y-4">
+          <fieldset className="field_with_errors flex flex-col">
+            <label className="form__label mb-2" htmlFor="to">
+              To
+            </label>
+            <div
+              className={cn("flex flex-wrap rounded bg-miru-gray-100 p-1.5", {
+                "h-9": !invoiceEmail.recipients,
+              })}
+              // onClick={() => input.current.focus()}
+            >
+              {invoiceEmail.recipients.map(recipient => (
+                <Recipient
+                  email={recipient}
+                  handleClick={() => handleRemove(recipient)}
+                  key={recipient}
+                />
+              ))}
+              {/* <input
                     name="to"
                     ref={input}
                     style={{ width }}
@@ -210,47 +200,47 @@ const SendInvoice: React.FC<any> = ({
                     onChange={e => setNewRecipient(e.target.value.trim())}
                     onKeyDown={handleInput}
                   /> */}
-                </div>
-              </fieldset>
-              <fieldset className="field_with_errors flex flex-col">
-                <label className="form__label mb-2" htmlFor="subject">
-                  Subject
-                </label>
-                <input
-                  className="rounded bg-miru-gray-100 p-1.5"
-                  name="subject"
-                  type="text"
-                  value={invoiceEmail.subject}
-                  onChange={e =>
-                    setInvoiceEmail({
-                      ...invoiceEmail,
-                      subject: e.target.value,
-                    })
-                  }
-                />
-              </fieldset>
-              <fieldset className="field_with_errors flex flex-col">
-                <label className="form__label mb-2" htmlFor="body">
-                  Message
-                </label>
-                <textarea
-                  className="rounded bg-miru-gray-100 p-1.5"
-                  name="body"
-                  rows={5}
-                  value={invoiceEmail.message}
-                  onChange={e =>
-                    setInvoiceEmail({
-                      ...invoiceEmail,
-                      message: e.target.value,
-                    })
-                  }
-                />
-              </fieldset>
-              <div>
-                <button
-                  type="button"
-                  className={cn(
-                    `mt-6 flex w-full justify-center rounded-md border border-transparent p-3 text-lg font-bold
+            </div>
+          </fieldset>
+          <fieldset className="field_with_errors flex flex-col">
+            <label className="form__label mb-2" htmlFor="subject">
+              Subject
+            </label>
+            <input
+              className="rounded bg-miru-gray-100 p-1.5"
+              name="subject"
+              type="text"
+              value={invoiceEmail.subject}
+              onChange={e =>
+                setInvoiceEmail({
+                  ...invoiceEmail,
+                  subject: e.target.value,
+                })
+              }
+            />
+          </fieldset>
+          <fieldset className="field_with_errors flex flex-col">
+            <label className="form__label mb-2" htmlFor="body">
+              Message
+            </label>
+            <textarea
+              className="rounded bg-miru-gray-100 p-1.5"
+              name="body"
+              rows={5}
+              value={invoiceEmail.message}
+              onChange={e =>
+                setInvoiceEmail({
+                  ...invoiceEmail,
+                  message: e.target.value,
+                })
+              }
+            />
+          </fieldset>
+          <div>
+            <button
+              type="button"
+              className={cn(
+                `mt-6 flex w-full justify-center rounded-md border border-transparent p-3 text-lg font-bold
                     uppercase text-white shadow-sm
                     ${
                       invoiceEmail?.recipients.length > 0
@@ -259,24 +249,22 @@ const SendInvoice: React.FC<any> = ({
                         : "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"
                     }
                     `,
-                    {
-                      "bg-miru-chart-green-600 hover:bg-miru-chart-green-400":
-                        status === InvoiceStatus.SUCCESS,
-                    }
-                  )}
-                  disabled={
-                    invoiceEmail?.recipients.length <= 0 || isDisabled(status)
-                  }
-                  onClick={handleSubmit}
-                >
-                  {isSendReminder ? "Send Reminder" : buttonText(status)}
-                </button>
-              </div>
-            </form>
+                {
+                  "bg-miru-chart-green-600 hover:bg-miru-chart-green-400":
+                    status === InvoiceStatus.SUCCESS,
+                }
+              )}
+              disabled={
+                invoiceEmail?.recipients.length <= 0 || isDisabled(status)
+              }
+              onClick={handleSubmit}
+            >
+              {isSendReminder ? "Send Reminder" : buttonText(status)}
+            </button>
           </div>
-        </div>
+        </form>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -190,7 +190,7 @@ const SendInvoice: React.FC<any> = ({
                       key={recipient}
                     />
                   ))}
-                  <input
+                  {/* <input
                     name="to"
                     ref={input}
                     style={{ width }}
@@ -204,10 +204,10 @@ const SendInvoice: React.FC<any> = ({
                     )}
                     onChange={e => setNewRecipient(e.target.value.trim())}
                     onKeyDown={handleInput}
-                  />
+                  /> */}
                 </div>
               }
-              onClick={() => input.current.focus()}
+              // onClick={() => input.current.focus()}
             />
           </fieldset>
           <fieldset className="field_with_errors flex flex-col">

--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -150,7 +150,7 @@ const SendInvoice: React.FC<any> = ({
           <h6 className="form__title">
             {isSendReminder
               ? "Send Invoice Reminder"
-              : `Send Invoice #{${invoice.invoiceNumber}}`}
+              : `Send Invoice #${invoice.invoiceNumber}`}
           </h6>
           <button
             className="text-miru-gray-1000"


### PR DESCRIPTION
## Designs
- [Send Reminder Modal](https://www.figma.com/file/4gdPDRPqGqQqPYsO3Qj8CG/Miru-App?type=design&node-id=14889%3A208433&mode=design&t=3AaVPFSt6iL2nPbU-1)
- [Options on invoice details page](https://www.figma.com/file/4gdPDRPqGqQqPYsO3Qj8CG/Miru-App?type=design&node-id=12636%3A207136&mode=design&t=3AaVPFSt6iL2nPbU-1)

## Description
- Fixed send reminder modal UI for the labels.
- Fixed the overlapping issue where when the options were opened it had text overlapping it.

## Preview
Before -
<img width="1490" alt="Screenshot 2023-07-06 at 3 45 27 PM" src="https://github.com/saeloun/miru-web/assets/57438322/8e57100e-5e30-4e1f-987e-1a297b528f67">

<img width="1492" alt="Screenshot 2023-07-06 at 3 46 02 PM" src="https://github.com/saeloun/miru-web/assets/57438322/fc665825-a0b3-41bb-a84c-fd8a35ab4032">


After -
<img width="1495" alt="Screenshot 2023-07-06 at 3 43 53 PM" src="https://github.com/saeloun/miru-web/assets/57438322/cc8c9944-a087-44a2-829e-b9ef9f5171a7">

<img width="1492" alt="Screenshot 2023-07-06 at 3 44 18 PM" src="https://github.com/saeloun/miru-web/assets/57438322/2723e2ed-a218-4944-b0e0-b78aeeaaa9bd">
