### PR TITLE
Auto save time tracking entries into local storage

### DIFF
--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -113,7 +113,7 @@ const AddEntry: React.FC<Iprops> = ({
       return;
     }
 
-    const entry = entries[selectedFullDate]?.find(
+    const entry = entries[selectedDate]?.find(
       entry => entry.editEntryId === editEntryId
     );
     if (!entry) {
@@ -127,7 +127,7 @@ const AddEntry: React.FC<Iprops> = ({
     setDuration(duration);
     setNote(note);
     setClient(client);
-  }, [editEntryId, selectedFullDate]);
+  }, [editEntryId, selectedDate]);
 
   // write data into local storage
   useEffect(() => {
@@ -148,42 +148,34 @@ const AddEntry: React.FC<Iprops> = ({
 
     if (!entries) {
       setToLocalStorage("timeTrackingEntries", {
-        [selectedFullDate]: [form],
+        [selectedDate]: [form],
       });
 
       return;
     }
 
-    if (!entries?.[selectedFullDate]) {
-      entries[selectedFullDate] = [form];
+    if (!entries?.[selectedDate]) {
+      entries[selectedDate] = [form];
       setToLocalStorage("timeTrackingEntries", entries);
 
       return;
     }
 
-    const entryIndex = entries[selectedFullDate].findIndex(
+    const entryIndex = entries[selectedDate].findIndex(
       entry => entry.editEntryId === editEntryId
     );
 
     if (entryIndex > -1) {
-      entries[selectedFullDate][entryIndex] = {
-        ...entries[selectedFullDate][entryIndex],
+      entries[selectedDate][entryIndex] = {
+        ...entries[selectedDate][entryIndex],
         ...form,
       };
     } else {
-      entries[selectedFullDate].push(form);
+      entries[selectedDate].push(form);
     }
 
     setToLocalStorage("timeTrackingEntries", entries);
-  }, [
-    project,
-    client,
-    billable,
-    duration,
-    note,
-    editEntryId,
-    selectedFullDate,
-  ]);
+  }, [project, client, billable, duration, note, editEntryId, selectedDate]);
 
   useEffect(() => {
     if (!project) {
@@ -294,11 +286,11 @@ const AddEntry: React.FC<Iprops> = ({
 
   const clearEntryInLocalStorage = (editEntryId: number) => {
     const entries = getValueFromLocalStorage("timeTrackingEntries");
-    if (!entries?.[selectedFullDate]) {
+    if (!entries?.[selectedDate]) {
       return;
     }
 
-    entries[selectedFullDate] = entries[selectedFullDate].filter(
+    entries[selectedDate] = entries[selectedDate].filter(
       entry => entry.editEntryId !== editEntryId
     );
     setToLocalStorage("timeTrackingEntries", entries);

--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -58,6 +58,13 @@ const AddEntry: React.FC<Iprops> = ({
 
   useEffect(() => {
     setSelectedDate(selectedFullDate);
+    // make sure the current form's locally saved info is not overwrting the
+    // next form's when date selection is changed
+    setDuration("");
+    setProject("");
+    setClient("");
+    setNote("");
+    setBillable(false);
   }, [selectedFullDate]);
 
   useEffect(() => {
@@ -106,7 +113,7 @@ const AddEntry: React.FC<Iprops> = ({
       return;
     }
 
-    const entry = entries[selectedDate]?.find(
+    const entry = entries[selectedFullDate]?.find(
       entry => entry.editEntryId === editEntryId
     );
     if (!entry) {
@@ -120,7 +127,7 @@ const AddEntry: React.FC<Iprops> = ({
     setDuration(duration);
     setNote(note);
     setClient(client);
-  }, [editEntryId, selectedDate]);
+  }, [editEntryId, selectedFullDate]);
 
   // write data into local storage
   useEffect(() => {


### PR DESCRIPTION
## Problem
Reference https://github.com/saeloun/miru-web/issues/1495. 

## Scenarios accounted for in this PR
1. Save info into local storage simultaneously when user updates the entry form
2. Save form info based on the selected date
3. Clear time tracking local storage on save, edit and cancel

## Solution
Saving the time tracking info into local storage in the following format:
```ts
{ [key: selectedDate]: { editEntryId, client, project, billable, duration, note }[] }
```

## Things to consider
`billable` is synced automatically based on the project settings. If user changes a preset billable project to non-billable in one entry, even though the correct info is saved locally, they still see the entry billable in the next visit.

## Demo
https://drive.google.com/file/d/1oWkiLfcT2TmkjtumsfVxHNec-edjXOfi/view?usp=sharing