### PR TITLE
Handled internal api related 404 errors

### DIFF
--- a/app/controllers/internal_api/v1/application_controller.rb
+++ b/app/controllers/internal_api/v1/application_controller.rb
@@ -10,4 +10,10 @@ class InternalApi::V1::ApplicationController < ActionController::API
   include SetCurrentDetails
 
   before_action :authenticate_user!
+
+  def not_found
+    skip_authorization
+
+    render json: { error: "Route not found" }, status: :not_found
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,6 @@ Rails.application.routes.draw do
   root "home#index"
 
   match "*path", via: :all, to: "home#index", constraints: lambda { |req|
-    req.path.exclude? "rails/active_storage"
+    req.path.exclude?("rails/active_storage") && !req.path.include?("internal_api")
   }
 end

--- a/config/routes/internal_api.rb
+++ b/config/routes/internal_api.rb
@@ -124,5 +124,9 @@ namespace :internal_api, defaults: { format: "json" } do
     resources :expense_categories, only: [:create]
     resources :expenses, only: [:create, :index, :show]
     resources :bulk_previous_employments, only: [:update]
+
+    match "*path", to: "application#not_found", via: :all, constraints: lambda { |req|
+      req.path.exclude?("rails/active_storage") && req.path.include?("internal_api")
+    }
   end
 end


### PR DESCRIPTION
Notion card:

https://www.notion.so/Backend-Getting-HTML-response-on-accessing-undefined-route-1a7cc27102d442bd96f8e5c199bdde26?pvs=4

What changed:

Added a match route to handle internal API unknown paths

Screenshot:

<img width="911" alt="Screenshot 2023-07-17 at 5 15 32 PM" src="https://github.com/saeloun/miru-web/assets/52308930/fc75cec8-8ed8-42cd-8f53-12f7fe5f05fd">

Tests:

<img width="1269" alt="Screenshot 2023-07-17 at 6 01 07 PM" src="https://github.com/saeloun/miru-web/assets/52308930/62d7819c-cb51-41c3-be15-6d6aadb2aecf">

