### PR TITLE
Fix time tracking page for new user

### DIFF
--- a/app/javascript/src/components/TimeTracking/MonthCalender.tsx
+++ b/app/javascript/src/components/TimeTracking/MonthCalender.tsx
@@ -58,10 +58,13 @@ const MonthCalender = ({
         `${currentYear}-${currentMonthNumber + 1}-${i}`
       ).format("YYYY-MM-DD");
 
-      const totalDuration = entryList[date]?.reduce(
-        (acc: number, cv: number) => cv["duration"] + acc,
-        0
-      );
+      const totalDuration =
+        entryList && entryList[date]
+          ? entryList[date]?.reduce(
+              (acc: number, cv: number) => cv["duration"] + acc,
+              0
+            )
+          : 0;
       if (totalDuration) currentWeekTotalHours += totalDuration;
       weeksData[dayInWeekCounter] = {
         date,

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -264,7 +264,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
       const day = dayjs()
         .weekday(weekCounter + weekDay)
         .format("YYYY-MM-DD");
-      if (entryList[day]) {
+      if (entryList && entryList[day]) {
         let dayTotal = 0;
         entryList[day].forEach(e => {
           dayTotal += e.duration;
@@ -332,7 +332,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
         .weekday(weekDay + weekCounter)
         .format("YYYY-MM-DD");
 
-      if (!entryList[date]) continue;
+      if (!entryList || !entryList[date]) continue;
 
       entryList[date].forEach(entry => {
         let entryAdded = false;

--- a/app/javascript/src/components/TimesheetEntries/index.tsx
+++ b/app/javascript/src/components/TimesheetEntries/index.tsx
@@ -360,7 +360,7 @@ const TimesheetEntries = ({ user, isAdminUser }: Iprops) => {
       const day = dayjs()
         .weekday(weekCounter + weekDay)
         .format("YYYY-MM-DD");
-      if (entryList[day]) {
+      if (entryList && entryList[day]) {
         let dayTotal = 0;
         entryList[day].forEach(e => {
           dayTotal += e.duration;
@@ -432,7 +432,7 @@ const TimesheetEntries = ({ user, isAdminUser }: Iprops) => {
         .weekday(weekDay + weekCounter)
         .format("YYYY-MM-DD");
 
-      if (!entryList[date]) continue;
+      if (!entryList || !entryList[date]) continue;
 
       entryList[date].forEach(entry => {
         if (entry["type"] == "timesheet") {
@@ -549,10 +549,13 @@ const TimesheetEntries = ({ user, isAdminUser }: Iprops) => {
         `${currentYear}-${currentMonthNumber + 1}-${i}`
       ).format("YYYY-MM-DD");
 
-      const totalDuration = entryList[date]?.reduce(
-        (acc: number, cv: number) => cv["duration"] + acc,
-        0
-      );
+      const totalDuration =
+        entryList && entryList[date]
+          ? entryList[date]?.reduce(
+              (acc: number, cv: number) => cv["duration"] + acc,
+              0
+            )
+          : 0;
       if (totalDuration) currentWeekTotalHours += totalDuration;
       weeksData[dayInWeekCounter] = {
         date,


### PR DESCRIPTION
- Fix https://github.com/saeloun/miru-web/issues/1732
- For new users, there won't be any timesheet or time-off entries present
- After login, we redirect new users to the time tracking page
- Handle these cases when the `entryList` is blank for new users