### PR TITLE
Hubspot form integration with background job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,6 +138,9 @@ gem "ruby_audit", require: false
 gem "rubyzip"
 
 gem "ahoy_matey"
+
+gem "httparty"
+
 group :development, :test, :ci do
   # See https://edgeguides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", ">= 1.0.0", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,9 @@ GEM
     hash_dot (2.5.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -606,6 +609,7 @@ DEPENDENCIES
   foreman
   grover
   hash_dot
+  httparty
   image_processing (>= 1.2)
   jbuilder (~> 2.11)
   letter_opener

--- a/app/jobs/hubspot_integration_job.rb
+++ b/app/jobs/hubspot_integration_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HubspotIntegrationJob < ApplicationJob
+  queue_as :default
+
+  def perform(email, first_name, last_name)
+    hubspot_integration = HubspotIntegrationService.new(email, first_name, last_name)
+    hubspot_integration.process
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,8 @@ class User < ApplicationRecord
   after_discard :discard_project_members
   before_create :set_token
 
+  after_commit :send_to_hubspot, on: :create
+
   def prevent_spam_user_sign_up
     if self.email.include?("internetkeno")
       raise SpamUserSignup.new("#{self.email} Spam User Signup")
@@ -209,5 +211,9 @@ class User < ApplicationRecord
       return false if skip_password_validation
 
       super
+    end
+
+    def send_to_hubspot
+      HubspotIntegrationJob.perform_later(email, first_name, last_name)
     end
 end

--- a/app/services/hubspot_integration_service.rb
+++ b/app/services/hubspot_integration_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class HubspotIntegrationService
+  include HTTParty
+
+  attr_reader :email, :first_name, :last_name
+
+  HUBSPOT_URL = "https://api.hsforms.com/submissions/v3/integration/submit/#{ENV["HUBSPOT_SIGNUP_FORM_PORTAL_ID"]}/#{ENV["HUBSPOT_SIGNUP_FORM_FORMID"]}"
+
+  def initialize(email, first_name, last_name)
+    @email = email
+    @first_name = first_name
+    @last_name = last_name
+  end
+
+  def process
+    payload = {
+      fields: [
+        {
+          name: "email",
+          value: email
+        },
+        {
+          name: "firstname",
+          value: first_name
+        },
+        {
+          name: "lastname",
+          value: last_name
+        },
+      ]
+    }
+
+    HTTParty.post(
+      HUBSPOT_URL, body: payload.to_json,
+      headers: { "Content-Type" => "application/json" })
+  end
+end


### PR DESCRIPTION
### Notion :
https://www.notion.so/saeloun/Integration-with-Marketing-tool-Hubspot-4836e0626b8843378996ea943ccd1d13?pvs=4

### What :
- With this PR, any user who signups up on Miru either the owner who creates an organization or an invited user with any role will be added to the Hubspot form so that in future we can use those onboarded emails for communication purposes.
- Under the hood, it uses the background job to handle the Hubspot API integration asynchronously when a user transaction is completed 

### Why :
To keep track of user signups on Miru.

### Demo
https://youtu.be/gwj4frxs5eg