### PR TITLE
View public holiday and optional holiday cards on leave management

### DIFF
--- a/app/controllers/internal_api/v1/timeoff_entries_controller.rb
+++ b/app/controllers/internal_api/v1/timeoff_entries_controller.rb
@@ -15,7 +15,9 @@ class InternalApi::V1::TimeoffEntriesController < InternalApi::V1::ApplicationCo
       timeoff_entries: data[:timeoff_entries],
       employees: data[:employees],
       leave_balance: data[:leave_balance],
-      total_timeoff_entries_duration: data[:total_timeoff_entries_duration]
+      total_timeoff_entries_duration: data[:total_timeoff_entries_duration],
+      optional_timeoff_entries: data[:optional_timeoff_entries],
+      national_timeoff_entries: data[:national_timeoff_entries]
     }, status: :ok
   end
 

--- a/app/javascript/src/components/LeaveManagement/Container/LeaveBlock.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/LeaveBlock.tsx
@@ -4,15 +4,29 @@ import { minToHHMM } from "helpers";
 import { Avatar } from "StyledComponents";
 
 import {
-  generateLeaveColor,
   generateLeaveIcon,
+  generateLeaveColor,
+  generateHolidayIcon,
+  generateHolidayColor,
 } from "components/Profile/Organization/Leaves/utils";
 
 const LeaveBlock = ({ leaveType, setSelectedLeaveType }) => {
-  const { icon, color, name, netDuration, netDays } = leaveType;
+  const {
+    icon,
+    color,
+    name,
+    netDuration,
+    netDays,
+    type,
+    category,
+    timePeriod,
+  } = leaveType;
 
-  const leaveIcon = generateLeaveIcon(icon);
-  const leaveColor = generateLeaveColor(color);
+  const leaveIcon =
+    type == "leave" ? generateLeaveIcon(icon) : generateHolidayIcon(icon);
+
+  const leaveColor =
+    type == "leave" ? generateLeaveColor(color) : generateHolidayColor(color);
 
   return (
     <div
@@ -29,7 +43,9 @@ const LeaveBlock = ({ leaveType, setSelectedLeaveType }) => {
       <div className="mt-4 flex flex-col">
         <span className="text-xs font-semibold lg:text-sm">{name}</span>
         <span className="mt-2 text-base font-semibold lg:text-2xl">
-          {`${minToHHMM(netDuration)} h (${netDays} days)`}
+          {category != "national" &&
+            `${minToHHMM(netDuration)} h (${netDays} days)`}
+          {category == "optional" && `this ${timePeriod}`}
         </span>
       </div>
     </div>

--- a/app/javascript/src/components/LeaveManagement/index.tsx
+++ b/app/javascript/src/components/LeaveManagement/index.tsx
@@ -25,6 +25,8 @@ const LeaveManagement = () => {
   const [filterTimeoffEntries, setFilterTimeoffEntries] = useState([]);
   const [filterTimeoffEntriesDuration, setFilterTimeoffEntriesDuration] =
     useState(0);
+  const [optionalTimeoffEntries, setOptionalTimeoffEntries] = useState([]);
+  const [nationalTimeoffEntries, setNationalTimeoffEntries] = useState([]);
 
   useEffect(() => {
     fetchTimeoffEntries();
@@ -45,6 +47,8 @@ const LeaveManagement = () => {
       employees,
       leaveBalance,
       totalTimeoffEntriesDuration,
+      optionalTimeoffEntries,
+      nationalTimeoffEntries,
     } = res.data;
 
     setSelectedLeaveType(null);
@@ -52,6 +56,8 @@ const LeaveManagement = () => {
     setEmployees(employees);
     setLeaveBalance(leaveBalance);
     setTotalTimeoffEntriesDuration(totalTimeoffEntriesDuration);
+    setOptionalTimeoffEntries(optionalTimeoffEntries);
+    setNationalTimeoffEntries(nationalTimeoffEntries);
     handlefilterTimeoffEntries(
       timeoffEntries,
       totalTimeoffEntriesDuration,
@@ -66,15 +72,21 @@ const LeaveManagement = () => {
     selectedLeaveType
   ) => {
     if (selectedLeaveType) {
-      const sortedTimeoffEntries =
-        timeoffEntries.length &&
-        selectedLeaveType &&
-        timeoffEntries.filter(
-          timeoffEntry => timeoffEntry.leaveType?.id === selectedLeaveType.id
-        );
+      let sortedTimeoffEntries = [];
+      if (selectedLeaveType.id == "optional") {
+        sortedTimeoffEntries = optionalTimeoffEntries;
+      } else if (selectedLeaveType.id == "national") {
+        sortedTimeoffEntries = nationalTimeoffEntries;
+      } else {
+        sortedTimeoffEntries =
+          timeoffEntries.length &&
+          timeoffEntries.filter(
+            timeoffEntry => timeoffEntry.leaveType?.id === selectedLeaveType.id
+          );
+      }
 
       const leaveType = leaveBalance.find(
-        item => item.id === selectedLeaveType.id
+        item => item.id == selectedLeaveType.id
       );
 
       setFilterTimeoffEntries(sortedTimeoffEntries);

--- a/app/javascript/src/constants/leaveType.ts
+++ b/app/javascript/src/constants/leaveType.ts
@@ -83,11 +83,11 @@ export const leaveIcons = [
 export const holidayColors = [
   {
     label: "national",
-    value: "#FFFFE0",
+    value: "#7CC984",
   },
   {
     label: "optional",
-    value: "#FFC0CB",
+    value: "#68AEAA",
   },
 ];
 

--- a/app/models/timeoff_entry.rb
+++ b/app/models/timeoff_entry.rb
@@ -71,33 +71,13 @@ class TimeoffEntry < ApplicationRecord
       optional_timeoff_entries = holiday.optional_timeoff_entries
 
       error_message = "You have exceeded the maximum number of permitted optional holidays"
-      case time_period_optional_holidays.to_sym
-      when :per_week
-        start_of_week = leave_date.beginning_of_week
-        end_of_week = leave_date.end_of_week
-
-        total_optional_entries = optional_timeoff_entries.where(
-          leave_date: start_of_week..end_of_week,
-          user:).count
-      when :per_month
-        start_of_month = leave_date.beginning_of_month
-        end_of_month = leave_date.end_of_month
-
-        total_optional_entries = optional_timeoff_entries.where(
-          leave_date: start_of_month..end_of_month,
-          user:).count
-      when :per_quarter
-        start_of_quarter = leave_date.beginning_of_quarter
-        end_of_quarter = leave_date.end_of_quarter
-
-        total_optional_entries = optional_timeoff_entries.where(
-          leave_date: start_of_quarter..end_of_quarter,
-          user:).count
-      when :per_year
-        total_optional_entries = optional_timeoff_entries.where(user:).count
-      else
-        errors.add(:base, error_message)
-      end
+      total_optional_entries = TimeoffEntries::CalculateOptionalHolidayTimeoffEntriesService.new(
+        no_of_allowed_optional_holidays,
+        time_period_optional_holidays,
+        optional_timeoff_entries,
+        leave_date,
+        user
+      ).process
 
       if total_optional_entries >= no_of_allowed_optional_holidays
         errors.add(:base, error_message)

--- a/app/models/timeoff_entry.rb
+++ b/app/models/timeoff_entry.rb
@@ -72,7 +72,6 @@ class TimeoffEntry < ApplicationRecord
 
       error_message = "You have exceeded the maximum number of permitted optional holidays"
       total_optional_entries = TimeoffEntries::CalculateOptionalHolidayTimeoffEntriesService.new(
-        no_of_allowed_optional_holidays,
         time_period_optional_holidays,
         optional_timeoff_entries,
         leave_date,

--- a/app/services/time_tracking_index_service.rb
+++ b/app/services/time_tracking_index_service.rb
@@ -93,12 +93,14 @@ class TimeTrackingIndexService
 
     def leave_types
       leave = current_company.leaves.find_by(year:)
-      leave&.leave_types&.kept
+      leave&.leave_types&.kept || []
     end
 
     def holiday_infos
       holiday = current_company.holidays.find_by(year:)
       all_holidays = holiday&.holiday_infos&.kept
+      return [] if holiday.blank? || all_holidays.blank?
+
       holiday.enable_optional_holidays ? all_holidays : all_holidays.national
     end
 end

--- a/app/services/timeoff_entries/calculate_optional_holiday_timeoff_entries_service.rb
+++ b/app/services/timeoff_entries/calculate_optional_holiday_timeoff_entries_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module TimeoffEntries
+  class CalculateOptionalHolidayTimeoffEntriesService < ApplicationService
+    attr_reader :time_period, :optional_timeoff_entries, :leave_date, :user
+
+    def initialize(time_period, optional_timeoff_entries, leave_date, user)
+      @time_period = time_period
+      @optional_timeoff_entries = optional_timeoff_entries
+      @leave_date = leave_date
+      @user = user
+    end
+
+    def process
+      case time_period.to_sym
+      when :per_week
+        start_of_week = leave_date.beginning_of_week
+        end_of_week = leave_date.end_of_week
+
+        total_optional_entries = optional_timeoff_entries.where(
+          leave_date: start_of_week..end_of_week,
+          user:).count
+      when :per_month
+        start_of_month = leave_date.beginning_of_month
+        end_of_month = leave_date.end_of_month
+
+        total_optional_entries = optional_timeoff_entries.where(
+          leave_date: start_of_month..end_of_month,
+          user:).count
+      when :per_quarter
+        start_of_quarter = leave_date.beginning_of_quarter
+        end_of_quarter = leave_date.end_of_quarter
+
+        total_optional_entries = optional_timeoff_entries.where(
+          leave_date: start_of_quarter..end_of_quarter,
+          user:).count
+      when :per_year
+        total_optional_entries = optional_timeoff_entries.where(user:).count
+      end
+      total_optional_entries
+    end
+  end
+end

--- a/app/services/timeoff_entries/index_service.rb
+++ b/app/services/timeoff_entries/index_service.rb
@@ -2,7 +2,8 @@
 
 module TimeoffEntries
   class IndexService < ApplicationService
-    attr_reader :current_company, :current_user, :user_id, :year
+    attr_reader :current_company, :current_user, :user_id, :year, :optional_timeoff_entries, :national_timeoff_entries
+    attr_accessor :leave_balance
 
     CURRENT_DATE = DateTime.now
     CURRENT_YEAR = CURRENT_DATE.year
@@ -14,16 +15,17 @@ module TimeoffEntries
       @current_company = current_company
       @user_id = user_id
       @year = year.to_i
+      @leave_balance = []
     end
 
     def process
       {
         timeoff_entries:,
         employees:,
-        leave_balance:,
+        leave_balance: process_leave_balance,
         total_timeoff_entries_duration: timeoff_entries.sum(:duration),
-        optional_timeoff_entries: @optional_timeoff_entries,
-        national_timeoff_entries: @national_timeoff_entries
+        optional_timeoff_entries:,
+        national_timeoff_entries:
       }
     end
 
@@ -51,91 +53,9 @@ module TimeoffEntries
         current_user.has_role?(:owner, current_company) || current_user.has_role?(:admin, current_company)
       end
 
-      def leave_balance
-        leave_balance = []
-
-        leave = current_company.leaves.kept.find_by(year:)
-
-        holiday = current_company.holidays.kept.find_by(year:)
-
-        if leave
-          previous_year_leave = current_company.leaves.kept.find_by(year: leave.year - 1)
-
-          leave.leave_types.kept.all.each do |leave_type|
-            total_leave_type_days = calculate_total_duration(leave_type)
-
-            timeoff_entries_duration = leave_type.timeoff_entries.kept.where(user_id:).sum(:duration)
-
-            previous_year_leave_type = previous_year_leave &&
-              previous_year_leave.leave_types.kept.find_by(name: leave_type.name)
-
-            previous_year_carryforward = calculate_previous_year_carryforward(previous_year_leave_type)
-
-            net_duration = (total_leave_type_days * 8 * 60) + previous_year_carryforward - timeoff_entries_duration
-
-            summary_object = {
-              id: leave_type.id,
-              name: leave_type.name,
-              icon: leave_type.icon,
-              color: leave_type.color,
-              total_leave_type_days:,
-              timeoff_entries_duration:,
-              net_duration:,
-              net_days: net_duration / 60 / 8,
-              type: "leave"
-            }
-
-            leave_balance << summary_object
-          end
-        end
-
-        if holiday
-          no_of_allowed_optional_holidays = holiday.no_of_allowed_optional_holidays
-          time_period_optional_holidays = holiday.time_period_optional_holidays
-          @optional_timeoff_entries = holiday.optional_timeoff_entries.where(user: user_id)
-          @national_timeoff_entries = holiday.national_timeoff_entries.where(user: user_id)
-
-          total_optional_entries = TimeoffEntries::CalculateOptionalHolidayTimeoffEntriesService.new(
-            time_period_optional_holidays,
-            holiday.optional_timeoff_entries,
-            Date.current,
-            user_id
-          ).process
-
-          if total_optional_entries >= no_of_allowed_optional_holidays
-            net_days = 0
-          else
-            net_days = no_of_allowed_optional_holidays - total_optional_entries
-          end
-
-          optional_holidays = {
-            id: "optional",
-            name: "Optional Holidays",
-            icon: "optional",
-            color: "optional",
-            net_duration: net_days * 60 * 8,
-            net_days:,
-            timeoff_entries_duration: @optional_timeoff_entries.sum(:duration),
-            type: "holiday",
-            category: "optional",
-            time_period: time_period_optional_holidays.to_s.sub("per_", "")
-          }
-
-          leave_balance << optional_holidays
-
-          national_holidays = {
-            id: "national",
-            name: "National Holidays",
-            icon: "national",
-            color: "national",
-            timeoff_entries_duration: @national_timeoff_entries.sum(:duration),
-            type: "holiday",
-            category: "national"
-          }
-
-          leave_balance << national_holidays
-        end
-
+      def process_leave_balance
+        calculate_leave_balance
+        calculate_holiday_balance
         leave_balance
       end
 
@@ -255,6 +175,91 @@ module TimeoffEntries
         carry_forward_duration = leave_type.carry_forward_days * 8 * 60
 
         net_duration > carry_forward_duration ? carry_forward_duration : net_duration > 0 ? net_duration : 0
+      end
+
+      def calculate_leave_balance
+        leave = current_company.leaves.kept.find_by(year: Date.current.year)
+        return unless leave
+
+        previous_year_leave = current_company.leaves.kept.find_by(year: leave.year - 1)
+
+        leave.leave_types.kept.all.each do |leave_type|
+          total_leave_type_days = calculate_total_duration(leave_type)
+
+          timeoff_entries_duration = leave_type.timeoff_entries.kept.where(user_id:).sum(:duration)
+
+          previous_year_leave_type = previous_year_leave &&
+            previous_year_leave.leave_types.kept.find_by(name: leave_type.name)
+
+          previous_year_carryforward = calculate_previous_year_carryforward(previous_year_leave_type)
+
+          net_duration = (total_leave_type_days * 8 * 60) + previous_year_carryforward - timeoff_entries_duration
+
+          summary_object = {
+            id: leave_type.id,
+            name: leave_type.name,
+            icon: leave_type.icon,
+            color: leave_type.color,
+            total_leave_type_days:,
+            timeoff_entries_duration:,
+            net_duration:,
+            net_days: net_duration / 60 / 8,
+            type: "leave"
+          }
+
+          @leave_balance << summary_object
+        end
+      end
+
+      def calculate_holiday_balance
+        holiday = current_company.holidays.kept.find_by(year:)
+
+        return unless holiday
+
+        no_of_allowed_optional_holidays = holiday.no_of_allowed_optional_holidays
+        time_period_optional_holidays = holiday.time_period_optional_holidays
+        @optional_timeoff_entries = holiday.optional_timeoff_entries.where(user: user_id)
+        @national_timeoff_entries = holiday.national_timeoff_entries.where(user: user_id)
+
+        total_optional_entries = TimeoffEntries::CalculateOptionalHolidayTimeoffEntriesService.new(
+          time_period_optional_holidays,
+          holiday.optional_timeoff_entries,
+          Date.current,
+          user_id
+        ).process
+
+        if total_optional_entries >= no_of_allowed_optional_holidays
+          net_days = 0
+        else
+          net_days = no_of_allowed_optional_holidays - total_optional_entries
+        end
+
+        optional_holidays = {
+          id: "optional",
+          name: "Optional Holidays",
+          icon: "optional",
+          color: "optional",
+          net_duration: net_days * 60 * 8,
+          net_days:,
+          timeoff_entries_duration: @optional_timeoff_entries.sum(:duration),
+          type: "holiday",
+          category: "optional",
+          time_period: time_period_optional_holidays.to_s.sub("per_", "")
+        }
+
+        leave_balance << optional_holidays
+
+        national_holidays = {
+          id: "national",
+          name: "National Holidays",
+          icon: "national",
+          color: "national",
+          timeoff_entries_duration: @national_timeoff_entries.sum(:duration),
+          type: "holiday",
+          category: "national"
+        }
+
+        leave_balance << national_holidays
       end
   end
 end

--- a/app/views/internal_api/v1/timeoff_entries/index.json.jbuilder
+++ b/app/views/internal_api/v1/timeoff_entries/index.json.jbuilder
@@ -10,6 +10,23 @@ json.timeoff_entries timeoff_entries do |timeoff_entry|
   json.leave_date CompanyDateFormattingService.new(timeoff_entry.leave_date, company: current_company).process
   json.leave_type timeoff_entry.leave_type if timeoff_entry.leave_type.present?
   json.holiday_info timeoff_entry.holiday_info if timeoff_entry.holiday_info.present?
+  json.type timeoff_entry.leave_type.present? ? "leave" : "holiday"
+end
+
+json.optional_timeoff_entries optional_timeoff_entries do |timeoff_entry|
+  json.id timeoff_entry.id
+  json.duration timeoff_entry.duration
+  json.leave_date CompanyDateFormattingService.new(timeoff_entry.leave_date, company: current_company).process
+  json.holiday_info timeoff_entry.holiday_info if timeoff_entry.holiday_info.present?
+  json.type timeoff_entry.holiday_info.present? ? "holiday" : "leave"
+end
+
+json.national_timeoff_entries national_timeoff_entries do |timeoff_entry|
+  json.id timeoff_entry.id
+  json.duration timeoff_entry.duration
+  json.leave_date CompanyDateFormattingService.new(timeoff_entry.leave_date, company: current_company).process
+  json.holiday_info timeoff_entry.holiday_info if timeoff_entry.holiday_info.present?
+  json.type timeoff_entry.holiday_info.present? ? "holiday" : "leave"
 end
 
 json.employees employees

--- a/spec/requests/internal_api/v1/time_tracking/index_spec.rb
+++ b/spec/requests/internal_api/v1/time_tracking/index_spec.rb
@@ -13,9 +13,6 @@ RSpec.describe "InternalApi::V1::TimeTracking#index", type: :request do
   let!(:project2) { create(:project, client: client1) }
   let!(:project3) { create(:project, client: client2) }
   let!(:project4) { create(:project, client: client3) }
-  let!(:holiday) { create(:holiday, year: Date.current.year, company: company1) }
-  let(:national_holiday) { create(:holiday_info, date: Date.current, category: "national", holiday:) }
-  let(:optional_holiday) { create(:holiday_info, date: Date.current + 2.days, category: "optional", holiday:) }
 
   before do
     create(:project_member, user:, project: project1)

--- a/spec/services/timeoff_entries/index_service_spec.rb
+++ b/spec/services/timeoff_entries/index_service_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 6,
         timeoff_entries_duration: 60,
         net_duration: 2820,
-        net_days: 5
+        net_days: 5,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][0]).to eq(summary_object)
@@ -145,7 +146,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 24,
         timeoff_entries_duration: 0,
         net_duration: 11520,
-        net_days: 24
+        net_days: 24,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][1]).to eq(summary_object)
@@ -160,7 +162,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 2,
         timeoff_entries_duration: 0,
         net_duration: 960,
-        net_days: 2
+        net_days: 2,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][2]).to eq(summary_object)
@@ -175,7 +178,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 2,
         timeoff_entries_duration: 0,
         net_duration: 960,
-        net_days: 2
+        net_days: 2,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][3]).to eq(summary_object)
@@ -205,7 +209,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 5,
         timeoff_entries_duration: 60,
         net_duration: 2340,
-        net_days: 4
+        net_days: 4,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][0]).to eq(summary_object)
@@ -235,7 +240,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 23,
         timeoff_entries_duration: 0,
         net_duration: 11040,
-        net_days: 23
+        net_days: 23,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][1]).to eq(summary_object)
@@ -265,7 +271,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 1,
         timeoff_entries_duration: 0,
         net_duration: 480,
-        net_days: 1
+        net_days: 1,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][2]).to eq(summary_object)
@@ -295,7 +302,8 @@ RSpec.describe TimeoffEntries::IndexService do # rubocop:disable RSpec/FilePath
         total_leave_type_days: 2,
         timeoff_entries_duration: 0,
         net_duration: 960,
-        net_days: 2
+        net_days: 2,
+        type: "leave"
       }
 
       expect(@data[:leave_balance][3]).to eq(summary_object)


### PR DESCRIPTION
Closes #1735 

### What
- Fixed the time tracking bug if leaves are not defined for the year.
- Calculate optional holiday timeoff entries using the service.
- Updated leave balance API with optional and national holiday timeoff entries.
- View national and optional holiday cards on leave management and click on those cards to view the applied holidays respectively.