### PR TITLE
Navigation button added on payment success page

### DIFF
--- a/app/javascript/src/components/payments/Success/index.tsx
+++ b/app/javascript/src/components/payments/Success/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "StyledComponents";
 
 import invoicesApi from "apis/invoices";
 import Loader from "common/Loader";
@@ -26,6 +27,10 @@ const Success = () => {
     } finally {
       setLoading(false);
     }
+  };
+
+  const redirectToHomePage = () => {
+    navigate("/invoices");
   };
 
   useEffect(() => {
@@ -68,6 +73,12 @@ const Success = () => {
               <p className="mt-2 text-base text-gray-500">
                 We have received your payment.
               </p>
+              <Button
+                className="mt-8 text-lg font-semibold"
+                onClick={redirectToHomePage}
+              >
+                Go to HomePage
+              </Button>
             </div>
           </div>
         </main>

--- a/app/javascript/src/components/payments/Success/index.tsx
+++ b/app/javascript/src/components/payments/Success/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 
+import { LeftArrowIcon } from "miruIcons";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "StyledComponents";
 
@@ -65,7 +66,7 @@ const Success = () => {
             </svg>
           </div>
           <div className="py-16">
-            <div className="text-center">
+            <div className="flex flex-col items-center">
               <p className="tracking-wide text-sm font-semibold uppercase text-indigo-600">{`Invoice ${invoice?.invoice_number}`}</p>
               <h1 className="tracking-tight mt-2 text-4xl font-extrabold text-gray-900 sm:text-5xl">
                 Payment was successful. 🎉
@@ -74,10 +75,11 @@ const Success = () => {
                 We have received your payment.
               </p>
               <Button
-                className="mt-8 text-lg font-semibold"
+                className="mt-8 flex items-center justify-between text-lg font-semibold"
                 onClick={redirectToHomePage}
               >
-                Go to HomePage
+                <LeftArrowIcon className="mr-1" />
+                Go To Home Page
               </Button>
             </div>
           </div>


### PR DESCRIPTION
### Notion
https://www.notion.so/saeloun/User-should-be-able-to-go-to-invoice-list-page-after-making-an-invoice-payment-4dc682fbe69945c992531e501b479a4e?pvs=4

### What:
- Added "Go to HomePage"  button on the payment success page 

### Why
- So that user can navigate back to the invoice list page.

### Preview
<img width="1785" alt="Screenshot 2024-01-02 at 2 08 48 PM" src="https://github.com/saeloun/miru-web/assets/72149587/160e175a-3a7c-4c31-9b72-c5828eef08fd">
