### PR TITLE
Mark timesheet entries as `billed` only when invoice is `sent` successfully

### DIFF
--- a/app/controllers/internal_api/v1/invoices_controller.rb
+++ b/app/controllers/internal_api/v1/invoices_controller.rb
@@ -2,7 +2,6 @@
 
 class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationController
   before_action :load_client, only: [:create, :update]
-  after_action :ensure_time_entries_billed, only: [:send_invoice]
   after_action :track_event, only: [:create, :update, :destroy, :send_invoice, :download]
 
   def index
@@ -120,10 +119,6 @@ class InternalApi::V1::InvoicesController < InternalApi::V1::ApplicationControll
 
     def invoice_email_params
       params.require(:invoice_email).permit(:subject, :message, recipients: [])
-    end
-
-    def ensure_time_entries_billed
-      invoice.update_timesheet_entry_status!
     end
 
     def track_event

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoiceMailer < ApplicationMailer
-  after_action -> { @invoice.sent! if @invoice.draft? || @invoice.viewed? || @invoice.declined? || @invoice.sending? }
+  after_action :update_status, only: [:invoice]
 
   def invoice
     @invoice = Invoice.find(params[:invoice_id])
@@ -36,5 +36,12 @@ class InvoiceMailer < ApplicationMailer
 
     def can_send_invoice?
       @invoice.sending? && @invoice.recently_sent_mail?
+    end
+
+    def update_status
+      if @invoice.draft? || @invoice.viewed? || @invoice.declined? || @invoice.sending?
+        @invoice.sent!
+        @invoice.update_timesheet_entry_status!
+      end
     end
 end

--- a/spec/requests/internal_api/v1/invoices/send_invoice_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/send_invoice_spec.rb
@@ -29,24 +29,31 @@ RSpec.describe "InternalApi::V1::Invoices#send_invoice", type: :request do
         sign_in user
       end
 
-      # it "returns a 202 response" do
-      #   post send_invoice_internal_api_v1_invoice_path(id: invoice.id), params: { invoice_email: },
-      #     headers: auth_headers(user)
-
-      #   expect(response).to have_http_status :accepted
-      #   expect(json_response["message"]).to eq("Invoice will be sent!")
-      # end
-
-      # it "enqueues an email for delivery" do
-      #   expect do
-      #     post send_invoice_internal_api_v1_invoice_path(id: invoice.id), params: { invoice_email: },
-      #       headers: auth_headers(user)
-      #   end.to have_enqueued_mail(InvoiceMailer, :invoice)
-      # end
-
-      it "changes time_sheet_entries status to billed" do
+      it "returns a 202 response" do
         post send_invoice_internal_api_v1_invoice_path(id: invoice.id), params: { invoice_email: },
           headers: auth_headers(user)
+
+        expect(response).to have_http_status :accepted
+        expect(json_response["message"]).to eq("Invoice will be sent!")
+      end
+
+      it "enqueues an email for delivery" do
+        expect do
+          post send_invoice_internal_api_v1_invoice_path(id: invoice.id), params: { invoice_email: },
+            headers: auth_headers(user)
+        end.to have_enqueued_mail(InvoiceMailer, :invoice)
+      end
+
+      it "changes time_sheet_entries status to billed" do
+        expect do
+          post send_invoice_internal_api_v1_invoice_path(id: invoice.id), params: { invoice_email: },
+            headers: auth_headers(user)
+        end.to have_enqueued_mail(InvoiceMailer, :invoice)
+
+        perform_enqueued_jobs do
+          InvoiceMailer.with({ invoice_id: invoice.id }.merge(invoice_email)).invoice.deliver_later
+        end
+
         invoice.invoice_line_items.reload.each do |line_item|
           expect(line_item.timesheet_entry.bill_status).to eq("billed")
         end


### PR DESCRIPTION
- Fix https://github.com/saeloun/miru-web/issues/1853
- A couple of weeks back, invoices were stuck in the `sending` state due to insufficient memory at sidekiq
- And, we found this issue that timesheet entries were `billed`
- These timesheet entries must be marked as `billed` only when the invoice is in the `sent` state