### PR TITLE
Fix rack-cors insuecure file permission failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -230,7 +230,7 @@ gem "sentry-ruby"
 # https://github.com/grosser/parallel_tests
 gem "parallel_tests", group: [:development, :test]
 
-# CROS: https://github.com/cyu/rack-cors
+# CORS: https://github.com/cyu/rack-cors
 gem "rack-cors", "2.0.0"
 
 # Administrate dashboard

--- a/Gemfile
+++ b/Gemfile
@@ -231,7 +231,7 @@ gem "sentry-ruby"
 gem "parallel_tests", group: [:development, :test]
 
 # CROS: https://github.com/cyu/rack-cors
-gem "rack-cors"
+gem "rack-cors", "2.0.0"
 
 # Administrate dashboard
 gem "administrate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8.1)
-    rack-cors (2.0.1)
+    rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
@@ -672,7 +672,7 @@ DEPENDENCIES
   pg
   puma (~> 6.4.2)
   pundit (~> 2.2)
-  rack-cors
+  rack-cors (= 2.0.0)
   rack-mini-profiler (>= 2.3.3)
   rails (~> 7.0.8.1)
   rails-controller-testing (~> 1.0, >= 1.0.5)


### PR DESCRIPTION
What
- Pin down the rack-cors version to 2.0.0 as the issue is still open https://github.com/cyu/rack-cors/issues/274
Why
- To fix rack-cors insecure file permission failure 
<img width="1394" alt="Screenshot 2024-02-29 at 10 55 35 AM" src="https://github.com/saeloun/miru-web/assets/18750194/b5184cfe-8146-43cb-8e60-50c503c00b4d">
