### PR TITLE
Fixed username issue in side nav when user refreshes page

### DIFF
--- a/app/javascript/src/components/Profile/Layout.tsx
+++ b/app/javascript/src/components/Profile/Layout.tsx
@@ -24,10 +24,10 @@ const Layout = ({ isAdminUser, user, company }) => {
 
   const { profileSettings } = settingsStates;
   const setUserState = (key, value) => {
-    setSettingsStates({
-      ...settingsStates,
-      ...{ [key]: { ...settingsStates[key], ...value } },
-    });
+    setSettingsStates(previousSettings => ({
+      ...previousSettings,
+      ...{ [key]: { ...previousSettings[key], ...value } },
+    }));
   };
 
   return (

--- a/app/javascript/src/components/Profile/RouteConfig.tsx
+++ b/app/javascript/src/components/Profile/RouteConfig.tsx
@@ -1,11 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { Routes, Route, Navigate } from "react-router-dom";
 
+import profileApi from "apis/profile";
 import ErrorPage from "common/Error";
 import { useUserContext } from "context/UserContext";
+import { teamsMapper } from "mapper/teams.mapper";
 
+import { useProfile } from "./context/EntryContext";
 import { SETTINGS_ROUTES } from "./routes";
+
+import Toastr from "../../StyledComponents/Toastr";
 
 const ProtectedRoute = ({ role, authorisedRoles, children }) => {
   if (authorisedRoles.includes(role)) {
@@ -17,6 +22,30 @@ const ProtectedRoute = ({ role, authorisedRoles, children }) => {
 
 const RouteConfig = () => {
   const { companyRole } = useUserContext();
+  const {
+    setUserState,
+    profileSettings: { first_name, last_name },
+  } = useProfile();
+
+  const getData = async () => {
+    if (!first_name && !last_name) {
+      const data = await profileApi.index();
+      if (data.status && data.status == 200) {
+        const addressData = await profileApi.getAddress(data.data.user.id);
+        const userObj = teamsMapper(
+          data.data.user,
+          addressData.data.addresses[0]
+        );
+        setUserState("profileSettings", userObj);
+      } else {
+        Toastr.error("Something went wrong.");
+      }
+    }
+  };
+
+  useEffect(() => {
+    getData();
+  }, []);
 
   return (
     <Routes>

--- a/app/javascript/src/components/Profile/RouteConfig.tsx
+++ b/app/javascript/src/components/Profile/RouteConfig.tsx
@@ -10,8 +10,6 @@ import { teamsMapper } from "mapper/teams.mapper";
 import { useProfile } from "./context/EntryContext";
 import { SETTINGS_ROUTES } from "./routes";
 
-import Toastr from "../../StyledComponents/Toastr";
-
 const ProtectedRoute = ({ role, authorisedRoles, children }) => {
   if (authorisedRoles.includes(role)) {
     return children;
@@ -29,16 +27,14 @@ const RouteConfig = () => {
 
   const getData = async () => {
     if (!first_name && !last_name) {
-      const data = await profileApi.index();
-      if (data.status && data.status == 200) {
-        const addressData = await profileApi.getAddress(data.data.user.id);
+      const res = await profileApi.index();
+      if (res.status && res.status == 200) {
+        const addressData = await profileApi.getAddress(res.data.user.id);
         const userObj = teamsMapper(
-          data.data.user,
+          res.data.user,
           addressData.data.addresses[0]
         );
         setUserState("profileSettings", userObj);
-      } else {
-        Toastr.error("Something went wrong.");
       }
     }
   };


### PR DESCRIPTION
Issue #1565 
Description
When user refreshes any of the page in setting the username should be populated under the profile picture

Steps:
Login in to any user in Miru
Click on settings on the left navigation bar
Go to any tab except Personal Details
Refresh the page

Screenshots or screencast

https://github.com/saeloun/miru-web/assets/35322884/6b112dcf-3d08-49d3-b5e5-d74422954c58

