### PR TITLE
Remove invitation pending clients from team page

### DIFF
--- a/app/services/team/index_service.rb
+++ b/app/services/team/index_service.rb
@@ -33,7 +33,7 @@ module Team
       end
 
       def invitations
-        invitation_ids = current_company.invitations.valid_invitations.pluck(:id)
+        invitation_ids = current_company.invitations.valid_invitations.where.not(role: "client").pluck(:id)
 
         Invitation.search(
           search_term,


### PR DESCRIPTION
- Fix #1775 (Fix another issue: The team page also shows invited and pending clients)