### PR TITLE
Fixed unable to add new, edit or delete the client details error fixed

### DIFF
--- a/app/javascript/src/components/Clients/ClientForm/index.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/index.tsx
@@ -90,7 +90,7 @@ const ClientForm = ({
     if (formType === "new") {
       try {
         const res = await clientApi.create(formData);
-        setClientData([...clientData, { ...res.data, minutes: 0 }]);
+        setClientData([...clientData, { ...res.data.client, minutes: 0 }]);
         setnewClient(false);
         Toastr.success("Client added successfully");
       } catch {
@@ -300,10 +300,6 @@ const ClientForm = ({
                 disabled={disableBtn(values, errors, submitting)}
                 style="primary"
                 type="submit"
-                onClick={() => {
-                  setSubmitting(true);
-                  handleSubmit(values);
-                }}
               >
                 SAVE CHANGES
               </Button>

--- a/app/javascript/src/components/Clients/ClientForm/index.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/index.tsx
@@ -302,6 +302,7 @@ const ClientForm = ({
                 type="submit"
                 onClick={() => {
                   setSubmitting(true);
+                  handleSubmit(values);
                 }}
               >
                 SAVE CHANGES

--- a/app/views/internal_api/v1/clients/_client.json.jbuilder
+++ b/app/views/internal_api/v1/clients/_client.json.jbuilder
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 json.client do
-  json.extract! client, :id, :name, :email, :phone, :logo
+  json.extract! client, :id, :name, :email, :phone
+
+  json.logo_url client.logo.attached? ? client.logo_url : nil
+
   json.address do
     json.partial! "internal_api/v1/partial/address", locals: { address: }
   end

--- a/app/views/internal_api/v1/clients/_client.json.jbuilder
+++ b/app/views/internal_api/v1/clients/_client.json.jbuilder
@@ -3,7 +3,7 @@
 json.client do
   json.extract! client, :id, :name, :email, :phone
 
-  json.logo_url client.logo.attached? ? client.logo_url : nil
+  json.logo client.logo.attached? ? client.logo_url : nil
 
   json.address do
     json.partial! "internal_api/v1/partial/address", locals: { address: }


### PR DESCRIPTION
Notion: 
https://www.notion.so/saeloun/Unable-to-add-new-or-update-the-client-details-fd20d72aea684f959fce2f7e6413585f?pvs=4
 
### What:
- Now the request for adding a new client or updating the client details is being sent to the backend server.
- Clicking on edit/delete icons from client list page errors got fixed
- After adding new client, on the client list page we can see the newly added client

### Demo
https://youtu.be/h-lSAtDhaY4?feature=shared