### PR TITLE
Hubspot form integration

### DIFF
--- a/app/javascript/src/apis/authentication.ts
+++ b/app/javascript/src/apis/authentication.ts
@@ -34,6 +34,12 @@ const googleAuth = () =>
     })
     .get("users/auth/google_oauth2");
 
+const hubspot = async (portalId, formId, payload) =>
+  await axios.post(
+    `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`,
+    payload
+  );
+
 const authenticationApi = {
   signin,
   signup,
@@ -41,6 +47,7 @@ const authenticationApi = {
   resetPassword,
   googleAuth,
   sendEmailConfirmation,
+  hubspot,
 };
 
 export default authenticationApi;

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React, { useRef, useState } from "react";
 
 import { Formik, Form, FormikProps } from "formik";
@@ -43,7 +42,15 @@ const SignUpForm = () => {
       const portalId = 23903467;
       const formId = "3266596a-b69b-40a2-9cd4-58ef522a270a";
 
-      const result = await authenticationApi.hubspot(portalId, formId, {
+      const payload = {
+        first_name,
+        last_name,
+        email,
+        password,
+        password_confirmation: confirm_password,
+      };
+      const res = await authenticationApi.signup(payload);
+      await authenticationApi.hubspot(portalId, formId, {
         portalId,
         formId,
         fields: [
@@ -62,14 +69,6 @@ const SignUpForm = () => {
         ],
       });
 
-      const payload = {
-        first_name,
-        last_name,
-        email,
-        password,
-        password_confirmation: confirm_password,
-      };
-      const res = await authenticationApi.signup(payload);
       navigate(`/email_confirmation?email=${res.data.email}`);
     } catch (error) {
       if (error?.response?.data?.error) {

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -40,8 +40,8 @@ const SignUpForm = () => {
       const { first_name, last_name, email, password, confirm_password } =
         values;
 
-      const portalId = "3266596a-b69b-40a2-9cd4-58ef522a270a";
-      const formId = "23903467";
+      const portalId = 23903467;
+      const formId = "3266596a-b69b-40a2-9cd4-58ef522a270a";
 
       const result = await authenticationApi.hubspot(portalId, formId, {
         portalId,

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { useRef, useState } from "react";
 
 import { Formik, Form, FormikProps } from "formik";
@@ -38,6 +39,28 @@ const SignUpForm = () => {
     try {
       const { first_name, last_name, email, password, confirm_password } =
         values;
+
+      const portalId = "3266596a-b69b-40a2-9cd4-58ef522a270a";
+      const formId = "23903467";
+
+      const result = await authenticationApi.hubspot(portalId, formId, {
+        portalId,
+        formId,
+        fields: [
+          {
+            name: "email",
+            value: email,
+          },
+          {
+            name: "firstname",
+            value: first_name,
+          },
+          {
+            name: "lastname",
+            value: last_name,
+          },
+        ],
+      });
 
       const payload = {
         first_name,

--- a/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
+++ b/app/javascript/src/components/Authentication/SignUp/SignUpForm.tsx
@@ -39,8 +39,8 @@ const SignUpForm = () => {
       const { first_name, last_name, email, password, confirm_password } =
         values;
 
-      const portalId = 23903467;
-      const formId = "3266596a-b69b-40a2-9cd4-58ef522a270a";
+      const portalId = process.env.HUBSPOT_SIGNUP_FORM_PORTAL_ID;
+      const formId = process.env.HUBSPOT_SIGNUP_FORM_FORMID;
 
       const payload = {
         first_name,

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv::Railtie.load
+
 module MiruWeb
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/Integration-with-Marketing-tool-Hubspot-4836e0626b8843378996ea943ccd1d13?pvs=4
### **What :**
- Hubspot form integration
### **Why :**
- To keep a track of user signups on miru.
### **Preview :**
<img width="1672" alt="Screenshot 2023-07-31 at 4 14 08 PM" src="https://github.com/saeloun/miru-web/assets/72149587/d1bdebea-11ed-43f0-bee0-0317f11f73c9">
### **Todos** (for testing):

Won't send a req with already existing email Ids as we are sending the hubspot req after the signup req.
