### PR TITLE
Enable Time-off entry  in "Day" view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ gem "data_migrate", "~> 8.0.0.rc2"
 # pagy for Pagination
 gem "pagy", "~> 5.10"
 
-gem "nokogiri", ">= 1.13.10"
+gem "nokogiri", ">= 1.16.2"
 
 # Manage application specific business logic. https://github.com/AaronLasseigne/active_interaction
 gem "active_interaction"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,7 +664,7 @@ DEPENDENCIES
   letter_opener_web
   money
   newrelic_rpm (~> 8.4)
-  nokogiri (>= 1.13.10)
+  nokogiri (>= 1.16.2)
   omniauth-google-oauth2 (~> 1.0)
   omniauth-rails_csrf_protection (~> 1.0)
   pagy (~> 5.10)

--- a/app/javascript/src/components/TimesheetEntries/index.tsx
+++ b/app/javascript/src/components/TimesheetEntries/index.tsx
@@ -661,7 +661,25 @@ const TimesheetEntries = ({ user, isAdminUser }: Iprops) => {
       <div className="pb-14">
         {!isDesktop && <Header />}
         <div className="mt-0 h-full p-4 lg:mt-6 lg:p-0">
-          <div className="mb-6 flex items-center justify-between md:flex-row-reverse">
+          <div className="mb-6 flex items-center justify-between">
+            {isDesktop && (
+              <nav className="flex">
+                {["month", "day"].map((item, index) => (
+                  <button
+                    key={index}
+                    className={`mr-10 tracking-widest
+                      ${
+                        item === view
+                          ? "border-b-2 border-miru-han-purple-1000 font-bold text-miru-han-purple-1000"
+                          : "font-medium text-miru-han-purple-600"
+                      }`}
+                    onClick={() => setView(item)}
+                  >
+                    {item.toUpperCase()}
+                  </button>
+                ))}
+              </nav>
+            )}
             {isDesktop && isViewTogglerVisible && (
               <ViewToggler view={view} setView={setView} />
             )}
@@ -718,7 +736,7 @@ const TimesheetEntries = ({ user, isAdminUser }: Iprops) => {
                     + NEW ENTRY
                   </button>
                 )}
-              {view === "month" &&
+              {view !== "week" &&
                 !newEntryView &&
                 !newTimeoffEntryView &&
                 isDesktop && (


### PR DESCRIPTION
Notion:
https://www.notion.so/Enable-Timeoff-for-Day-view-470bc12917a34a74b186b0a070fd0aaf

**What**
- Enabled "day view" in Timesheet entry screen
- Enabled Time-off entry button for Day view

**Why** 
- Added the time-off entry to day view cause fewer changes are required to enable it

**Screenshots:**

<img width="1792" alt="Screenshot 2024-02-13 at 5 47 22 PM" src="https://github.com/saeloun/miru-web/assets/13100108/9571dc2b-e238-4d93-bf46-2ea284d0acef">


Screen-recording:


https://github.com/saeloun/miru-web/assets/13100108/89c57ef7-2031-4e8d-8b9e-cfa4dfd39816

