### PR TITLE
Employment details bug

### DIFF
--- a/app/controllers/internal_api/v1/employments_controller.rb
+++ b/app/controllers/internal_api/v1/employments_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class InternalApi::V1::EmploymentsController < InternalApi::V1::ApplicationController
-  before_action :set_user, only: [:show]
   before_action :set_employment, only: [:update, :show]
 
   def index
@@ -11,8 +10,7 @@ class InternalApi::V1::EmploymentsController < InternalApi::V1::ApplicationContr
 
   def show
     authorize @employment
-    employment_with_email = @employment.attributes.merge(email: @user.email)
-    render json: { employment: employment_with_email }, status: :ok
+    render :show
   end
 
   def update
@@ -22,10 +20,6 @@ class InternalApi::V1::EmploymentsController < InternalApi::V1::ApplicationContr
   end
 
   private
-
-    def set_user
-      @user ||= User.find(params[:id])
-    end
 
     def set_employment
       @employment = Employment.find_by!(user_id: params[:id], company_id: current_company.id)

--- a/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/StaticPage.tsx
+++ b/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/StaticPage.tsx
@@ -9,7 +9,6 @@ import CustomDatePicker from "common/CustomDatePicker";
 import { CustomInputText } from "common/CustomInputText";
 import { CustomReactSelect } from "common/CustomReactSelect";
 import { ErrorSpan } from "common/ErrorSpan";
-import { useUserContext } from "context/UserContext";
 
 const inputClass =
   "form__input block w-full appearance-none bg-white p-4 text-base h-12 focus-within:border-miru-han-purple-1000";
@@ -36,9 +35,13 @@ const StaticPage = ({
   handleDeletePreviousEmployment,
   handleAddPastEmployment,
   updatePreviousEmploymentValues,
+  dateFormat,
+  joinedAt,
+  resignedAt,
 }) => {
-  const { company } = useUserContext();
-  const { date_format } = company;
+  const getDOJ = joinedAt && dayjs(joinedAt, dateFormat).format(dateFormat);
+
+  const getDOR = resignedAt && dayjs(resignedAt, dateFormat).format(dateFormat);
 
   return (
     <div className="mt-4 h-full bg-miru-gray-100 px-10">
@@ -115,6 +118,7 @@ const StaticPage = ({
           <div className="flex flex-row py-3">
             <div className="flex w-1/2 flex-col px-2">
               <CustomInputText
+                disabled={employmentDetails.current_employment.email}
                 id="email"
                 label="Email ID (Official)"
                 name="email"
@@ -175,10 +179,7 @@ const StaticPage = ({
                   label="Date of Joining"
                   name="joined_at"
                   type="text"
-                  value={employmentDetails.current_employment.joined_at || ""}
-                  onChange={e => {
-                    updateCurrentEmploymentDetails(e.target.value, "joined_at");
-                  }}
+                  value={getDOJ || ""}
                 />
                 <CalendarIcon
                   className="absolute top-0 bottom-0 right-4 my-auto"
@@ -194,15 +195,9 @@ const StaticPage = ({
               )}
               {showDOJDatePicker.visibility && (
                 <CustomDatePicker
-                  dateFormat={date_format}
-                  date={
-                    employmentDetails.current_employment.joined_at
-                      ? employmentDetails.current_employment.joined_at
-                      : dayjs()
-                  }
-                  handleChange={e =>
-                    handleDOJDatePicker(dayjs(e).format(date_format), true)
-                  }
+                  date={joinedAt || dayjs()}
+                  dateFormat={dateFormat}
+                  handleChange={handleDOJDatePicker}
                 />
               )}
             </div>
@@ -222,13 +217,7 @@ const StaticPage = ({
                   label="Date of Resignation"
                   name="resigned_at"
                   type="text"
-                  value={employmentDetails.current_employment.resigned_at || ""}
-                  onChange={e => {
-                    updateCurrentEmploymentDetails(
-                      e.target.value,
-                      "resigned_at"
-                    );
-                  }}
+                  value={getDOR || ""}
                 />
                 <CalendarIcon
                   className="absolute top-0 bottom-0 right-4 my-auto"
@@ -244,15 +233,9 @@ const StaticPage = ({
               )}
               {showDORDatePicker.visibility && (
                 <CustomDatePicker
-                  dateFormat={date_format}
-                  date={
-                    employmentDetails.current_employment.resigned_at
-                      ? employmentDetails.current_employment.resigned_at
-                      : dayjs()
-                  }
-                  handleChange={e =>
-                    handleDORDatePicker(dayjs(e).format(date_format), true)
-                  }
+                  date={resignedAt || dayjs()}
+                  dateFormat={dateFormat}
+                  handleChange={handleDORDatePicker}
                 />
               )}
             </div>

--- a/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/index.tsx
+++ b/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/index.tsx
@@ -198,15 +198,20 @@ const EmploymentDetails = () => {
     const getDifference = (array1, array2) =>
       array1.filter(object1 => !array2.some(object2 => object1 === object2));
 
+    //creating an array which includes removed records
     const removed = employmentDetails.previous_employments.filter(
       e => !previousEmployments.includes(e)
     );
 
+    //creating an array which includes updated and added records
     const unSortedEmployments = getDifference(
       previousEmployments,
       employmentDetails.previous_employments
     );
+
     const pastEmployments = InitialPrevEmployments;
+
+    //sorting new entries and updated entries into
     unSortedEmployments.map(unSorted => {
       if (unSorted.id) {
         pastEmployments.updated_employments.push(unSorted);
@@ -214,13 +219,19 @@ const EmploymentDetails = () => {
         pastEmployments.added_employments.push(unSorted);
       }
     });
+
+    //Extracting removed records id
     if (removed.length > 0) {
       removed.map(remove => {
-        pastEmployments.updated_employments.filter(updated => {
-          if (updated.id !== remove.id) {
-            pastEmployments.removed_employment_ids.push(remove?.id);
-          }
-        });
+        if (pastEmployments.updated_employments.length > 0) {
+          pastEmployments.updated_employments.filter(updated => {
+            if (updated.id !== remove.id) {
+              pastEmployments.removed_employment_ids.push(remove?.id);
+            }
+          });
+        } else {
+          pastEmployments.removed_employment_ids.push(remove?.id);
+        }
       });
     }
     updateEmploymentDetails(pastEmployments);

--- a/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/index.tsx
+++ b/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/index.tsx
@@ -60,6 +60,10 @@ const EmploymentDetails = () => {
   });
   const [errDetails, setErrDetails] = useState(initialErrState);
   const [isLoading, setIsLoading] = useState(false);
+  const [dateFormat, setDateFormat] = useState("DD-MM-YYYY");
+  const [resignedAt, setResignedAt] = useState(null);
+  const [joinedAt, setJoinedAt] = useState(null);
+
   useOutsideClick(DOJRef, () => setShowDOJDatePicker({ visibility: false }));
   useOutsideClick(DORRef, () => setShowDORDatePicker({ visibility: false }));
 
@@ -71,6 +75,9 @@ const EmploymentDetails = () => {
   const getDetails = async () => {
     const curr: any = await teamsApi.getEmploymentDetails(memberId);
     const prev: any = await teamsApi.getPreviousEmployments(memberId);
+    setDateFormat(curr.data.date_format);
+    setJoinedAt(curr.data.employment.joined_at);
+    setResignedAt(curr.data.employment.resigned_at);
     const employmentData = employmentMapper(
       curr.data.employment,
       prev.data.previous_employments
@@ -136,12 +143,18 @@ const EmploymentDetails = () => {
 
   const handleDOJDatePicker = date => {
     setShowDOJDatePicker({ visibility: !showDOJDatePicker.visibility });
+    setJoinedAt(date);
     updateDetails("employment", {
       ...employmentDetails,
       ...{
         current_employment: {
           ...employmentDetails.current_employment,
-          ...{ joined_at: date },
+          ...{
+            joined_at:
+              dateFormat == "DD-MM-YYYY"
+                ? date
+                : dayjs(date).format("DD-MM-YYYY"),
+          },
         },
       },
     });
@@ -149,12 +162,18 @@ const EmploymentDetails = () => {
 
   const handleDORDatePicker = date => {
     setShowDORDatePicker({ visibility: !showDORDatePicker.visibility });
+    setResignedAt(date);
     updateDetails("employment", {
       ...employmentDetails,
       ...{
         current_employment: {
           ...employmentDetails.current_employment,
-          ...{ resigned_at: date },
+          ...{
+            resigned_at:
+              dateFormat == "DD-MM-YYYY"
+                ? date
+                : dayjs(date).format("DD-MM-YYYY"),
+          },
         },
       },
     });
@@ -272,6 +291,7 @@ const EmploymentDetails = () => {
             <StaticPage
               DOJRef={DOJRef}
               DORRef={DORRef}
+              dateFormat={dateFormat}
               employeeType={employeeType}
               employeeTypes={employeeTypes}
               employmentDetails={employmentDetails}
@@ -281,7 +301,9 @@ const EmploymentDetails = () => {
               handleDORDatePicker={handleDORDatePicker}
               handleDeletePreviousEmployment={handleDeletePreviousEmployment}
               handleOnChangeEmployeeType={handleOnChangeEmployeeType}
+              joinedAt={joinedAt}
               previousEmployments={previousEmployments}
+              resignedAt={resignedAt}
               setShowDOJDatePicker={setShowDOJDatePicker}
               setShowDORDatePicker={setShowDORDatePicker}
               showDOJDatePicker={showDOJDatePicker}

--- a/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/validationSchema.ts
+++ b/app/javascript/src/components/Team/Details/EmploymentDetails/Edit/validationSchema.ts
@@ -4,15 +4,22 @@ export const employmentSchema = {
   current_employment: Yup.object().shape({
     employee_id: Yup.string()
       .required("Please enter employee id")
+      .typeError("Please enter employee id")
       .max(20, "Maximum 20 characters are allowed"),
-    employment_type: Yup.string().required("Please select employment type"),
+    employment_type: Yup.string()
+      .typeError("Please select employment type")
+      .required("Please select employment type"),
     designation: Yup.string()
       .required("Please enter designation")
+      .typeError("Please enter designation")
       .max(20, "Maximum 20 characters are allowed"),
     email: Yup.string()
+      .required("Please enter email id")
       .email("Please enter valid email")
-      .required("Please enter email"),
-    joined_at: Yup.string(),
+      .typeError("Please enter email"),
+    joined_at: Yup.string()
+      .required("Please enter Date of joining")
+      .typeError("Please enter Date of joining"),
   }),
   previous_employment: Yup.array(),
 };

--- a/app/javascript/src/components/Team/Details/EmploymentDetails/StaticPage.tsx
+++ b/app/javascript/src/components/Team/Details/EmploymentDetails/StaticPage.tsx
@@ -83,7 +83,7 @@ const StaticPage = ({ employmentDetails }) => (
           Previous <br /> Employment
         </span>
       </div>
-      <div className="flex w-4/5 items-center justify-center">
+      <div className="flex w-4/5 flex-col items-center justify-center">
         {employmentDetails?.previous_employments[0]?.company_name ? (
           employmentDetails.previous_employments.map((previous, index) => (
             <div className="mb-4 flex w-full" key={index}>

--- a/app/javascript/src/components/Team/Details/Layout/SideNav.tsx
+++ b/app/javascript/src/components/Team/Details/Layout/SideNav.tsx
@@ -23,7 +23,7 @@ const getTeamUrls = memberId => [
   },
   {
     url: `/team/${memberId}/employment`,
-    text: "EMPLOYEMENT DETAILS",
+    text: "EMPLOYMENT DETAILS",
   },
 ];
 

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -50,6 +50,14 @@ class Employment < ApplicationRecord
     end
   end
 
+  def formatted_joined_at
+    CompanyDateFormattingService.new(joined_at, company:).process
+  end
+
+  def formatted_resigned_at
+    CompanyDateFormattingService.new(resigned_at, company:).process
+  end
+
   private
 
     def remove_user_invitations

--- a/app/services/company_date_formatting_service.rb
+++ b/app/services/company_date_formatting_service.rb
@@ -13,7 +13,7 @@ class CompanyDateFormattingService < ApplicationService
     return if !company
 
     @date = date.to_date if es_date_presence
-    date.strftime(company_date_format)
+    date&.strftime(company_date_format)
   end
 
   private

--- a/app/views/internal_api/v1/employments/show.json.jbuilder
+++ b/app/views/internal_api/v1/employments/show.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+json.employment do
+json.id @employment.id
+json.joined_at @employment.formatted_joined_at
+json.resigned_at @employment.formatted_resigned_at
+json.company_id @employment.company_id
+json.employee_id @employment.employee_id
+json.designation @employment.designation
+json.employment_type @employment.employment_type
+json.user_id @employment.user_id
+json.email @employment.user.email
+end
+json.date_format current_company.date_format


### PR DESCRIPTION
Notion:
https://www.notion.so/saeloun/Integration-An-admin-owner-user-should-be-able-to-view-the-employment-details-page-of-a-user-with-e-6d4ab6227d8e4e34a24081865931592d?pvs=4

What:
- Bug fixes mentioned in the comments of above ticket
- This PR contains changes from #1419 

Tested both date of joining and resigning in all date formates multiple times. 