### PR TITLE
Fix: Page breaks if the payment gateway is not connected on client portal

### DIFF
--- a/app/javascript/src/components/ClientInvoices/Details/Header.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/Header.tsx
@@ -5,7 +5,12 @@ import { Badge, Tooltip } from "StyledComponents";
 
 import getStatusCssClass from "utils/getBadgeStatus";
 
-const Header = ({ invoice, stripeUrl }) => (
+const Header = ({
+  invoice,
+  stripeUrl,
+  stripe_connected_account,
+  setShowConnectPaymentDialog,
+}) => (
   <div className="mt-6 mb-3 sm:flex sm:items-center sm:justify-between">
     <div className="flex flex-row">
       <div className="mr-2 flex self-center">
@@ -49,7 +54,13 @@ const Header = ({ invoice, stripeUrl }) => (
                   : "bg-miru-han-purple-1000"
               }`}
             onClick={() => {
-              invoice.status != "paid" && (window.location.href = stripeUrl);
+              if (invoice.status != "paid") {
+                if (stripe_connected_account) {
+                  window.location.href = stripeUrl;
+                } else {
+                  setShowConnectPaymentDialog(true);
+                }
+              }
             }}
           >
             <div className="flex flex-row items-center justify-between">

--- a/app/javascript/src/components/ClientInvoices/Details/index.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 
 import invoicesApi from "apis/invoices";
 import Loader from "common/Loader/index";
+import ConnectPaymentGateway from "components/Invoices/popups/ConnectPaymentGateway";
 import { useUserContext } from "context/UserContext";
 
 import Header from "./Header";
@@ -18,6 +19,8 @@ const ClientInvoiceDetails = () => {
 
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState(null);
+  const [showConnectPaymentDialog, setShowConnectPaymentDialog] =
+    useState<boolean>(false);
 
   useEffect(() => {
     fetchViewInvoice();
@@ -38,12 +41,25 @@ const ClientInvoiceDetails = () => {
   }
 
   if (data) {
-    const { url, invoice, logo, lineItems, company, client } = data;
+    const {
+      url,
+      invoice,
+      logo,
+      lineItems,
+      company,
+      client,
+      stripe_connected_account,
+    } = data;
 
     return isDesktop ? (
       <div className="flex flex-col justify-between">
         <div className="font-manrope">
-          <Header invoice={invoice} stripeUrl={url} />
+          <Header
+            invoice={invoice}
+            setShowConnectPaymentDialog={setShowConnectPaymentDialog}
+            stripeUrl={url}
+            stripe_connected_account={stripe_connected_account}
+          />
           <div className="m-0 mt-5 mb-10 w-full bg-miru-gray-100 p-0">
             <InvoiceDetails
               client={client}
@@ -53,6 +69,14 @@ const ClientInvoiceDetails = () => {
               logo={logo}
             />
           </div>
+          {showConnectPaymentDialog && (
+            <ConnectPaymentGateway
+              isInvoiceEmail
+              invoice={invoice}
+              setShowConnectPaymentDialog={setShowConnectPaymentDialog}
+              showConnectPaymentDialog={showConnectPaymentDialog}
+            />
+          )}
         </div>
       </div>
     ) : (


### PR DESCRIPTION
## Notion Card
[Notion Card](https://www.notion.so/saeloun/Client-Portal-Page-breaks-if-the-payment-gateway-is-not-connected-8c286782c20a435aa233a7fead2634fc)

## Description
- Fixed the issue where if the payment gateway was not connected on the client portal and the pay button was clicked it was breaking.

## Preview
Before-

https://github.com/saeloun/miru-web/assets/57438322/f155fc32-df8f-4d5a-b738-0132c8db1f46


After-

https://github.com/saeloun/miru-web/assets/57438322/69f638a5-9d18-4cff-a388-30265f2b5bf9

