### PR TITLE
fix eager loading invoice index service

### DIFF
--- a/app/services/invoices/index_service.rb
+++ b/app/services/invoices/index_service.rb
@@ -87,7 +87,7 @@ module Invoices
           match: :word_middle,
           where: filters.where_clause,
           order: options[:order] || DEFAULT_ORDER,
-          includes: [:client, :company]
+          includes: [:client, { client: :logo_attachment }, :company]
         }
 
         invoice_options[:page] = options[:page] if options[:page]


### PR DESCRIPTION
Fixes eager loading shown in console

```
13:27:04 web.1       | GET /internal_api/v1/invoices?invoices_per_page=20&page=1&query=
13:27:04 web.1       | USE eager loading detected
13:27:04 web.1       |   Client => [:logo_attachment]
13:27:04 web.1       |   Add to your query: .includes([:logo_attachment])
13:27:04 web.1       | Call stack
13:27:04 web.1       |   /Users/apoorv/miru-web/app/models/client.rb:94:in `logo_url'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/models/invoice.rb:95:in `client_logo_url'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/views/internal_api/v1/partial/_invoice_item.json.jbuilder:16:in `block (2 levels) in _app_views_internal_api_v__partial__invoice_item_json_jbuilder___2394826446058644790_393300'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/views/internal_api/v1/partial/_invoice_item.json.jbuilder:13:in `block in _app_views_internal_api_v__partial__invoice_item_json_jbuilder___2394826446058644790_393300'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/views/internal_api/v1/partial/_invoice_item.json.jbuilder:6:in `_app_views_internal_api_v__partial__invoice_item_json_jbuilder___2394826446058644790_393300'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/views/internal_api/v1/invoices/index.json.jbuilder:6:in `block in _app_views_internal_api_v__invoices_index_json_jbuilder___2348408639570885108_393280'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/views/internal_api/v1/invoices/index.json.jbuilder:5:in `_app_views_internal_api_v__invoices_index_json_jbuilder___2348408639570885108_393280'
13:27:04 web.1       |   /Users/apoorv/miru-web/app/controllers/internal_api/v1/invoices_controller.rb:11:in `index'
13:27:04 web.1       |
```