### PR TITLE
Pagination and search box alignment fixed

### DIFF
--- a/app/javascript/src/common/Pagination/Pagination.tsx
+++ b/app/javascript/src/common/Pagination/Pagination.tsx
@@ -42,14 +42,12 @@ const Pagination = ({
     return setParams({ ...params, page });
   };
 
-  const disableNextButton = () => {
-    if (!isNaN(Number(pagy?.last)) && pagy?.last === currentPage) {
-      return true;
-    }
-
-    if (typeof pagy?.last === "boolean") {
+  const isLastPage = () => {
+    if (typeof pagy?.last == "boolean") {
       return pagy?.last;
     }
+
+    return pagy?.last == currentPage;
   };
 
   return (
@@ -96,23 +94,22 @@ const Pagination = ({
                 </Fragment>
               ))}
             </div>
-            {!pagy?.last ||
-              (!isNaN(Number(pagy?.last)) && (
-                <button
-                  disabled={disableNextButton()}
-                  className={cn("m-1 mx-4 font-bold", {
-                    "text-miru-gray-400": disableNextButton(),
-                    "text-miru-han-purple-1000": !pagy?.last,
-                  })}
-                  onClick={() => {
-                    isReport
-                      ? handleClick(pagy?.next)
-                      : setParams({ ...params, page: pagy?.next });
-                  }}
-                >
-                  <CaretCircleRightIcon size={16} weight="bold" />
-                </button>
-              ))}
+            {!isLastPage() && (
+              <button
+                disabled={isLastPage()}
+                className={cn("m-1 mx-4 font-bold", {
+                  "text-miru-gray-400": isLastPage(),
+                  "text-miru-han-purple-1000": !isLastPage(),
+                })}
+                onClick={() => {
+                  isReport
+                    ? handleClick(pagy?.next)
+                    : setParams({ ...params, page: pagy?.next });
+                }}
+              >
+                <CaretCircleRightIcon size={16} weight="bold" />
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/app/javascript/src/components/ClientInvoices/Header.tsx
+++ b/app/javascript/src/components/ClientInvoices/Header.tsx
@@ -124,7 +124,7 @@ const Header = ({ showSearch, params, setParams }) => {
               </div>
             </div>
           ) : (
-            <div className="flex w-10/12 md:w-11/12 lg:w-1/3">
+            <div className="flex w-10/12 items-center justify-center md:w-11/12 lg:w-1/3">
               <div
                 className={`${
                   expandSearchBox || searchQuery


### PR DESCRIPTION
Notion
-
What 
- Fixed Pagination on invoices page. (Next button was not working as expected)

Why:
- Time entry report pagination bug fix changes affected the pagination on invoices module. The type of `pagy.last` variable is boolean on invoices API and the type of same variable is number in reports API need to update it from backend.  

Testing:
Tested the working of pagination on both reports page and invoices.