### PR TITLE
Updated Leaves & Holidays balance cards according to the design

### DIFF
--- a/app/javascript/src/components/LeaveManagement/Container/LeaveBlock.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/LeaveBlock.tsx
@@ -11,16 +11,8 @@ import {
 } from "components/Profile/Organization/Leaves/utils";
 
 const LeaveBlock = ({ leaveType, setSelectedLeaveType }) => {
-  const {
-    icon,
-    color,
-    name,
-    netDuration,
-    netDays,
-    type,
-    category,
-    timePeriod,
-  } = leaveType;
+  const { icon, color, name, netDuration, netDays, type, category, label } =
+    leaveType;
 
   const leaveIcon =
     type == "leave" ? generateLeaveIcon(icon) : generateHolidayIcon(icon);
@@ -48,8 +40,10 @@ const LeaveBlock = ({ leaveType, setSelectedLeaveType }) => {
       <div className="mt-4 flex flex-col">
         <span className="text-xs font-semibold lg:text-sm">{name}</span>
         <span className="mt-2 text-base font-semibold lg:text-2xl">
-          {category !== "national" && formattedDuration}
-          {category == "optional" && `this ${timePeriod}`}
+          {category !== "national" &&
+            category != "optional" &&
+            formattedDuration}
+          {label}
         </span>
       </div>
     </div>

--- a/app/javascript/src/components/LeaveManagement/Header.tsx
+++ b/app/javascript/src/components/LeaveManagement/Header.tsx
@@ -13,7 +13,7 @@ const Header = ({
 }) => (
   <div className="m-4 flex items-center justify-between lg:mx-0">
     <span className="hidden text-3xl font-bold text-miru-dark-purple-1000 lg:inline">
-      Leave Management
+      Leaves & Holidays
     </span>
     <CustomYearPicker
       nextYearButtonDisabled

--- a/app/javascript/src/components/LeaveManagement/index.tsx
+++ b/app/javascript/src/components/LeaveManagement/index.tsx
@@ -114,7 +114,7 @@ const LeaveManagement = () => {
         date = new Date();
       }
 
-      return `Leave Balance Untill ${format(date, "do MMM yyyy")}`;
+      return `Balance Until ${format(date, "do MMM yyyy")}`;
     };
 
     return (

--- a/app/javascript/src/components/Navbar/utils.tsx
+++ b/app/javascript/src/components/Navbar/utils.tsx
@@ -62,7 +62,7 @@ const navOptions = [
   },
   {
     logo: <CalendarIcon className="mr-0 md:mr-4" size={26} />,
-    label: "Leave Management",
+    label: "Leaves & Holidays",
     path: Paths.Leave_Management,
     allowedRoles: ["admin", "owner", "employee"],
   },


### PR DESCRIPTION
Closes #1758, #1767

### What
- Changed the unit on cards for National and Optional holidays as declared by admin according to net and total calculations.
-  Updated Sidebar nav menu from `Leave Management` to `Leaves & Holidays `

### Figma
https://www.figma.com/file/4gdPDRPqGqQqPYsO3Qj8CG/Miru-App?type=design&node-id=19633-28935&mode=design&t=FGwNt9zBepUe3sTi-0