### PR TITLE
Add whitespace nowrap to search results

### DIFF
--- a/app/javascript/src/components/Clients/Header/SearchDataRow.tsx
+++ b/app/javascript/src/components/Clients/Header/SearchDataRow.tsx
@@ -14,7 +14,7 @@ const SearchDataRow = ({ item }) => {
       className="group flex cursor-pointer items-center py-2 last:border-b-0 hover:bg-miru-gray-100"
       onClick={() => handleClick(item)}
     >
-      <p className="w-5/12 pl-3 pr-6 text-base font-normal tracking-wider text-miru-dark-purple-1000">
+      <p className="w-5/12 whitespace-nowrap pl-3 pr-6 text-base font-normal tracking-wider text-miru-dark-purple-1000">
         {item.label}
       </p>
     </div>

--- a/app/javascript/src/components/Projects/List/SearchDataRow.tsx
+++ b/app/javascript/src/components/Projects/List/SearchDataRow.tsx
@@ -14,7 +14,7 @@ const SearchDataRow = ({ item }) => {
       className="group flex cursor-pointer items-center py-2 last:border-b-0 hover:bg-miru-gray-100"
       onClick={() => handleClick(item)}
     >
-      <p className="w-5/12 pl-3 pr-6 text-base font-normal tracking-wider text-miru-dark-purple-1000">
+      <p className="w-5/12 whitespace-nowrap pl-3 pr-6 text-base font-normal tracking-wider text-miru-dark-purple-1000">
         {item.name}
       </p>
     </div>


### PR DESCRIPTION
What
- Add whitespace no-wrap to search results so that the text would come in one line
<img width="1001" alt="Screenshot 2023-10-30 at 3 53 15 PM" src="https://github.com/saeloun/miru-web/assets/18750194/a9efd396-daf7-473c-ba69-60f8e70312df">
<img width="593" alt="Screenshot 2023-10-30 at 3 53 41 PM" src="https://github.com/saeloun/miru-web/assets/18750194/b7e516c0-e56d-4be6-bfa5-1baaa16bbf3d">
<img width="1113" alt="Screenshot 2023-10-30 at 3 55 39 PM" src="https://github.com/saeloun/miru-web/assets/18750194/5b3b9750-0f17-47af-a3f1-d3baa38b4f36">
