### PR TITLE
Clients chart color fix

### DIFF
--- a/app/javascript/src/common/ChartBar/index.tsx
+++ b/app/javascript/src/common/ChartBar/index.tsx
@@ -16,9 +16,11 @@ const Client = ({ element, totalMinutes, index }: ISingleClient) => {
   const chartColorIndex = index % 4;
   const randomColor = chartColor[chartColorIndex];
   const hourPercentage = (element.minutes * 100) / totalMinutes;
+  const finalHourPercentage =
+    hourPercentage > 1 ? hourPercentage : Math.ceil(hourPercentage);
 
   const divStyle = {
-    width: `${hourPercentage}%`,
+    width: `${finalHourPercentage}%`,
   };
 
   return (
@@ -41,29 +43,38 @@ const Client = ({ element, totalMinutes, index }: ISingleClient) => {
   );
 };
 
-const GetClientBar = ({ data, totalMinutes }: IChartBarGraph) => (
-  <section>
-    <div className="hidden md:block">
-      <p className="mb-3 text-tiny tracking-widest text-miru-dark-purple-600">
-        TOTAL HOURS:{" "}
-        <span className="font-medium">{minToHHMM(totalMinutes)}</span>
-      </p>
-      <div className="flex h-1 w-full bg-gray-200">
-        {data.map((element, index) => (
-          <Client
-            element={element}
-            index={index}
-            key={index}
-            totalMinutes={totalMinutes}
-          />
-        ))}
+const GetClientBar = ({ data, totalMinutes }: IChartBarGraph) => {
+  //removing elements whose minutes value is less than or equal to zero.
+  const dataWithMinutes = data.filter(element => element.minutes > 0);
+
+  return (
+    <section>
+      <div className="hidden md:block">
+        <p className="mb-3 text-tiny tracking-widest text-miru-dark-purple-600">
+          TOTAL HOURS:{" "}
+          <span className="font-medium">{minToHHMM(totalMinutes)}</span>
+        </p>
+        <div className="flex h-1 w-full bg-gray-200">
+          {dataWithMinutes.map((element, index) => {
+            if (element.minutes > 0) {
+              return (
+                <Client
+                  element={element}
+                  index={index}
+                  key={index}
+                  totalMinutes={totalMinutes}
+                />
+              );
+            }
+          })}
+        </div>
+        <div className="mt-3 flex justify-between pb-6 text-tiny tracking-widest text-miru-dark-purple-400">
+          <span>0</span>
+          <span>{minToHHMM(totalMinutes)}</span>
+        </div>
       </div>
-      <div className="mt-3 flex justify-between pb-6 text-tiny tracking-widest text-miru-dark-purple-400">
-        <span>0</span>
-        <span>{minToHHMM(totalMinutes)}</span>
-      </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default GetClientBar;


### PR DESCRIPTION
### **Notion :**
4th point in this [ticket](https://www.notion.so/saeloun/Bugs-after-deployment-7752310dde324ef897c44dd7eee12ebb?pvs=4)
### **What :**
- Multiple clients were showing the same color simultaneously or alternatively. 
- Filtered data array: removed the elements with 0 minutes values.
- Round up the percentage to ceil value if it is less than 1. 
### **Why :**
- Because few clients have less logged hours/minutes data, such as 2 minutes or even 0 minutes. So these values were coming very small (e.g 0.02 %) after converting it to the hour percentage on a chart and that's why it was being neglected.
### **Preview :**
Before:
<img width="1345" alt="Screenshot 2023-07-27 at 3 18 20 PM" src="https://github.com/saeloun/miru-web/assets/72149587/5f18abd6-df21-4144-861b-8c4dcfa8911b">

After:
<img width="1340" alt="Screenshot 2023-07-27 at 3 18 41 PM" src="https://github.com/saeloun/miru-web/assets/72149587/8a17ef35-5bc7-42e0-8643-0452fd6c04b7">