### PR TITLE
Sorted invoice timesheet entries as per the date on view invoice for admin & client

### DIFF
--- a/app/javascript/src/components/ClientInvoices/Details/InvoiceDetails.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/InvoiceDetails.tsx
@@ -11,6 +11,13 @@ const InvoiceDetails = ({ invoice, company, lineItems, client, logo }) => {
   const invoiceWaived = invoice?.status === "waived";
   const strikeAmount = invoiceWaived && "line-through";
 
+  const sortedLineItems = [...lineItems].sort((a, b) => {
+    const dateA = new Date(a.date);
+    const dateB = new Date(b.date);
+
+    return dateA.getTime() - dateB.getTime();
+  });
+
   return (
     <>
       <CompanyInfo company={company} logo={logo} />
@@ -25,7 +32,7 @@ const InvoiceDetails = ({ invoice, company, lineItems, client, logo }) => {
       <InvoiceLineItems
         currency={company.currency}
         dateFormat={company.dateFormat || company.date_format}
-        items={lineItems}
+        items={sortedLineItems}
         showHeader={lineItems.length > 0}
         strikeAmount={strikeAmount}
       />

--- a/app/javascript/src/components/InvoiceEmail/InvoiceDetails.tsx
+++ b/app/javascript/src/components/InvoiceEmail/InvoiceDetails.tsx
@@ -11,6 +11,13 @@ const InvoiceDetails = ({ invoice, company, lineItems, client, logo }) => {
   const invoiceWaived = invoice?.status === "waived";
   const strikeAmount = invoiceWaived && "line-through";
 
+  const sortedLineItems = [...lineItems].sort((a, b) => {
+    const dateA = new Date(a.date);
+    const dateB = new Date(b.date);
+
+    return dateA.getTime() - dateB.getTime();
+  });
+
   return (
     <>
       <CompanyInfo company={company} logo={logo} />
@@ -25,7 +32,7 @@ const InvoiceDetails = ({ invoice, company, lineItems, client, logo }) => {
       <InvoiceLineItems
         currency={company.currency}
         dateFormat={company.dateFormat || company.date_format}
-        items={lineItems}
+        items={sortedLineItems}
         showHeader={lineItems.length > 0}
         strikeAmount={strikeAmount}
       />

--- a/app/javascript/src/components/Invoices/Invoice/InvoiceDetails.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceDetails.tsx
@@ -11,6 +11,13 @@ const InvoiceDetails = ({ invoice }) => {
   const invoiceWaived = invoice?.status === "waived";
   const strikeAmount = invoiceWaived && "line-through";
 
+  const sortedLineItems = [...invoice.invoiceLineItems].sort((a, b) => {
+    const dateA = new Date(a.date);
+    const dateB = new Date(b.date);
+
+    return dateA.getTime() - dateB.getTime();
+  });
+
   return (
     <>
       <CompanyInfo company={invoice.company} />
@@ -22,7 +29,7 @@ const InvoiceDetails = ({ invoice }) => {
         showHeader
         currency={invoice.company.currency}
         dateFormat={invoice.company.dateFormat}
-        items={invoice.invoiceLineItems}
+        items={sortedLineItems}
         strikeAmount={strikeAmount}
       />
       <InvoiceTotalSummary invoice={invoice} strikeAmount={strikeAmount} />


### PR DESCRIPTION
### Notion
https://www.notion.so/saeloun/6afc9500b2cc42af86be55f37894fb09?v=185bd45b9dc24dfcad9c57c07d32a7c0&p=4db0d1af26264aaeada90fa4cfcd6ce7&pm=s

### What
- Invoice timesheet entries are sorted as per the date on the view invoice for admin/owner & client

#### Before
https://youtu.be/BI8-V7T0iug?feature=shared

#### After
https://youtu.be/HhNit4Hl4A8?feature=shared