### PR TITLE
Use current day's date & minor changes

### DIFF
--- a/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/MarkInvoicePaidModal.tsx
@@ -23,7 +23,7 @@ const MarkInvoiceAsPaidModal = ({
   fetchInvoice,
 }) => {
   const { isDesktop } = useUserContext();
-  const [transactionDate, setTransactionDate] = useState<any>(null);
+  const [transactionDate, setTransactionDate] = useState<any>(dayjs());
   const [transactionType, setTransactionType] = useState<any>(null);
   const [note, setNote] = useState<any>(null);
   const [showDatePicker, setShowDatePicker] = useState<any>(false);
@@ -120,8 +120,9 @@ const MarkInvoiceAsPaidModal = ({
           }
         >
           <CustomInputText
-            disabled
+            readOnly
             id="transactionDate"
+            inputBoxClassName="cursor-pointer"
             label="Transaction Date"
             name="transactionDate"
             type="text"
@@ -129,7 +130,7 @@ const MarkInvoiceAsPaidModal = ({
             onChange={() => {}} //eslint-disable-line
           />
           <CalendarIcon
-            className="absolute top-0 bottom-0 right-1 mx-2 my-3 "
+            className="absolute top-0 bottom-0 right-1 mx-2 my-3 cursor-pointer "
             color="#5B34EA"
             size={20}
           />

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -34,7 +34,7 @@ const PaymentEntryForm = ({
   const { isDesktop } = useUserContext();
 
   const [invoice, setInvoice] = useState<any>(null);
-  const [transactionDate, setTransactionDate] = useState<any>(null);
+  const [transactionDate, setTransactionDate] = useState<any>(dayjs());
   const [transactionType, setTransactionType] = useState<any>(null);
   const [amount, setAmount] = useState<any>(null);
   const [note, setNote] = useState<any>(null);
@@ -249,8 +249,9 @@ const PaymentEntryForm = ({
           }
         >
           <CustomInputText
-            disabled
+            readOnly
             id="transactionDate"
+            inputBoxClassName="cursor-pointer"
             label="Transaction Date"
             name="transactionDate"
             type="text"
@@ -258,7 +259,7 @@ const PaymentEntryForm = ({
             onChange={() => {}} //eslint-disable-line
           />
           <CalendarIcon
-            className="absolute top-0 bottom-0 right-1 mx-2 my-3 "
+            className="absolute top-0 bottom-0 right-1 mx-2 my-3 cursor-pointer"
             color="#5B34EA"
             size={20}
           />


### PR DESCRIPTION
What
- Use the current day's date for the date filed in payment entry modals.
- Add cursor pointer for calendar and date fields.

Why
- Better UX