### PR TITLE
Fixed filter error on leave management

### DIFF
--- a/app/javascript/src/components/LeaveManagement/index.tsx
+++ b/app/javascript/src/components/LeaveManagement/index.tsx
@@ -70,7 +70,7 @@ const LeaveManagement = () => {
         timeoffEntries.length &&
         selectedLeaveType &&
         timeoffEntries.filter(
-          timeoffEntry => timeoffEntry.leaveType.id === selectedLeaveType.id
+          timeoffEntry => timeoffEntry.leaveType?.id === selectedLeaveType.id
         );
 
       const leaveType = leaveBalance.find(


### PR DESCRIPTION
### What
- Whenever we filter leaves based on their leave type it renders a blank page if any leave type is a holiday