### PR TITLE
List not scrollable and overflowing social media links Fixed

### DIFF
--- a/app/javascript/src/components/Profile/UserDetail/UserDetailsView/MobilePersonalDetails.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/UserDetailsView/MobilePersonalDetails.tsx
@@ -101,10 +101,18 @@ const MobilePersonalDetails = ({
         </span>
         <div className="mt-2 flex w-full flex-row">
           <div className="w-1/2 px-1">
-            <InfoDescription description={linkedin} title="LinkedIn" />
+            <InfoDescription
+              description={linkedin}
+              title="LinkedIn"
+              wrapperClassName="break-all"
+            />
           </div>
           <div className="w-1/2 px-2">
-            <InfoDescription description={github} title="Github" />
+            <InfoDescription
+              description={github}
+              title="Github"
+              wrapperClassName="break-all"
+            />
           </div>
         </div>
       </div>

--- a/app/javascript/src/components/Profile/UserDetail/UserDetailsView/StaticPage.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/UserDetailsView/StaticPage.tsx
@@ -97,13 +97,13 @@ const StaticPage = ({ personalDetails, handleEditClick }) => (
       </div>
       <div className="w-4/5">
         <div className="flex">
-          <div className="w-6/12">
+          <div className="w-6/12 break-all pr-4">
             <span className="text-xs text-miru-dark-purple-1000">LinkedIn</span>
             <p className="min-h-24 text-miru-dark-purple-1000">
               {personalDetails.linkedin}
             </p>
           </div>
-          <div className="w-6/12">
+          <div className="w-6/12 break-all pr-4">
             <span className="text-xs text-miru-dark-purple-1000">Github</span>
             <p className="min-h-24 text-miru-dark-purple-1000">
               {personalDetails.github}

--- a/app/javascript/src/components/Projects/Details/EditMembersList.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersList.tsx
@@ -131,7 +131,7 @@ const EditMembersList = ({
   return (
     <Modal
       isOpen
-      customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle"
+      customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle overflow-visible"
       onClose={closeAddRemoveMembers}
     >
       <div className="flex items-center justify-between">


### PR DESCRIPTION
Notion:
https://www.notion.so/saeloun/Add-team-member-list-not-scrollable-c50da608d69449acbd55d69c0d4eb64e?pvs=4

What:
- Team member list on Add/edit team member modal is not scrollable issue fixed
-  Social media links are overflowing on profile settings page fixed

Preview:
Before:
![image](https://github.com/saeloun/miru-web/assets/72149587/f2d65d72-e5bd-4081-9b69-a8d31a3a3742)

<img width="675" alt="Screenshot 2023-07-20 at 6 04 27 PM" src="https://github.com/saeloun/miru-web/assets/72149587/0b123475-f791-49d5-81e7-103023eba606">

After:
<img width="877" alt="Screenshot 2023-07-20 at 6 03 40 PM" src="https://github.com/saeloun/miru-web/assets/72149587/d0742f75-9c61-49b5-9ff9-a3513043b2df">

<img width="757" alt="Screenshot 2023-07-20 at 6 04 54 PM" src="https://github.com/saeloun/miru-web/assets/72149587/c30bd350-8cc6-4bdd-aea8-0df0a6599223">
