### PR TITLE
Handle error while creating company

### DIFF
--- a/app/javascript/src/components/OrganizationSetup/index.tsx
+++ b/app/javascript/src/components/OrganizationSetup/index.tsx
@@ -19,6 +19,8 @@ import { financialDetailsFormInitialValues } from "./FinancialDetailsForm/utils"
 import Step from "./Step";
 import { organizationSetupSteps, TOTAL_NUMBER_OF_STEPS } from "./utils";
 
+import Toastr from "../../StyledComponents/Toastr";
+
 const OrganizationSetup = () => {
   const navigate = useNavigate();
   const { isDesktop } = useUserContext();
@@ -105,10 +107,18 @@ const OrganizationSetup = () => {
   ) => {
     setStepNoOfLastSubmittedForm(currentStep);
     const payload = generatePayload(companyDetails, financialDetails);
-    const res = await companiesApi.create(payload);
 
-    if (res?.status == 200) {
-      navigate(Paths.SIGNUP_SUCCESS);
+    try {
+      const res = await companiesApi.create(payload);
+      if (res?.status == 200) {
+        navigate(Paths.SIGNUP_SUCCESS);
+      }
+    } catch (error) {
+      Toastr.error(
+        error.response?.data?.errors ||
+          error.response?.data?.error ||
+          error.response?.data?.notice
+      );
     }
   };
 

--- a/app/javascript/src/components/OrganizationSetup/index.tsx
+++ b/app/javascript/src/components/OrganizationSetup/index.tsx
@@ -114,11 +114,10 @@ const OrganizationSetup = () => {
         navigate(Paths.SIGNUP_SUCCESS);
       }
     } catch (error) {
-      Toastr.error(
-        error.response?.data?.errors ||
-          error.response?.data?.error ||
-          error.response?.data?.notice
-      );
+      const { errors, error: err, notice } = error?.response?.data || {};
+      const errorMessage = errors || err || notice;
+
+      Toastr.error(errorMessage);
     }
   };
 


### PR DESCRIPTION
What
- Added toast error if an error occurs not related to company fields while creating a company.

Why
- In PR #1356 the companies.ts was modified to show error on text fields instead of the toast messages. 