### PR TITLE
Autogenerate Invoice number

### DIFF
--- a/app/javascript/src/common/CustomInputText/index.tsx
+++ b/app/javascript/src/common/CustomInputText/index.tsx
@@ -8,7 +8,7 @@ const defaultInputBoxClassName =
   "form__input block w-full appearance-none bg-white p-4 text-sm lg:text-base h-12 border-miru-gray-1000";
 const defaultWrapperClassName = "outline relative h-12";
 const defaultLabelClassname =
-  "absolute top-0.5 h-6 z-1 origin-0 bg-white p-2 text-sm lg:text-base font-medium text-miru-dark-purple-200 duration-300";
+  "absolute top-0.5 h-6 z-1 origin-0 bg-white p-2 text-sm 2xl:text-base font-medium text-miru-dark-purple-200 duration-300";
 
 type customInputTextProps = {
   id?: string;

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -58,7 +58,7 @@ const ClientSelection = ({
   const autoGenerateInvoiceNumber = client => {
     const { previousInvoiceNumber } = client;
     // on edit invoice page: invoice number should not be incremented for same client
-    if (prePopulatedClient.value == client.value) {
+    if (prePopulatedClient?.value == client.value) {
       setInvoiceNumber(prePopulatedInvoiceNumber);
     } else {
       if (previousInvoiceNumber) {

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -14,6 +14,7 @@ const ClientSelection = ({
   setSelectedClient,
   optionSelected,
   clientVisible,
+  setInvoiceNumber,
 }) => {
   const [isOptionSelected, setIsOptionSelected] =
     useState<boolean>(optionSelected);
@@ -43,10 +44,31 @@ const ClientSelection = ({
     handleAlreadySelectedClient();
   }, [selectedClient]);
 
+  const autoGenerateInvoiceNumber = client => {
+    const { previous_invoice_number } = client;
+
+    //extracting last character of invoice
+    const lastChar = parseInt(
+      previous_invoice_number.charAt(previous_invoice_number.length - 1)
+    );
+
+    //extracting remaining invoice number
+    const remaining = previous_invoice_number.slice(
+      0,
+      previous_invoice_number.length - 1
+    );
+
+    //incrementing invoice number
+    if (!isNaN(lastChar)) {
+      setInvoiceNumber(remaining.concat(lastChar + 1));
+    }
+  };
+
   const handleClientChange = selection => {
     setSelectedClient(selection);
     setIsClientVisible(false);
     setIsOptionSelected(true);
+    autoGenerateInvoiceNumber(selection);
   };
 
   const handleAlreadySelectedClient = () => {
@@ -78,7 +100,8 @@ const ClientSelection = ({
           label="Billed to"
           wrapperClassName="h-full cursor-pointer"
           value={
-            isOptionSelected && (
+            isOptionSelected &&
+            selectedClient && (
               <div className="h-full overflow-y-scroll">
                 <p className="text-base font-bold text-miru-dark-purple-1000">
                   {selectedClient.label}

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -46,21 +46,26 @@ const ClientSelection = ({
 
   const autoGenerateInvoiceNumber = client => {
     const { previous_invoice_number } = client;
+    if (previous_invoice_number) {
+      //extracting last character of invoice
+      const lastChar = parseInt(
+        previous_invoice_number.charAt(previous_invoice_number.length - 1)
+      );
 
-    //extracting last character of invoice
-    const lastChar = parseInt(
-      previous_invoice_number.charAt(previous_invoice_number.length - 1)
-    );
+      //extracting remaining invoice number
+      const remaining = previous_invoice_number.slice(
+        0,
+        previous_invoice_number.length - 1
+      );
 
-    //extracting remaining invoice number
-    const remaining = previous_invoice_number.slice(
-      0,
-      previous_invoice_number.length - 1
-    );
-
-    //incrementing invoice number
-    if (!isNaN(lastChar)) {
-      setInvoiceNumber(remaining.concat(lastChar + 1));
+      //incrementing invoice number
+      if (!isNaN(lastChar)) {
+        setInvoiceNumber(remaining.concat(lastChar + 1));
+      } else {
+        setInvoiceNumber("");
+      }
+    } else {
+      setInvoiceNumber("");
     }
   };
 
@@ -106,16 +111,20 @@ const ClientSelection = ({
                 <p className="text-base font-bold text-miru-dark-purple-1000">
                   {selectedClient.label}
                 </p>
-                <p className="w-52 text-sm font-normal text-miru-dark-purple-600">
-                  {`${address_line_1}${
-                    address_line_2 ? `, ${address_line_2}` : ""
-                  }
+                {selectedClient?.address ? (
+                  <p className="w-52 text-sm font-normal text-miru-dark-purple-600">
+                    {`${address_line_1}${
+                      address_line_2 ? `, ${address_line_2}` : ""
+                    }
                 ${
                   address_line_2 ? "," : ""
                 }\n ${city}, ${state}, ${country},\n ${pin}`}
-                  <br />
-                  {selectedClient.phone}
-                </p>
+                    <br />
+                    {selectedClient.phone}
+                  </p>
+                ) : (
+                  "-"
+                )}
               </div>
             )
           }

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -15,9 +15,15 @@ const ClientSelection = ({
   optionSelected,
   clientVisible,
   setInvoiceNumber,
+  invoiceNumber,
 }) => {
   const [isOptionSelected, setIsOptionSelected] =
     useState<boolean>(optionSelected);
+
+  //storing prepopulated values before editing invoice
+  const [prePopulatedClient, setPrePopulatedClient] = useState<any>();
+  const [prePopulatedInvoiceNumber, setPrePopulatedInvoiceNumber] =
+    useState<any>();
 
   const [isClientVisible, setIsClientVisible] =
     useState<boolean>(clientVisible);
@@ -38,6 +44,11 @@ const ClientSelection = ({
       );
       selection[0] && handleClientChange(selection[0]);
     }
+
+    if (selectedClient) {
+      setPrePopulatedClient(selectedClient);
+      setPrePopulatedInvoiceNumber(invoiceNumber);
+    }
   }, []);
 
   useEffect(() => {
@@ -46,26 +57,31 @@ const ClientSelection = ({
 
   const autoGenerateInvoiceNumber = client => {
     const { previousInvoiceNumber } = client;
-    if (previousInvoiceNumber) {
-      //extracting last character of invoice
-      const lastChar = parseInt(
-        previousInvoiceNumber.charAt(previousInvoiceNumber.length - 1)
-      );
+    // on edit invoice page: invoice number should not be incremented for same client
+    if (prePopulatedClient.value == client.value) {
+      setInvoiceNumber(prePopulatedInvoiceNumber);
+    } else {
+      if (previousInvoiceNumber) {
+        //extracting last character of invoice
+        const lastChar = parseInt(
+          previousInvoiceNumber.charAt(previousInvoiceNumber.length - 1)
+        );
 
-      //extracting remaining invoice number
-      const remaining = previousInvoiceNumber.slice(
-        0,
-        previousInvoiceNumber.length - 1
-      );
+        //extracting remaining invoice number
+        const remaining = previousInvoiceNumber.slice(
+          0,
+          previousInvoiceNumber.length - 1
+        );
 
-      //incrementing invoice number
-      if (!isNaN(lastChar)) {
-        setInvoiceNumber(remaining.concat(lastChar + 1));
+        //incrementing invoice number
+        if (!isNaN(lastChar)) {
+          setInvoiceNumber(remaining.concat(lastChar + 1));
+        } else {
+          setInvoiceNumber("");
+        }
       } else {
         setInvoiceNumber("");
       }
-    } else {
-      setInvoiceNumber("");
     }
   };
 

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/ClientSelection.tsx
@@ -45,17 +45,17 @@ const ClientSelection = ({
   }, [selectedClient]);
 
   const autoGenerateInvoiceNumber = client => {
-    const { previous_invoice_number } = client;
-    if (previous_invoice_number) {
+    const { previousInvoiceNumber } = client;
+    if (previousInvoiceNumber) {
       //extracting last character of invoice
       const lastChar = parseInt(
-        previous_invoice_number.charAt(previous_invoice_number.length - 1)
+        previousInvoiceNumber.charAt(previousInvoiceNumber.length - 1)
       );
 
       //extracting remaining invoice number
-      const remaining = previous_invoice_number.slice(
+      const remaining = previousInvoiceNumber.slice(
         0,
-        previous_invoice_number.length - 1
+        previousInvoiceNumber.length - 1
       );
 
       //incrementing invoice number

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
@@ -56,6 +56,7 @@ const InvoiceDetails = ({
         clientVisible={clientVisible}
         optionSelected={optionSelected}
         selectedClient={selectedClient}
+        setInvoiceNumber={setInvoiceNumber}
         setSelectedClient={setSelectedClient}
       />
       <div className="mr-2 flex w-2/12 flex-col justify-between">

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
@@ -59,6 +59,7 @@ const InvoiceDetails = ({
       <ClientSelection
         clientList={clientList}
         clientVisible={clientVisible}
+        invoiceNumber={invoiceNumber}
         optionSelected={optionSelected}
         selectedClient={selectedClient}
         setInvoiceNumber={setInvoiceNumber}

--- a/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceDetails/index.tsx
@@ -49,6 +49,11 @@ const InvoiceDetails = ({
     setShowDueDatePicker(false);
   };
 
+  const handleInvoiceNumberChange = e => {
+    const result = e.target.value.replace(/[^a-zA-Z0-9_-]/g, "");
+    setInvoiceNumber(result);
+  };
+
   return (
     <div className="flex w-full flex-col justify-between border-b border-miru-gray-400 px-5 py-5 md:h-40 md:flex-row md:px-10">
       <ClientSelection
@@ -68,7 +73,7 @@ const InvoiceDetails = ({
           name="invoiceNumber"
           type="text"
           value={invoiceNumber}
-          onChange={e => setInvoiceNumber(e.target.value)}
+          onChange={handleInvoiceNumberChange}
         />
         <CustomInputText
           id="Reference"
@@ -87,7 +92,7 @@ const InvoiceDetails = ({
             <CustomInputText
               readOnly
               id="Date of Issue"
-              inputBoxClassName="focus:border-miru-han-purple-1000 cursor-pointer"
+              inputBoxClassName="focus:border-miru-han-purple-1000 cursor-pointer pr-9 truncate"
               label="Date of Issue"
               name="Date of Issue"
               type="text"
@@ -116,7 +121,7 @@ const InvoiceDetails = ({
             <CustomInputText
               readOnly
               id="Due Date"
-              inputBoxClassName="focus:border-miru-han-purple-1000 cursor-pointer"
+              inputBoxClassName="focus:border-miru-han-purple-1000 cursor-pointer pr-9 truncate"
               label="Due Date"
               name="Due Date"
               type="text"

--- a/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceForm/Header/index.tsx
@@ -65,7 +65,7 @@ const Header = ({
           onClick={handleSendInvoice}
         >
           <PaperPlaneTiltIcon color="White" size={18} />
-          <span className="ml-2 inline-block" id="sendInvoiceButton">
+          <span className="ml-2 inline-block truncate" id="sendInvoiceButton">
             SEND TO
           </span>
         </button>

--- a/app/javascript/src/mapper/generateInvoice.mapper.ts
+++ b/app/javascript/src/mapper/generateInvoice.mapper.ts
@@ -6,7 +6,7 @@ interface GenerateInvoiceClientList {
   name: string;
   phone_number: number;
   email: string;
-  previous_invoice_number: string;
+  previousInvoiceNumber: string;
 }
 
 interface CompanyDetails {
@@ -25,7 +25,7 @@ const getClientList = (clientList: Array<GenerateInvoiceClientList>) =>
     label: client.name,
     phone: client.phone_number,
     email: client.email,
-    previous_invoice_number: client.previous_invoice_number,
+    previousInvoiceNumber: client.previousInvoiceNumber,
   }));
 
 const getCompanyDetails = (input: CompanyDetails) => input;

--- a/app/javascript/src/mapper/generateInvoice.mapper.ts
+++ b/app/javascript/src/mapper/generateInvoice.mapper.ts
@@ -6,6 +6,7 @@ interface GenerateInvoiceClientList {
   name: string;
   phone_number: number;
   email: string;
+  previous_invoice_number: string;
 }
 
 interface CompanyDetails {
@@ -24,6 +25,7 @@ const getClientList = (clientList: Array<GenerateInvoiceClientList>) =>
     label: client.name,
     phone: client.phone_number,
     email: client.email,
+    previous_invoice_number: client.previous_invoice_number,
   }));
 
 const getCompanyDetails = (input: CompanyDetails) => input;

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -57,7 +57,7 @@ class Company < ApplicationRecord
     clients.kept.map do |client|
       {
         id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.current_address,
-        previous_invoice_number: client.invoices&.last&.invoice_number || 0
+        previousInvoiceNumber: client.invoices&.last&.invoice_number || 0
       }
     end
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -55,7 +55,10 @@ class Company < ApplicationRecord
 
   def client_list
     clients.kept.map do |client|
-      { id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.current_address }
+      {
+        id: client.id, name: client.name, email: client.email, phone: client.phone, address: client.current_address,
+        previous_invoice_number: client.invoices&.last&.invoice_number || 0
+      }
     end
   end
 

--- a/app/views/internal_api/v1/partial/_client_list.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_client_list.json.jbuilder
@@ -6,3 +6,4 @@ json.address client[:address]
 json.phone client[:phone]
 json.email client[:email]
 json.logo client[:logo] ? polymorphic_url(client[:logo]) : ""
+json.previousInvoiceNumber client[:previousInvoiceNumber] || 0


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/While-generating-a-new-invoice-the-invoice-number-should-be-autopulated-as-per-the-previous-invoice--05e98f0d18064bb5b47f9f4e92f8292d?pvs=4

### **What :**
- if the previous invoice number for a client is 003, then when the user selects the client name on a new invoice, then the invoice number field is getting be auto-populated with 004. 
- If last character of previous invoice number is alphabet then the invoice number will be blank.
- If no previous invoices are present for the selected client then the invoice number will be blank.
-
### **Why :**
- To ensure that the invoice number is incremented from the previous number and maintain consistency. 
### **Preview :**
https://www.loom.com/share/89f4ce5938f0498381582f247b797c41?sid=7a0ff982-fdb0-4258-a418-40a37311eb9a

### **Todos** (for testing):
- Tested according to requirement.