### PR TITLE
Fixed hours logged for employees

### DIFF
--- a/app/javascript/src/components/Clients/List/index.tsx
+++ b/app/javascript/src/components/Clients/List/index.tsx
@@ -10,6 +10,7 @@ import TableData from "./TableData";
 
 import {
   employeeTableHeader,
+  mobileEmployeeTableHeader,
   mobileTableHeader,
   tableHeader,
 } from "../constants";
@@ -59,7 +60,9 @@ const ClientList = ({
                     ? tableHeader
                     : isAdminUser && !isDesktop
                     ? mobileTableHeader
-                    : employeeTableHeader
+                    : !isAdminUser && isDesktop
+                    ? employeeTableHeader
+                    : mobileEmployeeTableHeader
                 }
               />
             ) : (

--- a/app/javascript/src/components/Clients/constants.ts
+++ b/app/javascript/src/components/Clients/constants.ts
@@ -19,11 +19,22 @@ export const employeeTableHeader = [
   },
   {
     Header: "HOURS LOGGED",
+    accessor: "col2",
+    cssClass: "text-right", // accessor is the "key" in the data
+  },
+];
+export const mobileEmployeeTableHeader = [
+  {
+    Header: "CLIENT",
+    accessor: "col1", // accessor is the "key" in the data
+    cssClass: "",
+  },
+  {
+    Header: "HOURS LOGGED",
     accessor: "col3",
     cssClass: "text-right", // accessor is the "key" in the data
   },
 ];
-
 export const mobileTableHeader = [
   {
     Header: "CLIENT",


### PR DESCRIPTION
Issue #1544 
Hours logged data should be visible for all screen sizes for both admin and employees

Steps:
Login as employee
Create a timesheet entry for a client in the current week
Visit clients page
Employee (PC):
<img width="959" alt="employee pc" src="https://github.com/saeloun/miru-web/assets/35322884/8f64cbc8-45e5-44bf-9b7f-ab8169835ef2">
Employee (Mobile)
<img width="312" alt="employee mobile" src="https://github.com/saeloun/miru-web/assets/35322884/9c42d624-c833-4b44-82a9-34a2c55f1b9b">
Admin(PC)
<img width="959" alt="Admin PC" src="https://github.com/saeloun/miru-web/assets/35322884/de7eed31-7469-42ea-8697-0a679f9742bf">
Admin (Mobile)
<img width="314" alt="Admin mobile" src="https://github.com/saeloun/miru-web/assets/35322884/c056d1a6-7239-4f20-be7f-f3f9bbe4546e">
