### PR TITLE
View the invoice history according to org timezone

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/ViewHistory/utils.ts
+++ b/app/javascript/src/components/Invoices/Invoice/ViewHistory/utils.ts
@@ -33,9 +33,13 @@ const calculateTime = (date, dateFormat, timezone) => {
   }
 
   if (hour >= 48) {
-    const format = `${dateFormat}, HH:MM a`;
+    const timeZoneString = timezone;
+    const timeZoneOffset = timeZoneString.split("GMT")[1].trim();
+    const utcDateTime = dayjs.utc(date);
+    const convertedDateTime = utcDateTime.utcOffset(timeZoneOffset);
+    const format = `${dateFormat}, hh:mm a`;
 
-    return dayjs(date).format(format);
+    return convertedDateTime.format(format);
   }
 };
 


### PR DESCRIPTION
### What
- View the invoice history according to org timezone settings. We convert invoice history from UTC timezone to organizational level timezone when we display the invoice history to admin/owner.

### Demo
https://youtu.be/LeI70C7AOIc?feature=shared