### PR TITLE
Updated time tracking api for timesheet and timeoff entries

### DIFF
--- a/app/controllers/internal_api/v1/time_tracking_controller.rb
+++ b/app/controllers/internal_api/v1/time_tracking_controller.rb
@@ -6,7 +6,12 @@ class InternalApi::V1::TimeTrackingController < InternalApi::V1::ApplicationCont
 
   def index
     authorize :index, policy_class: TimeTrackingPolicy
-    data = TimeTrackingIndexService.new(current_user, current_company).process
+    user = params[:user_id] || current_user
+    year = params[:year] || Date.today.year
+    from = params[:from] || 1.month.ago.beginning_of_month
+    to = params[:to] || 1.month.since.end_of_month
+
+    data = TimeTrackingIndexService.new(user, current_company, from, to, year).process
     render json: data, status: :ok
   end
 end

--- a/app/models/timeoff_entry.rb
+++ b/app/models/timeoff_entry.rb
@@ -36,4 +36,6 @@ class TimeoffEntry < ApplicationRecord
 
   validates :duration, presence: true, numericality: { less_than_or_equal_to: 6000000, greater_than_or_equal_to: 0 }
   validates :leave_date, presence: true
+
+  scope :during, -> (from, to) { where(leave_date: from..to).order(leave_date: :desc) }
 end

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -84,7 +84,8 @@ class TimesheetEntry < ApplicationRecord
       note:,
       work_date:,
       bill_status:,
-      team_member: user.full_name
+      team_member: user.full_name,
+      type: "timesheet"
     }
   end
 

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe TimesheetEntry, type: :model do
           note: timesheet_entry.note,
           work_date: timesheet_entry.work_date,
           bill_status: timesheet_entry.bill_status,
-          team_member: timesheet_entry.user.full_name
+          team_member: timesheet_entry.user.full_name,
+          type: "timesheet"
         }
       )
     end


### PR DESCRIPTION
#### What
- With this PR, we can fetch both timesheet and timeoff entries.
- We can pass the customised duration for both timesheet and timeoff entries.