### PR TITLE
Send client member emails for payment reminders

### DIFF
--- a/app/controllers/internal_api/v1/clients_controller.rb
+++ b/app/controllers/internal_api/v1/clients_controller.rb
@@ -31,6 +31,7 @@ class InternalApi::V1::ClientsController < InternalApi::V1::ApplicationControlle
 
     render locals: {
              client_details: Client::ShowPresenter.new(client).process,
+             client_member_emails: client.send_invoice_emails(@virtual_verified_invitations_allowed),
              project_details: client.project_details(params[:time_frame]),
              total_minutes: client.total_hours_logged(params[:time_frame]),
              overdue_outstanding_amount: client.client_overdue_and_outstanding_calculation,
@@ -78,7 +79,7 @@ class InternalApi::V1::ClientsController < InternalApi::V1::ApplicationControlle
       subject: client_email_params[:email_params][:subject],
     ).send_payment_reminder.deliver_later
 
-    render json: { notice: "Payment reminder has been sent to #{client.email}" }, status: :accepted
+    render json: { notice: "Payment reminder has been sent" }, status: :accepted
   end
 
   private

--- a/app/controllers/internal_api/v1/invoices_controller.rb
+++ b/app/controllers/internal_api/v1/invoices_controller.rb
@@ -93,7 +93,7 @@ class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationControll
         message: invoice_email_params[:message]
       ).send_reminder.deliver_later
 
-      render json: { message: "A reminder has been sent to #{invoice.client.email}" }, status: :accepted
+      render json: { message: "A reminder has been sent" }, status: :accepted
     end
   end
 

--- a/app/javascript/src/components/Clients/Modals/PaymentReminder/MobileView/index.tsx
+++ b/app/javascript/src/components/Clients/Modals/PaymentReminder/MobileView/index.tsx
@@ -44,7 +44,7 @@ const MobilePaymentReminder = ({
     subject: "Reminder to complete payments for unpaid invoices",
     message:
       "This is a gentle reminder to complete payments for the following invoices. You can find the respective payment links along with the invoice details given below",
-    recipients: [client.email],
+    recipients: client.clientMembersEmails,
   });
 
   const isStepFormSubmittedOrVisited = stepNo => {

--- a/app/views/internal_api/v1/clients/show.json.jbuilder
+++ b/app/views/internal_api/v1/clients/show.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 json.client_details client_details
+json.client_members_emails client_member_emails
 json.project_details project_details
 json.total_minutes total_minutes
 json.overdue_outstanding_amount overdue_outstanding_amount


### PR DESCRIPTION
What
- Send client member emails for payment reminders.

Why
- Fix bug while sending payment reminders