### PR TITLE
Send payment reminder mail responsive design fixed

### DIFF
--- a/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
+++ b/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
@@ -32,7 +32,7 @@
       }
     </style>
   </head>
-  <body style="color:#1D1A31">
+  <body style="color:#1D1A31;">
     <div class="desktop-invoice">
       <div id="header" style="padding:0 40px;">
         <div
@@ -139,7 +139,7 @@
             </tr>
           </table>
           <div>
-            Invoice and accounting software for every business
+            Invoice software for every business
           </div>
         </div>
         <div
@@ -178,7 +178,7 @@
         </div>
       </div>
     </div>
-    <div class="mobile-invoice">
+    <div class="mobile-invoice" style="font-family: Manrope;">
       <div id="mobile-header">
         <div id="mobile-header" style="padding:0 16px;">
           <div
@@ -200,23 +200,23 @@
             style="display: flex; flex-wrap: wrap; gap: 1rem; border-top-width: 0px; border-left-width: 0px; border-right-width: 0px; border-bottom-width: 1px; border-style: solid; border-color: #ebeff2; padding: 16px 6px"
           >
             <div class="invoice-columns">
-              <span>INVOICE NO.</span>
-              <div><%= invoice.invoice_number %></div>
+              <span style="font-size: 12px; font-weight: 500; letter-spacing: 0.125em; color: black; padding-bottom:10px;">INVOICE NO.</span>
+              <div style="font-size: 16px; font-weight: 500; color: black;"><%= invoice.invoice_number %></div>
             </div>
             <div class="invoice-columns">
-              <span>ISSUED DATE</span>
-              <div><%= invoice.issue_date %></div>
+              <span style="font-size: 12px; font-weight: 500; letter-spacing: 0.125em; color: black; padding-bottom:10px;">ISSUED DATE</span>
+              <div style="font-size: 16px; font-weight: 500; color: black;"><%= invoice.issue_date %></div>
             </div>
             <div class="invoice-columns">
-              <span>DUE DATE</span>
-              <div><%= invoice.due_date %></div>
+              <span style="font-size: 12px; font-weight: 500; letter-spacing: 0.125em; color: black; padding-bottom:10px;">DUE DATE</span>
+              <div style="font-size: 16px; font-weight: 500; color: black;"><%= invoice.due_date %></div>
             </div>
             <div class="invoice-columns">
-              <span>AMOUNT</span>
-              <div><%= FormatAmountService.new(@company.base_currency, invoice.amount).process %></div>
+              <span style="font-size: 12px; font-weight: 500; letter-spacing: 0.125em; color: black; padding-bottom:10px;">AMOUNT</span>
+              <div style="font-size: 16px; font-weight: 500; color: black;"><%= FormatAmountService.new(@company.base_currency, invoice.amount).process %></div>
             </div>
             <div class="invoice-columns">
-              <span>STATUS</span>
+              <span style="font-size: 12px; font-weight: 500; letter-spacing: 0.125em; color: black; padding-bottom:10px;">STATUS</span>
               <div>
                 <span
                   style="display: inline-flex; align-items: center; border-radius: 9999px; padding: 2px 10px; font-size: .75rem; font-weight: 600; line-height: 16px; letter-spacing: 0.125em; <%= invoice.status == 'overdue' ? 'background-color: #efa9a9; color: #561013;' : invoice.status == 'sent' ? 'background-color: #a9efc5; color: #10562c;' : 'background-color: #a9deef; color: #104556;' %> text-transform: uppercase;"
@@ -255,7 +255,7 @@
             </tr>
           </table>
           <p style="font-family: 'Manrope'; font-style: normal; font-size:14px; font-weight:400; line-height: 19px; text-align: center; color:#A5A3AD; width: 80%; margin: 8px auto 0px auto;">
-            Invoice and accounting software for every business
+            Invoice software for every business
           </p>
         </div>
         <div

--- a/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
+++ b/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
@@ -26,6 +26,9 @@
         .mobile-invoice {
           display: block;
         }
+        .invoice-columns {
+          flex-basis: calc(45%);
+        }
       }
     </style>
   </head>
@@ -194,25 +197,25 @@
         </p>
         <% @invoices.map do |invoice| %>
           <div
-            style="display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; border-top-width: 0px; border-left-width: 0px; border-right-width: 0px; border-bottom-width: 1px; border-style: solid; border-color: #ebeff2; padding: 16px 6px"
+            style="display: flex; flex-wrap: wrap; gap: 1rem; border-top-width: 0px; border-left-width: 0px; border-right-width: 0px; border-bottom-width: 1px; border-style: solid; border-color: #ebeff2; padding: 16px 6px"
           >
-            <div>
+            <div class="invoice-columns">
               <span>INVOICE NO.</span>
               <div><%= invoice.invoice_number %></div>
             </div>
-            <div>
+            <div class="invoice-columns">
               <span>ISSUED DATE</span>
               <div><%= invoice.issue_date %></div>
             </div>
-            <div>
+            <div class="invoice-columns">
               <span>DUE DATE</span>
               <div><%= invoice.due_date %></div>
             </div>
-            <div>
+            <div class="invoice-columns">
               <span>AMOUNT</span>
               <div><%= FormatAmountService.new(@company.base_currency, invoice.amount).process %></div>
             </div>
-            <div>
+            <div class="invoice-columns">
               <span>STATUS</span>
               <div>
                 <span
@@ -222,7 +225,7 @@
                 </span>
               </div>
             </div>
-            <div>
+            <div class="invoice-columns">
               <span></span>
               <div>
                 <a

--- a/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
+++ b/app/views/mailers/send_payment_reminder_mailer/send_payment_reminder.html.erb
@@ -178,7 +178,7 @@
         </div>
       </div>
     </div>
-    <div class="mobile-invoice" style="font-family: Manrope;">
+    <div class="mobile-invoice">
       <div id="mobile-header">
         <div id="mobile-header" style="padding:0 16px;">
           <div
@@ -187,12 +187,12 @@
             <div style="padding: 10px; display: inline-block; text-align: center">
               <%= image_tag @company_logo, height: 80 ,width: 80 %>
             </div>
-            <p  style="font-family: 'Manrope';font-style: normal;font-size: 16px;line-height: 22px;text-align: center;color: #1D1A31; margin: 0px; padding: 0px">
+            <p  style="font-style: normal;font-size: 16px;line-height: 22px;text-align: center;color: #1D1A31; margin: 0px; padding: 0px">
               <%= sanitize @message %>
             </p>
           </div>
         </div>
-        <p style="text-align: center; font-family: 'Manrope'; font-weight:700; font-size: 24px; line-height:33px; color: #1D1A31;text-transform: capitalize; margin: 40px auto; padding: 0;">
+        <p style="text-align: center; font-weight:700; font-size: 24px; line-height:33px; color: #1D1A31;text-transform: capitalize; margin: 40px auto; padding: 0;">
           Payment Reminder
         </p>
         <% @invoices.map do |invoice| %>

--- a/app/views/mailers/send_reminder_mailer/send_reminder.html.erb
+++ b/app/views/mailers/send_reminder_mailer/send_reminder.html.erb
@@ -107,7 +107,7 @@
             </tr>
           </table>
           <div>
-            Invoice and accounting software for every business
+            Invoice software for every business
           </div>
         </div>
         <div
@@ -208,7 +208,7 @@
             </tr>
           </table>
           <p style="font-family: 'Manrope'; font-style: normal; font-size:14px; font-weight:400; line-height: 19px; text-align: center; color:#A5A3AD; width: 80%; margin: 8px auto 0px auto;">
-            Invoice and accounting software for every business
+            Invoice software for every business
           </p>
         </div>
         <div


### PR DESCRIPTION
Notion:
https://www.notion.so/saeloun/Design-the-invoice-payment-reminder-email-09e430e5f96347fe977e1dbbc404fce1?pvs=4

what:
Fixed broken design on mobile screens

<img width="347" alt="Screenshot 2023-08-09 at 4 38 35 PM" src="https://github.com/saeloun/miru-web/assets/72149587/ebcaa394-b6ab-4d6b-8223-97b0fb967d9c">



testing:
Was not able to test on actual mobile because couldn’t receive mail through local.