### PR TITLE
Fix enable / disable of optional holidays

### DIFF
--- a/app/models/holiday_info.rb
+++ b/app/models/holiday_info.rb
@@ -35,7 +35,6 @@ class HolidayInfo < ApplicationRecord
     format: { with: /\A[a-zA-Z\s]+\z/ },
     length: { maximum: 30 }
   validates :date, :category, presence: true
-  validate :validate_optional_holidays, if: -> { category == "optional" }
   validate :validate_holiday_category
   validate :validate_year
 
@@ -48,12 +47,6 @@ class HolidayInfo < ApplicationRecord
   }
 
   private
-
-    def validate_optional_holidays
-      unless holiday&.enable_optional_holidays
-        errors.add(:base, "optional holidays are disabled")
-      end
-    end
 
     def validate_holiday_category
       unless holiday&.holiday_types&.include?(category)

--- a/app/services/time_tracking_index_service.rb
+++ b/app/services/time_tracking_index_service.rb
@@ -93,11 +93,12 @@ class TimeTrackingIndexService
 
     def leave_types
       leave = current_company.leaves.find_by(year:)
-      leave&.leave_types&.kept || []
+      leave&.leave_types&.kept
     end
 
     def holiday_infos
       holiday = current_company.holidays.find_by(year:)
-      holiday&.holiday_infos&.kept || []
+      all_holidays = holiday&.holiday_infos&.kept
+      holiday.enable_optional_holidays ? all_holidays : all_holidays.national
     end
 end

--- a/spec/models/holiday_info_spec.rb
+++ b/spec/models/holiday_info_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe HolidayInfo, type: :model do
     it { is_expected.to validate_presence_of(:date) }
     it { is_expected.to validate_presence_of(:category) }
 
-    it 'validates optional holidays when the category is "optional"' do
-      optional_holiday_info.holiday.enable_optional_holidays = false
-      optional_holiday_info.valid?
-      expect(optional_holiday_info.errors[:base]).to include("optional holidays are disabled")
-    end
-
     it "validates the year of the date" do
       invalid_holiday_info = build(:holiday_info, holiday:, date: "2022-01-01")
       invalid_holiday_info.valid?

--- a/spec/requests/internal_api/v1/time_tracking/index_spec.rb
+++ b/spec/requests/internal_api/v1/time_tracking/index_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe "InternalApi::V1::TimeTracking#index", type: :request do
   let!(:project2) { create(:project, client: client1) }
   let!(:project3) { create(:project, client: client2) }
   let!(:project4) { create(:project, client: client3) }
+  let!(:holiday) { create(:holiday, year: Date.current.year, company: company1) }
+  let(:national_holiday) { create(:holiday_info, date: Date.current, category: "national", holiday:) }
+  let(:optional_holiday) { create(:holiday_info, date: Date.current + 2.days, category: "optional", holiday:) }
 
   before do
     create(:project_member, user:, project: project1)


### PR DESCRIPTION
- Fix https://github.com/saeloun/miru-web/issues/1715
- Show only `National` holidays in the dropdown after disabling the `Optional` holiday
- Remove unwanted validation and respective spec