### PR TITLE
Invoice download access enabled for client

### DIFF
--- a/app/javascript/src/components/ClientInvoices/Details/Header.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/Header.tsx
@@ -6,7 +6,7 @@ import {
   DotsThreeVerticalIcon,
   DownloadSimpleIcon,
 } from "miruIcons";
-import { Badge, Button, MoreOptions, Tooltip } from "StyledComponents";
+import { Badge, Button, MoreOptions, Toastr, Tooltip } from "StyledComponents";
 
 import { handleDownloadInvoice } from "components/Invoices/common/utils";
 import getStatusCssClass from "utils/getBadgeStatus";
@@ -27,6 +27,12 @@ const Header = ({
     () => setIsMoreOptionsVisible(false),
     isMoreOptionsVisible
   );
+
+  const handleDownloadAction = invoice => {
+    Toastr.success("Download request sent");
+    handleDownloadInvoice(invoice);
+    setIsMoreOptionsVisible(false);
+  };
 
   return (
     <div className="mt-6 mb-3 sm:flex sm:items-center sm:justify-between">
@@ -107,7 +113,7 @@ const Header = ({
             >
               <li
                 className="flex cursor-pointer items-center py-2.5 px-4 text-miru-han-purple-1000 hover:bg-miru-gray-100"
-                onClick={() => handleDownloadInvoice(invoice)}
+                onClick={() => handleDownloadAction(invoice)}
               >
                 <DownloadSimpleIcon className="mr-4" size={16} weight="bold" />
                 Download

--- a/app/javascript/src/components/ClientInvoices/Details/Header.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/Header.tsx
@@ -6,11 +6,10 @@ import {
   DotsThreeVerticalIcon,
   DownloadSimpleIcon,
 } from "miruIcons";
-import { Badge, MoreOptions, Tooltip } from "StyledComponents";
+import { Badge, Button, MoreOptions, Tooltip } from "StyledComponents";
 
+import { handleDownloadInvoice } from "components/Invoices/common/utils";
 import getStatusCssClass from "utils/getBadgeStatus";
-
-import { handleDownloadInvoice } from "../../Invoices/common/utils";
 
 const Header = ({
   invoice,
@@ -21,6 +20,8 @@ const Header = ({
   const [isMoreOptionsVisible, setIsMoreOptionsVisible] =
     useState<boolean>(false);
   const wrapperRef = useRef(null);
+  const { invoice_number, status } = invoice;
+
   useOutsideClick(
     wrapperRef,
     () => setIsMoreOptionsVisible(false),
@@ -31,20 +32,18 @@ const Header = ({
     <div className="mt-6 mb-3 sm:flex sm:items-center sm:justify-between">
       <div className="flex flex-row">
         <div className="mr-2 flex self-center">
-          <p className="text-4xl font-bold">
-            Invoice #{invoice.invoice_number}
-          </p>
+          <p className="text-4xl font-bold">Invoice #{invoice_number}</p>
         </div>
         <div className="ml-2 flex self-center">
           <Badge
-            className={`${getStatusCssClass(invoice.status)} uppercase`}
-            text={invoice.status}
+            className={`${getStatusCssClass(status)} uppercase`}
+            text={status}
           />
         </div>
       </div>
       <div className="justify-items-right flex flex-row">
         <div className="send-button-container ml-1 flex flex-col justify-items-center">
-          {invoice.status == "waived" ? (
+          {status == "waived" ? (
             <Tooltip
               content="This invoice has been waived off by the sender"
               wrapperClassName="relative block max-w-full "
@@ -65,15 +64,15 @@ const Header = ({
             </Tooltip>
           ) : (
             <button
-              disabled={invoice.status == "paid"}
+              disabled={status == "paid"}
               className={`flex h-10 w-44 flex-row items-center justify-center rounded
               ${
-                invoice.status == "paid"
+                status == "paid"
                   ? "cursor-not-allowed bg-indigo-100"
                   : "bg-miru-han-purple-1000"
               }`}
               onClick={() => {
-                if (invoice.status != "paid") {
+                if (status != "paid") {
                   if (stripe_connected_account) {
                     window.location.href = stripeUrl;
                   } else {
@@ -94,12 +93,13 @@ const Header = ({
           )}
         </div>
         <div className="relative">
-          <button
+          <Button
             className="ml-2 rounded border border-miru-han-purple-1000 bg-miru-gray-1000 p-2.5 text-miru-han-purple-1000 opacity-50"
+            style="ternary"
             onClick={() => setIsMoreOptionsVisible(!isMoreOptionsVisible)}
           >
             <DotsThreeVerticalIcon size={16} />
-          </button>
+          </Button>
           {isMoreOptionsVisible && (
             <MoreOptions
               className="right-0"

--- a/app/javascript/src/components/ClientInvoices/Details/Header.tsx
+++ b/app/javascript/src/components/ClientInvoices/Details/Header.tsx
@@ -1,38 +1,86 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 
-import { ReportsIcon } from "miruIcons";
-import { Badge, Tooltip } from "StyledComponents";
+import { useOutsideClick } from "helpers";
+import {
+  ReportsIcon,
+  DotsThreeVerticalIcon,
+  DownloadSimpleIcon,
+} from "miruIcons";
+import { Badge, MoreOptions, Tooltip } from "StyledComponents";
 
 import getStatusCssClass from "utils/getBadgeStatus";
+
+import { handleDownloadInvoice } from "../../Invoices/common/utils";
 
 const Header = ({
   invoice,
   stripeUrl,
   stripe_connected_account,
   setShowConnectPaymentDialog,
-}) => (
-  <div className="mt-6 mb-3 sm:flex sm:items-center sm:justify-between">
-    <div className="flex flex-row">
-      <div className="mr-2 flex self-center">
-        <p className="text-4xl font-bold">Invoice #{invoice.invoice_number}</p>
+}) => {
+  const [isMoreOptionsVisible, setIsMoreOptionsVisible] =
+    useState<boolean>(false);
+  const wrapperRef = useRef(null);
+  useOutsideClick(
+    wrapperRef,
+    () => setIsMoreOptionsVisible(false),
+    isMoreOptionsVisible
+  );
+
+  return (
+    <div className="mt-6 mb-3 sm:flex sm:items-center sm:justify-between">
+      <div className="flex flex-row">
+        <div className="mr-2 flex self-center">
+          <p className="text-4xl font-bold">
+            Invoice #{invoice.invoice_number}
+          </p>
+        </div>
+        <div className="ml-2 flex self-center">
+          <Badge
+            className={`${getStatusCssClass(invoice.status)} uppercase`}
+            text={invoice.status}
+          />
+        </div>
       </div>
-      <div className="ml-2 flex self-center">
-        <Badge
-          className={`${getStatusCssClass(invoice.status)} uppercase`}
-          text={invoice.status}
-        />
-      </div>
-    </div>
-    <div className="justify-items-right flex flex-row">
-      <div className="send-button-container ml-1 flex flex-col justify-items-center">
-        {invoice.status == "waived" ? (
-          <Tooltip
-            content="This invoice has been waived off by the sender"
-            wrapperClassName="relative block max-w-full "
-          >
+      <div className="justify-items-right flex flex-row">
+        <div className="send-button-container ml-1 flex flex-col justify-items-center">
+          {invoice.status == "waived" ? (
+            <Tooltip
+              content="This invoice has been waived off by the sender"
+              wrapperClassName="relative block max-w-full "
+            >
+              <button
+                disabled
+                className="flex h-10 w-44 cursor-not-allowed flex-row items-center justify-center rounded bg-indigo-100"
+              >
+                <div className="flex flex-row items-center justify-between">
+                  <div className="mr-1">
+                    <ReportsIcon color="white" size={16} weight="bold" />
+                  </div>
+                  <p className="ml-1 text-base font-bold tracking-widest text-miru-white-1000">
+                    PAY
+                  </p>
+                </div>
+              </button>
+            </Tooltip>
+          ) : (
             <button
-              disabled
-              className="flex h-10 w-44 cursor-not-allowed flex-row items-center justify-center rounded bg-indigo-100"
+              disabled={invoice.status == "paid"}
+              className={`flex h-10 w-44 flex-row items-center justify-center rounded
+              ${
+                invoice.status == "paid"
+                  ? "cursor-not-allowed bg-indigo-100"
+                  : "bg-miru-han-purple-1000"
+              }`}
+              onClick={() => {
+                if (invoice.status != "paid") {
+                  if (stripe_connected_account) {
+                    window.location.href = stripeUrl;
+                  } else {
+                    setShowConnectPaymentDialog(true);
+                  }
+                }
+              }}
             >
               <div className="flex flex-row items-center justify-between">
                 <div className="mr-1">
@@ -43,39 +91,33 @@ const Header = ({
                 </p>
               </div>
             </button>
-          </Tooltip>
-        ) : (
+          )}
+        </div>
+        <div className="relative">
           <button
-            disabled={invoice.status == "paid"}
-            className={`flex h-10 w-44 flex-row items-center justify-center rounded
-              ${
-                invoice.status == "paid"
-                  ? "cursor-not-allowed bg-indigo-100"
-                  : "bg-miru-han-purple-1000"
-              }`}
-            onClick={() => {
-              if (invoice.status != "paid") {
-                if (stripe_connected_account) {
-                  window.location.href = stripeUrl;
-                } else {
-                  setShowConnectPaymentDialog(true);
-                }
-              }
-            }}
+            className="ml-2 rounded border border-miru-han-purple-1000 bg-miru-gray-1000 p-2.5 text-miru-han-purple-1000 opacity-50"
+            onClick={() => setIsMoreOptionsVisible(!isMoreOptionsVisible)}
           >
-            <div className="flex flex-row items-center justify-between">
-              <div className="mr-1">
-                <ReportsIcon color="white" size={16} weight="bold" />
-              </div>
-              <p className="ml-1 text-base font-bold tracking-widest text-miru-white-1000">
-                PAY
-              </p>
-            </div>
+            <DotsThreeVerticalIcon size={16} />
           </button>
-        )}
+          {isMoreOptionsVisible && (
+            <MoreOptions
+              className="right-0"
+              setVisibilty={setIsMoreOptionsVisible}
+            >
+              <li
+                className="flex cursor-pointer items-center py-2.5 px-4 text-miru-han-purple-1000 hover:bg-miru-gray-100"
+                onClick={() => handleDownloadInvoice(invoice)}
+              >
+                <DownloadSimpleIcon className="mr-4" size={16} weight="bold" />
+                Download
+              </li>
+            </MoreOptions>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Header;

--- a/app/javascript/src/components/Invoices/common/utils.js
+++ b/app/javascript/src/components/Invoices/common/utils.js
@@ -113,7 +113,8 @@ export const handleDownloadInvoice = async invoice => {
     const url = window.URL.createObjectURL(new Blob([res.data]));
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", `${invoice.invoiceNumber}.pdf`);
+    const filename = invoice?.invoiceNumber || invoice?.invoice_number;
+    link.setAttribute("download", `${filename}.pdf`);
     document.body.appendChild(link);
     link.click();
   } catch {

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -10,7 +10,7 @@ class InvoicePolicy < ApplicationPolicy
   end
 
   def show?
-    authorize_owner_admin_book_keeper
+    authorize_owner_admin_book_keeper_client
   end
 
   def update?
@@ -30,7 +30,7 @@ class InvoicePolicy < ApplicationPolicy
   end
 
   def download?
-    authorize_current_user && (user_owner_role? || user_admin_role? || user_book_keeper_role? || user_client_role?)
+    authorize_owner_admin_book_keeper_client
   end
 
   def send_reminder?
@@ -66,5 +66,9 @@ class InvoicePolicy < ApplicationPolicy
 
   def authorize_owner_admin
     authorize_current_user && (user_owner_role? || user_admin_role?)
+  end
+
+  def authorize_owner_admin_book_keeper_client
+    authorize_current_user && (user_owner_role? || user_admin_role? || user_book_keeper_role? || user_client_role?)
   end
 end

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -30,7 +30,7 @@ class InvoicePolicy < ApplicationPolicy
   end
 
   def download?
-    authorize_owner_admin_book_keeper
+    authorize_current_user && (user_owner_role? || user_admin_role? || user_book_keeper_role? || user_client_role?)
   end
 
   def send_reminder?

--- a/spec/policies/invoice_policy_spec.rb
+++ b/spec/policies/invoice_policy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe InvoicePolicy, type: :policy do
   let(:another_employee) { create(:user, current_workspace_id: another_company.id) }
   let(:another_owner) { create(:user, current_workspace_id: another_company.id) }
   let(:another_book_keeper) { create(:user, current_workspace_id: another_company.id) }
+  let(:client_member) { create(:user, current_workspace_id: company.id) }
 
   subject { described_class }
 
@@ -24,7 +25,7 @@ RSpec.describe InvoicePolicy, type: :policy do
     owner.add_role :owner, company
     employee.add_role :employee, company
     book_keeper.add_role :book_keeper, company
-    client.add_role :client_role, company
+    client_member.add_role :client, company
 
     another_owner.add_role :owner, another_company
     another_admin.add_role :admin, another_company

--- a/spec/policies/invoice_policy_spec.rb
+++ b/spec/policies/invoice_policy_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe InvoicePolicy, type: :policy do
     owner.add_role :owner, company
     employee.add_role :employee, company
     book_keeper.add_role :book_keeper, company
+    client.add_role :client_role, company
 
     another_owner.add_role :owner, another_company
     another_admin.add_role :admin, another_company
@@ -56,11 +57,12 @@ RSpec.describe InvoicePolicy, type: :policy do
   end
 
   permissions :show?, :download? do
-    context "when user is an admin, owner or book keeper" do
+    context "when user is an admin, owner, client or book keeper" do
       it "grants permission" do
         expect(described_class).to permit(admin, invoice)
         expect(described_class).to permit(owner, invoice)
         expect(described_class).to permit(book_keeper, invoice)
+        expect(described_class).to permit(client, invoice)
       end
     end
 

--- a/spec/policies/invoice_policy_spec.rb
+++ b/spec/policies/invoice_policy_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe InvoicePolicy, type: :policy do
         expect(described_class).to permit(admin, invoice)
         expect(described_class).to permit(owner, invoice)
         expect(described_class).to permit(book_keeper, invoice)
-        expect(described_class).to permit(client, invoice)
+        expect(described_class).to permit(client_member, invoice)
       end
     end
 


### PR DESCRIPTION
### **Notion :**
https://www.notion.so/saeloun/a-client-should-be-able-to-download-an-invoice-from-the-client-portal-after-they-have-logged-in-280076985fc94d69b72c528c431858e5?pvs=4
### **What :**
- Added more options button on view Invoice page client role
- Enabled access for clients to download a invoice 
### **Why :**
- Enhancement 
- Client should be able to download a invoice 

### **Todos** (for testing):
- Tested for oliver smith account