### PR TITLE
Removed redirecting to error page for 404 responses

### DIFF
--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -34,12 +34,6 @@ class ApiHandler {
         return response;
       },
       (error: any) => {
-        if (error.response?.status === 404) {
-          window.location.href = "/error";
-
-          return;
-        }
-
         if (error.response?.status === 401) {
           clearCredentialsFromLocalStorage();
           Toastr.error(error.response?.data?.error);


### PR DESCRIPTION
### What
- Instead of showing the error message for why the request is failing, it is redirecting to an error for 404 responses. Need to handle it in another way.