### PR TITLE
Fix capitalisation of Employee Type text in the read mode

### DIFF
--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/Edit/index.tsx
@@ -16,6 +16,8 @@ import { employmentMapper } from "mapper/teams.mapper";
 
 import StaticPage from "./StaticPage";
 
+import { employeeTypes } from "../helpers";
+
 dayjs.extend(utc);
 
 const schema = Yup.object().shape(employmentSchema);
@@ -62,11 +64,6 @@ const EmploymentDetailsEdit = () => {
 
   useOutsideClick(DOJRef, () => setShowDOJDatePicker({ visibility: false }));
   useOutsideClick(DORRef, () => setShowDORDatePicker({ visibility: false }));
-
-  const employeeTypes = [
-    { label: "Salaried Employee", value: "salaried" },
-    { label: "Contractor", value: "contractor" },
-  ];
 
   const getDetails = async () => {
     const curr: any = await teamsApi.getEmploymentDetails(user.id);

--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/StaticPage.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/StaticPage.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { ProjectsIcon } from "miruIcons";
 
+import { getLabelForValue } from "./helpers";
+
 const StaticPage = ({ employmentDetails }) => (
   <div className="mt-4 h-full bg-miru-gray-100 px-10">
     <div className="flex border-b border-b-miru-gray-400 py-10">
@@ -48,7 +50,9 @@ const StaticPage = ({ employmentDetails }) => (
               Employee Type
             </span>
             <p className="text-miru-dark-purple-1000">
-              {employmentDetails.current_employment.employment_type}
+              {getLabelForValue(
+                employmentDetails.current_employment.employment_type
+              )}
             </p>
           </div>
         </div>

--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/StaticPage.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/StaticPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { ProjectsIcon } from "miruIcons";
 
-import { getLabelForValue } from "./helpers";
+import { getLabelForEmployeeType } from "./helpers";
 
 const StaticPage = ({ employmentDetails }) => (
   <div className="mt-4 h-full bg-miru-gray-100 px-10">
@@ -50,7 +50,7 @@ const StaticPage = ({ employmentDetails }) => (
               Employee Type
             </span>
             <p className="text-miru-dark-purple-1000">
-              {getLabelForValue(
+              {getLabelForEmployeeType(
                 employmentDetails.current_employment.employment_type
               )}
             </p>

--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
@@ -1,0 +1,4 @@
+export const employeeTypes = [
+  { label: "Salaried Employee", value: "salaried" },
+  { label: "Contractor", value: "contractor" },
+];

--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
@@ -3,7 +3,7 @@ export const employeeTypes = [
   { label: "Contractor", value: "contractor" },
 ];
 
-export function getLabelForValue(valueToFind: string): string | null {
+export function getLabelForEmployeeType(valueToFind: string): string | null {
   const foundType = employeeTypes.find(type => type.value === valueToFind);
 
   return foundType ? foundType.label : null;

--- a/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
+++ b/app/javascript/src/components/Profile/UserDetail/EmploymentDetails/helpers.ts
@@ -2,3 +2,9 @@ export const employeeTypes = [
   { label: "Salaried Employee", value: "salaried" },
   { label: "Contractor", value: "contractor" },
 ];
+
+export function getLabelForValue(valueToFind: string): string | null {
+  const foundType = employeeTypes.find(type => type.value === valueToFind);
+
+  return foundType ? foundType.label : null;
+}


### PR DESCRIPTION
Fixes #1481 

We receive an uncapitalised employee type string from the API. The edit screen uses the `employeeTypes`'s `label` and the `value` attribute is saved to the server. So this PR implements a mapper for `employeeTypes`

<img width="1129" alt="Screenshot 2023-09-28 at 11 11 12 AM" src="https://github.com/saeloun/miru-web/assets/43875940/ab7c8c2f-787e-475a-b3d2-d8ccb57997f4">
