### PR TITLE
Fix invoice specs after invoice factory changes

### DIFF
--- a/spec/requests/internal_api/v1/invoices/create_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/create_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
           invoice_number: "SAI-C1-03",
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft,
           invoice_line_item: {
             name: "Test",
             description: "test description",
@@ -72,7 +71,6 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
           :invoice,
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft,
           invoice_line_item: {
             name: "Test",
             description: "test description",
@@ -99,7 +97,6 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
           :invoice,
           client: company.clients.first,
           client_id: company.clients.first.id,
-          status: :draft,
           invoice_line_item: {
             name: "Test",
             description: "test description",
@@ -122,8 +119,7 @@ RSpec.describe "InternalApi::V1::Invoices#create", type: :request do
         invoice: attributes_for(
           :invoice,
           client: company.clients.first,
-          client_id: company.clients.first.id,
-          status: :draft
+          client_id: company.clients.first.id
         )
       )
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/internal_api/v1/payments/new_spec.rb
+++ b/spec/requests/internal_api/v1/payments/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "InternalApi::V1::Payments#create", type: :request do
   let!(:client1_viewed_invoice1) { create(:invoice, client: client1, company:, status: "viewed") }
   let!(:client1_paid_invoice1) { create(:invoice, client: client1, company:, status: "paid") }
   let!(:client1_overdue_invoice1) { create(:invoice, client: client1, company:, status: "overdue") }
-  let!(:client1_draft_invoice1) { create(:invoice, client: client1, company:, status: "draft") }
+  let!(:client1_draft_invoice1) { create(:invoice, client: client1, company:) }
 
   context "when user is an admin" do
     before do

--- a/spec/services/update_invoice_status_to_overdue_service_spec.rb
+++ b/spec/services/update_invoice_status_to_overdue_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UpdateInvoiceStatusToOverdueService do
   let!(:client1_sent_invoice2) { create(:invoice, client: client1, status: "sent", due_date: Date.current - 1) }
   let!(:client1_sent_invoice3) { create(:invoice, client: client1, status: "sent", due_date: Date.current - 2) }
   let(:client1_paid_invoice2) { create(:invoice, client: client1, status: "paid", due_date: Date.current - 1) }
-  let!(:client1_draft_invoice1) { create(:invoice, client: client1, status: "draft", due_date: Date.current - 1) }
+  let!(:client1_draft_invoice1) { create(:invoice, client: client1, due_date: Date.current - 1) }
   let!(:client1_viewed_invoice1) { create(:invoice, client: client1, status: "viewed", due_date: Date.current + 1) }
   let!(:client1_viewed_invoice2) { create(:invoice, client: client1, status: "viewed", due_date: Date.current - 1) }
 

--- a/spec/system/invoices/edit_invoice_spec.rb
+++ b/spec/system/invoices/edit_invoice_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Edit Invoice", type: :system do
-  let!(:invoice) { create :invoice_with_invoice_line_items, status: :draft }
+  let!(:invoice) { create :invoice_with_invoice_line_items }
   let(:client) { invoice.client }
   let!(:company) { invoice.company }
   let(:admin) { create(:user, current_workspace_id: company.id) }


### PR DESCRIPTION
- By default, all invoices created are `draft` to avoid flakiness
- This is fixed in PR https://github.com/saeloun/miru-web/pull/1870