### PR TITLE
Show payment entry modal on invoice page

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/Header.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/Header.tsx
@@ -15,6 +15,7 @@ const Header = ({
   setShowConnectPaymentDialog,
   isStripeEnabled,
   setShowHistory,
+  fetchInvoice,
 }) => {
   const invoiceWaived = invoice?.status === "waived";
 
@@ -27,6 +28,7 @@ const Header = ({
       {!invoiceWaived && (
         <InvoiceActions
           editInvoiceLink={`/invoices/${invoice.id}/edit`}
+          fetchInvoice={fetchInvoice}
           invoice={invoice}
           isStripeEnabled={isStripeEnabled}
           sendInvoice={handleSendInvoice}

--- a/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
@@ -41,6 +41,9 @@ const InvoiceActions = ({
     isMoreOptionsVisible
   );
 
+  const currency = invoice?.company?.currency;
+  const dateFormat = invoice?.company?.dateFormat;
+
   return (
     <div className="justify-items-right flex flex-row">
       <EditButton editInvoiceLink={editInvoiceLink} />
@@ -75,8 +78,8 @@ const InvoiceActions = ({
         )}
         {showInvoicePaymentModal && (
           <MarkInvoiceAsPaidModal
-            baseCurrency={invoice.company.currency}
-            dateFormat={invoice.company.dateFormat}
+            baseCurrency={currency}
+            dateFormat={dateFormat}
             fetchInvoice={fetchInvoice}
             invoice={invoice}
             setShowManualEntryModal={setShowInvoicePaymentModal}

--- a/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/InvoiceActions.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useRef } from "react";
 
 import { useOutsideClick } from "helpers";
-import { useNavigate } from "react-router-dom";
 
 import EditButton from "./EditButton";
+import MarkInvoiceAsPaidModal from "./MarkInvoicePaidModal";
 import SendButton from "./SendButton";
 
 import MoreButton from "../common/MoreButton";
@@ -20,16 +20,19 @@ const InvoiceActions = ({
   setShowConnectPaymentDialog,
   isStripeEnabled,
   setShowHistory,
+  fetchInvoice,
 }) => {
   const [isMoreOptionsVisible, setIsMoreOptionsVisible] =
     useState<boolean>(false);
 
+  const [showInvoicePaymentModal, setShowInvoicePaymentModal] =
+    useState<boolean>(false);
+
   const wrapperRef = useRef(null);
 
-  const navigate = useNavigate();
-
-  const markInvoiceAsPaid = async (id: number) => {
-    navigate(`/payments/?invoiceId=${id}`);
+  const markInvoiceAsPaid = () => {
+    setShowInvoicePaymentModal(true);
+    setIsMoreOptionsVisible(false);
   };
 
   useOutsideClick(
@@ -68,6 +71,16 @@ const InvoiceActions = ({
               setShowHistory(true);
               setIsMoreOptionsVisible(false);
             }}
+          />
+        )}
+        {showInvoicePaymentModal && (
+          <MarkInvoiceAsPaidModal
+            baseCurrency={invoice.company.currency}
+            dateFormat={invoice.company.dateFormat}
+            fetchInvoice={fetchInvoice}
+            invoice={invoice}
+            setShowManualEntryModal={setShowInvoicePaymentModal}
+            showManualEntryModal={showInvoicePaymentModal}
           />
         )}
       </div>

--- a/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
@@ -1,0 +1,255 @@
+import React, { useState, useRef, useEffect } from "react";
+
+import dayjs from "dayjs";
+import { currencyFormat, useOutsideClick } from "helpers";
+import { CalendarIcon, XIcon } from "miruIcons";
+import { MobileMoreOptions, Modal, Toastr } from "StyledComponents";
+
+import payment from "apis/payments/payments";
+import CustomDatePicker from "common/CustomDatePicker";
+import { CustomInputText } from "common/CustomInputText";
+import CustomReactSelect from "common/CustomReactSelect";
+import { CustomTextareaAutosize } from "common/CustomTextareaAutosize";
+import { transactionTypes } from "components/payments/Modals/constants";
+import { useUserContext } from "context/UserContext";
+import { mapPayment } from "mapper/payment.mapper";
+
+const MarkInvoiceAsPaidModal = ({
+  invoice,
+  baseCurrency,
+  dateFormat,
+  showManualEntryModal,
+  setShowManualEntryModal,
+  fetchInvoice,
+}) => {
+  const { isDesktop } = useUserContext();
+  const [transactionDate, setTransactionDate] = useState<any>(null);
+  const [transactionType, setTransactionType] = useState<any>(null);
+  const [note, setNote] = useState<any>(null);
+  const [showDatePicker, setShowDatePicker] = useState<any>(false);
+  const [showTransactionTypes, setShowTransactionTypes] =
+    useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const wrapperSelectRef = useRef(null);
+  const wrapperCalendartRef = useRef(null);
+  const amount = invoice.amount;
+
+  const isAddPaymentBtnActive = (
+    invoice,
+    transactionDate,
+    transactionType,
+    amount
+  ) => invoice && transactionDate && transactionType && amount;
+
+  useEffect(() => {
+    const close = e => {
+      if (e.keyCode === 27) {
+        setShowDatePicker({ visibility: false });
+      }
+    };
+    window.addEventListener("keydown", close);
+
+    return () => window.removeEventListener("keydown", close);
+  }, []);
+
+  useOutsideClick(wrapperSelectRef, () => {
+    setShowManualEntryModal(false);
+  });
+
+  useOutsideClick(wrapperCalendartRef, () => {
+    setShowDatePicker({ visibility: false });
+  });
+
+  const handleAddPayment = async () => {
+    const sanitized = mapPayment({
+      invoice,
+      transactionDate,
+      transactionType,
+      amount,
+      note,
+    });
+    await payment.create(sanitized);
+    Toastr.success("Invoice marked as paid successfully");
+    setIsLoading(false);
+    setShowManualEntryModal(false);
+    fetchInvoice();
+  };
+
+  const handleDatePicker = date => {
+    setTransactionDate(date);
+    setShowDatePicker(false);
+  };
+
+  return (
+    <Modal
+      customStyle="sm:my-8 sm:w-full sm:max-w-lg sm:align-middle overflow-visible"
+      isOpen={showManualEntryModal}
+      onClose={() => setShowManualEntryModal(false)}
+    >
+      <div className="modal__position m-0">
+        <h6 className="modal__title"> Mark Invoice As Paid</h6>
+        <div className="modal__close">
+          <button
+            className="modal__button"
+            onClick={() => setShowManualEntryModal(false)}
+          >
+            <XIcon color="#CDD6DF" size={15} />
+          </button>
+        </div>
+      </div>
+      <div className="relative mt-4">
+        <div className="field">
+          <div className="mt-1" id="invoice" ref={wrapperSelectRef}>
+            <CustomInputText
+              disabled
+              id="invoice"
+              inputBoxClassName="form__input block w-full appearance-none bg-white p-4 text-base h-12 focus-within:border-miru-han-purple-1000 border-miru-gray-1000"
+              label="Invoice"
+              labelClassName="absolute top-0.5 left-1 h-6 z-1 origin-0 bg-white p-2 text-base font-medium duration-300 text-miru-dark-purple-200"
+              name="invoice"
+              type="text"
+              value={invoice.client.name}
+                onChange={() => {}} //eslint-disable-line
+            />
+          </div>
+        </div>
+      </div>
+      <div className="mt-4" ref={wrapperCalendartRef}>
+        <div
+          className="field relative flex w-full flex-col"
+          onClick={() =>
+            setShowDatePicker({ visibility: !showDatePicker.visibility })
+          }
+        >
+          <CustomInputText
+            disabled
+            id="transactionDate"
+            label="Transaction Date"
+            name="transactionDate"
+            type="text"
+            value={transactionDate && dayjs(transactionDate).format(dateFormat)}
+              onChange={() => {}} //eslint-disable-line
+          />
+          <CalendarIcon
+            className="absolute top-0 bottom-0 right-1 mx-2 my-3 "
+            color="#5B34EA"
+            size={20}
+          />
+        </div>
+        {showDatePicker.visibility && (
+          <CustomDatePicker
+            date={transactionDate || dayjs()}
+            handleChange={handleDatePicker}
+          />
+        )}
+      </div>
+      <div className="relative mt-4">
+        {isDesktop ? (
+          <CustomReactSelect
+            isSearchable
+            handleOnChange={e => setTransactionType(e.value)}
+            label="Transaction Type"
+            name="transactionType"
+            options={transactionTypes}
+            value={transactionTypes.find(type => type.value == transactionType)}
+          />
+        ) : (
+          <>
+            <CustomReactSelect
+              isDisabled={showTransactionTypes}
+              label="Transaction Type"
+              name="transactionType"
+              options={transactionTypes}
+              handleonFocus={() => {
+                setShowTransactionTypes(true);
+              }}
+              value={transactionTypes.find(
+                type => type.value == transactionType
+              )}
+            />
+            {showTransactionTypes && (
+              <MobileMoreOptions
+                className="h-3/4 w-full overflow-scroll md:h-3/5 md:w-3/4 lg:h-1/4"
+                setVisibilty={setShowTransactionTypes}
+                visibilty={showTransactionTypes}
+              >
+                {transactionTypes.map((transaction, index) => (
+                  <li
+                    className="flex items-center pb-5 font-manrope text-sm font-normal capitalize leading-5 text-miru-dark-purple-1000 hover:bg-miru-gray-100"
+                    key={index}
+                    onClick={() => {
+                      if (transaction?.value) {
+                        setTransactionType(transaction.value);
+                      }
+                      setShowTransactionTypes(false);
+                    }}
+                  >
+                    {transaction.label}
+                  </li>
+                ))}
+              </MobileMoreOptions>
+            )}
+          </>
+        )}
+      </div>
+      <div className="mt-4">
+        <CustomInputText
+          disabled
+          id="paymentAmount"
+          inputBoxClassName="form__input block w-full appearance-none bg-white p-4 text-base h-12 focus-within:border-miru-han-purple-1000 border-miru-gray-1000"
+          label="Payment amount"
+          labelClassName="absolute top-0.5 left-1 h-6 z-1 origin-0 bg-white p-2 text-base font-medium duration-300 text-miru-dark-purple-200"
+          name="paymentAmount"
+          type="text"
+          value={amount && baseCurrency && currencyFormat(baseCurrency, amount)}
+            onChange={() => {}} //eslint-disable-line
+        />
+      </div>
+      <div className="mt-4">
+        <CustomTextareaAutosize
+          id="NotesOptional"
+          label="Notes (optional)"
+          maxRows={12}
+          name="NotesOptional"
+          rows={5}
+          value={note}
+          onChange={e => setNote(e.target.value)}
+        />
+      </div>
+      <div className="actions mx-auto mt-4 mb-4 w-full">
+        <button
+          disabled={isLoading}
+          type="submit"
+          className={
+            isAddPaymentBtnActive(
+              invoice,
+              transactionDate,
+              transactionType,
+              amount
+            ) && !isLoading
+              ? "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-han-purple-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm hover:bg-miru-han-purple-600"
+              : "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-gray-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm"
+          }
+          onClick={() => {
+            setIsLoading(true);
+            if (
+              isAddPaymentBtnActive(
+                invoice,
+                transactionDate,
+                transactionType,
+                amount
+              )
+            ) {
+              handleAddPayment();
+            }
+          }}
+        >
+          MARK AS PAID
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default MarkInvoiceAsPaidModal;

--- a/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useEffect } from "react";
 import dayjs from "dayjs";
 import { currencyFormat, useOutsideClick } from "helpers";
 import { CalendarIcon, XIcon } from "miruIcons";
-import { MobileMoreOptions, Modal, Toastr } from "StyledComponents";
+import { Button, MobileMoreOptions, Modal, Toastr } from "StyledComponents";
 
 import payment from "apis/payments/payments";
 import CustomDatePicker from "common/CustomDatePicker";
@@ -33,7 +33,8 @@ const MarkInvoiceAsPaidModal = ({
 
   const wrapperSelectRef = useRef(null);
   const wrapperCalendartRef = useRef(null);
-  const amount = invoice.amount;
+  const amount = invoice?.amount;
+  const client = invoice?.client?.name;
 
   const isAddPaymentBtnActive = (
     invoice,
@@ -52,10 +53,6 @@ const MarkInvoiceAsPaidModal = ({
 
     return () => window.removeEventListener("keydown", close);
   }, []);
-
-  useOutsideClick(wrapperSelectRef, () => {
-    setShowManualEntryModal(false);
-  });
 
   useOutsideClick(wrapperCalendartRef, () => {
     setShowDatePicker({ visibility: false });
@@ -109,8 +106,8 @@ const MarkInvoiceAsPaidModal = ({
               labelClassName="absolute top-0.5 left-1 h-6 z-1 origin-0 bg-white p-2 text-base font-medium duration-300 text-miru-dark-purple-200"
               name="invoice"
               type="text"
-              value={invoice.client.name}
-                onChange={() => {}} //eslint-disable-line
+              value={client}
+              onChange={() => {}} //eslint-disable-line
             />
           </div>
         </div>
@@ -129,7 +126,7 @@ const MarkInvoiceAsPaidModal = ({
             name="transactionDate"
             type="text"
             value={transactionDate && dayjs(transactionDate).format(dateFormat)}
-              onChange={() => {}} //eslint-disable-line
+            onChange={() => {}} //eslint-disable-line
           />
           <CalendarIcon
             className="absolute top-0 bottom-0 right-1 mx-2 my-3 "
@@ -203,7 +200,7 @@ const MarkInvoiceAsPaidModal = ({
           name="paymentAmount"
           type="text"
           value={amount && baseCurrency && currencyFormat(baseCurrency, amount)}
-            onChange={() => {}} //eslint-disable-line
+          onChange={() => {}} //eslint-disable-line
         />
       </div>
       <div className="mt-4">
@@ -218,8 +215,9 @@ const MarkInvoiceAsPaidModal = ({
         />
       </div>
       <div className="actions mx-auto mt-4 mb-4 w-full">
-        <button
+        <Button
           disabled={isLoading}
+          size="medium"
           type="submit"
           className={
             isAddPaymentBtnActive(
@@ -227,7 +225,7 @@ const MarkInvoiceAsPaidModal = ({
               transactionDate,
               transactionType,
               amount
-            ) && !isLoading
+            )
               ? "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-han-purple-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm hover:bg-miru-han-purple-600"
               : "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-miru-gray-1000 py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-miru-white-1000 shadow-sm"
           }
@@ -246,7 +244,7 @@ const MarkInvoiceAsPaidModal = ({
           }}
         >
           MARK AS PAID
-        </button>
+        </Button>
       </div>
     </Modal>
   );

--- a/app/javascript/src/components/Invoices/Invoice/index.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/index.tsx
@@ -80,6 +80,7 @@ const Invoice = () => {
     (isDesktop ? (
       <>
         <Header
+          fetchInvoice={fetchInvoice}
           handleSendInvoice={handleSendInvoice}
           invoice={invoice}
           isStripeEnabled={isStripeEnabled}

--- a/app/javascript/src/components/Invoices/common/MoreOptions.tsx
+++ b/app/javascript/src/components/Invoices/common/MoreOptions.tsx
@@ -16,7 +16,7 @@ const MoreOptions: FC<MoreOptionsProps> = ({
   downloadInvoice,
   showHistory,
   invoice = null,
-  markInvoiceAsPaid = () => null,
+  markInvoiceAsPaid,
   setIsSendReminder,
   sendInvoice,
   setIsMoreOptionsVisible,

--- a/app/javascript/src/mapper/payment.mapper.ts
+++ b/app/javascript/src/mapper/payment.mapper.ts
@@ -19,7 +19,7 @@ const unmapPayment = input => {
 };
 
 const mapPayment = input => ({
-  invoice_id: input.invoice.value,
+  invoice_id: input.invoice.value || input.invoice.id,
   transaction_date: input.transactionDate,
   transaction_type: input.transactionType,
   amount: input.amount,


### PR DESCRIPTION
What
- Show payment entry modal onClick on the "Mark as paid" option on the Invoice page

Why
- For better UX. Earlier it used to redirect to the payments page


Loom: 
https://www.loom.com/share/45ca4e3552ad40f191fb9373379727d6