### PR TITLE
Allocated devices empty state

### DIFF
--- a/app/javascript/src/components/Profile/UserDetail/AllocatedDevicesDetails/StaticPage.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/AllocatedDevicesDetails/StaticPage.tsx
@@ -2,6 +2,8 @@ import React, { Fragment } from "react";
 
 import { MobileIcon } from "miruIcons";
 
+import EmptyStates from "common/EmptyStates";
+
 const StaticPage = ({ devices }) => {
   const DeviceDetails = ({ device }) => {
     const {
@@ -75,9 +77,17 @@ const StaticPage = ({ devices }) => {
 
   return (
     <Fragment>
-      {devices?.map((device, index) => (
-        <DeviceDetails device={device} key={index} />
-      ))}
+      {devices.length > 0 ? (
+        devices.map((device, index) => (
+          <DeviceDetails device={device} key={index} />
+        ))
+      ) : (
+        <EmptyStates
+          Message="No devices found"
+          containerClassName="h-full"
+          showNoSearchResultState={false}
+        />
+      )}
     </Fragment>
   );
 };

--- a/app/javascript/src/components/Profile/UserDetail/AllocatedDevicesDetails/index.tsx
+++ b/app/javascript/src/components/Profile/UserDetail/AllocatedDevicesDetails/index.tsx
@@ -36,16 +36,15 @@ const AllocatedDevicesDetails = () => {
 
   return (
     <Fragment>
-      {isDesktop && (
+      {isDesktop ? (
         <DetailsHeader
-          showButtons
           editAction={handleEdit}
           isDisableUpdateBtn={false}
+          showButtons={false}
           subTitle=""
           title="Allocated Devices"
         />
-      )}
-      {!isDesktop && (
+      ) : (
         <MobileEditHeader
           backHref="/settings/"
           href="/settings/devices/edit"


### PR DESCRIPTION
### Notion 
https://www.notion.so/saeloun/Allocated-devices-Bug-fix-2b5c4406360842c2abe13644cdb1f452?pvs=4
### What
- Added empty state design for allocated devices page
- Disabled Edit page for allocated devices.

### Why
- Blank space was being shown if no allocated devices are added.
- Edit allocated devices API is not present
 
### Preview
Before:
<img width="1492" alt="Screenshot 2024-01-23 at 11 19 14 AM" src="https://github.com/saeloun/miru-web/assets/72149587/71a371b5-7312-43a7-980a-2489915eed53">


After:
<img width="1407" alt="Screenshot 2024-01-23 at 11 09 48 AM" src="https://github.com/saeloun/miru-web/assets/72149587/ac71ffb5-b61d-4418-8871-5c329723c6a6">

 
