### PR TITLE
Button disabled after sending request 

### DIFF
--- a/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
+++ b/app/javascript/src/components/Invoices/popups/SendInvoice/index.tsx
@@ -249,7 +249,8 @@ const SendInvoice: React.FC<any> = ({
                 `mt-6 flex w-full justify-center rounded-md border border-transparent p-3 text-lg font-bold
                     uppercase text-white shadow-sm
                     ${
-                      invoiceEmail?.recipients.length > 0
+                      invoiceEmail?.recipients.length > 0 &&
+                      status !== InvoiceStatus.LOADING
                         ? `focus:outline-none cursor-pointer bg-miru-han-purple-1000 hover:bg-miru-han-purple-600 focus:ring-2
                         focus:ring-miru-han-purple-600 focus:ring-offset-2`
                         : "cursor-not-allowed border-transparent bg-indigo-100 hover:border-transparent"

--- a/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
+++ b/app/javascript/src/components/payments/Modals/AddManualEntry.tsx
@@ -16,7 +16,7 @@ const AddManualEntry = ({
   showManualEntryModal,
 }) => (
   <Modal
-    customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle"
+    customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle overflow-visible"
     isOpen={showManualEntryModal}
     onClose={() => setShowManualEntryModal(false)}
   >

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -43,6 +43,7 @@ const PaymentEntryForm = ({
   const [showSelectMenu, setShowSelectMenu] = useState(false);
   const [showTransactionTypes, setShowTransactionTypes] =
     useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const wrapperSelectRef = useRef(null);
   const wrapperCalendartRef = useRef(null);
@@ -106,6 +107,7 @@ const PaymentEntryForm = ({
       });
       await payment.create(sanitized);
       Toastr.success("Manual entry added successfully.");
+      setIsLoading(false);
       fetchPaymentList();
       fetchInvoiceList();
       setInvoice("");
@@ -119,6 +121,7 @@ const PaymentEntryForm = ({
       }
     } catch {
       Toastr.error("Failed to add manual entry");
+      setIsLoading(false);
     }
   };
 
@@ -342,6 +345,7 @@ const PaymentEntryForm = ({
       </div>
       <div className="actions mx-auto mt-4 mb-4 w-full">
         <button
+          disabled={isLoading}
           type="submit"
           className={
             isAddPaymentBtnActive(
@@ -349,11 +353,12 @@ const PaymentEntryForm = ({
               transactionDate,
               transactionType,
               amount
-            )
-              ? "focus:outline-none flex h-10 w-full cursor-pointer justify-center rounded border border-transparent bg-miru-han-purple-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm hover:bg-miru-han-purple-600"
-              : "focus:outline-none flex h-10 w-full cursor-pointer justify-center rounded border border-transparent bg-miru-gray-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm"
+            ) && !isLoading
+              ? "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-han-purple-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm hover:bg-miru-han-purple-600"
+              : "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-gray-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm"
           }
           onClick={() => {
+            setIsLoading(true);
             if (
               isAddPaymentBtnActive(
                 invoice,


### PR DESCRIPTION
### **Notion :**
NA
### **What :**
- Button disabled (color changed to gray) after sending the reminder request on send reminder modal and after send add payment request on add payment modal.
### **Why :**
- When in loading state it was unclear for the user if the request has been sent or not.
### **Preview :**
https://www.loom.com/share/a255ceef1ccd4238aafcbc15ab5bacfd?sid=adfd6068-6a7b-4f8d-ac8c-e6ca39ed057b