### PR TITLE
Team List broken row fixed

### DIFF
--- a/app/javascript/src/components/Team/List/Table/TableRow.tsx
+++ b/app/javascript/src/components/Team/List/Table/TableRow.tsx
@@ -56,11 +56,11 @@ const TableRow = ({ item }) => {
       className="group flex cursor-pointer border-b border-miru-gray-200 last:border-0 lg:grid lg:grid-cols-10 lg:gap-4"
       onClick={handleRowClick}
     >
-      <td className="flex w-3/5 py-2 text-left text-xs font-medium leading-4 tracking-widest text-miru-dark-purple-600 lg:col-span-4 lg:py-3">
-        <div className="my-auto">
+      <td className="flex w-3/5 py-2 text-left text-xs font-medium leading-4 tracking-widest text-miru-dark-purple-600 lg:col-span-4 lg:w-auto lg:py-3">
+        <div className="my-auto lg:w-1/6">
           <Avatar url={profilePicture} />
         </div>
-        <div className="ml-2 truncate capitalize lg:ml-4">
+        <div className="mx-2 truncate capitalize lg:ml-4 lg:w-5/6">
           <dt className="lg:flex">
             <p className="mr-2 text-sm font-bold leading-5 text-miru-dark-purple-1000 lg:text-base">
               {name}


### PR DESCRIPTION
### What:
- Fixed the width of column on team list page 

### Why:
- Pending status UI is broken

### Preview:
Before:
<img width="1270" alt="Screenshot 2024-05-30 at 11 31 53 AM" src="https://github.com/saeloun/miru-web/assets/72149587/ec13f138-e941-44b3-af33-7d6dc942c7a9">

After:
<img width="1304" alt="Screenshot 2024-05-30 at 11 31 27 AM" src="https://github.com/saeloun/miru-web/assets/72149587/247a81e5-3fd4-4609-af94-5dc845f1fdb8">
