### PR TITLE
Updated grover config

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Edit/index.tsx
@@ -133,12 +133,13 @@ const OrgEdit = () => {
       });
       setIsDetailUpdated(true);
     }
-  }, [file]);
+  }, [file, orgDetails]);
 
   const [currenciesOption, setCurrenciesOption] = useState([]);
   const [timezoneOption, setTimezoneOption] = useState([]);
   const [timezones, setTimezones] = useState({});
-  const [isDetailUpdated, setIsDetailUpdated] = useState(false);
+  /* eslint-disable-next-line */
+  const [_isDetailUpdated, setIsDetailUpdated] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [countries, setCountries] = useState([]);
 
@@ -286,8 +287,8 @@ const OrgEdit = () => {
     const changedCountry = {
       ...companyAddr,
       country: selectCountry,
-      state: {},
-      city: {},
+      state: "",
+      city: "",
     };
 
     setupTimezone(
@@ -486,7 +487,7 @@ const OrgEdit = () => {
       <EditHeader
         showButtons
         cancelAction={handleCancelAction}
-        isDisableUpdateBtn={isDetailUpdated}
+        isDisableUpdateBtn={false}
         saveAction={handleUpdateOrgDetails}
         subTitle=""
         title="Organization Settings"

--- a/app/javascript/src/components/Profile/Organization/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Edit/index.tsx
@@ -420,10 +420,12 @@ const OrgEdit = () => {
       formD.append("company[fiscal_year_end]", orgDetails.companyFiscalYear);
       formD.append("company[date_format]", orgDetails.companyDateFormat);
       formD.append("company[timezone]", orgDetails.companyTimezone);
-      formD.append(
-        "company[addresses_attributes][0][id]",
-        orgDetails.companyAddr.id
-      );
+      if (orgDetails.companyAddr.id) {
+        formD.append(
+          "company[addresses_attributes][0][id]",
+          orgDetails.companyAddr.id
+        );
+      }
 
       formD.append(
         "company[addresses_attributes][0][address_line_1]",

--- a/app/javascript/src/components/Profile/Organization/Edit/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Edit/index.tsx
@@ -421,37 +421,37 @@ const OrgEdit = () => {
       formD.append("company[date_format]", orgDetails.companyDateFormat);
       formD.append("company[timezone]", orgDetails.companyTimezone);
       formD.append(
-        "company[addresses_attributes[0][id]]",
+        "company[addresses_attributes][0][id]",
         orgDetails.companyAddr.id
       );
 
       formD.append(
-        "company[addresses_attributes[0][address_line_1]]",
+        "company[addresses_attributes][0][address_line_1]",
         orgDetails.companyAddr.addressLine1
       );
 
       formD.append(
-        "company[addresses_attributes[0][address_line_2]]",
+        "company[addresses_attributes][0][address_line_2]",
         orgDetails.companyAddr.addressLine2
       );
 
       formD.append(
-        "company[addresses_attributes[0][state]]",
+        "company[addresses_attributes][0][state]",
         orgDetails.companyAddr.state
       );
 
       formD.append(
-        "company[addresses_attributes[0][city]]",
+        "company[addresses_attributes][0][city]",
         orgDetails.companyAddr.city
       );
 
       formD.append(
-        "company[addresses_attributes[0][country]]",
+        "company[addresses_attributes][0][country]",
         orgDetails.companyAddr.country?.value
       );
 
       formD.append(
-        "company[addresses_attributes[0][pin]]",
+        "company[addresses_attributes][0][pin]",
         orgDetails.companyAddr.zipcode
       );
 

--- a/app/views/internal_api/v1/partial/_address.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_address.json.jbuilder
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-json.id address.id
-json.address_line_1 address.address_line_1
-json.address_line_2 address.address_line_2
-json.city address.city
-json.state address.state
-json.country address.country
-json.pin address.pin
+json.id address&.id
+json.address_line_1 address&.address_line_1
+json.address_line_2 address&.address_line_2
+json.city address&.city
+json.state address&.state
+json.country address&.country
+json.pin address&.pin

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -12,7 +12,7 @@ Grover.configure do |config|
     cache: false,
     timeout: 30000,
     wait_until: "domcontentloaded",
-    launch_args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    launch_args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"],
     viewport: { width: 800, height: 600 },
     javascript_enabled: false
   }

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -7,12 +7,14 @@ Grover.configure do |config|
       top: "5px",
       bottom: "5px"
     },
-    prefer_css_page_size: true,
+    prefer_css_page_size: false,
     emulate_media: "screen",
     cache: false,
-    timeout: 0, # Timeout in ms. A value of `0` means 'no timeout'
+    timeout: 30000,
     wait_until: "domcontentloaded",
-    launch_args: ["--no-sandbox", "--disable-setuid-sandbox"]
+    launch_args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    viewport: { width: 800, height: 600 },
+    javascript_enabled: false
   }
 
   if !(Rails.env.development? || Rails.env.test?)

--- a/deployment/fly/fly.staging.toml
+++ b/deployment/fly/fly.staging.toml
@@ -7,7 +7,7 @@ primary_region = "ewr"
 
 [processes]
   web = "bin/rails fly:server"
-  worker = "bundle exec rake solid_queue:start"
+  worker = "bin/rails fly:worker"
 
 [build]
   dockerfile = "Dockerfile"

--- a/lib/pdf/html_generator.rb
+++ b/lib/pdf/html_generator.rb
@@ -25,7 +25,7 @@ class Pdf::HtmlGenerator
         @options = user_defined_options
       else
         @options = {
-          wait_until: ["networkidle0", "load", "domcontentloaded", "networkidle2"]
+          wait_until: ["load", "domcontentloaded"]
         }
       end
 

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -21,6 +21,15 @@ namespace :fly do
     sh 'bin/rails server -b [::] -p 8080'
   end
 
+  # Worker step:
+  #  - changes to the filesystem made here are deployed
+  #  - full access to secrets, databases
+  #  - failures here result in VM being stated, shutdown, and rolled back
+  #    to last successful deploy (if any).
+  task :worker => :swapfile do
+    sh 'bundle exec rake solid_queue:start'
+  end
+
   # optional SWAPFILE task:
   #  - adjust fallocate size as needed
   #  - performance critical applications should scale memory to the

--- a/spec/mailers/previews/invoice_preview.rb
+++ b/spec/mailers/previews/invoice_preview.rb
@@ -5,7 +5,7 @@
 class InvoicePreview < ActionMailer::Preview
   def invoice
     invoice = Invoice.last
-    id = invoice.id
+    invoice_id = invoice.id
     recipients = [invoice.client.email, "miru@example.com"]
     subject = "Invoice (#{invoice.invoice_number}) due on #{invoice.due_date}"
     message = "#{invoice.client.company.name} has sent you an invoice (#{invoice.invoice_number}) for $#{invoice.amount.to_i} that's due on #{invoice.due_date}."


### PR DESCRIPTION
- Added swap to worker machine this will fix the memory issue.

- Grover config changes:
  - `prefer_css_page_size` set to `false` as we don't have any page css property.
  - Set `timeout` to 30 seconds. This will avoid Grover to waiting indefinitively which will also increase the memory usage and cause the server to restart.
  - Added [`--disable-gpu`](https://peter.sh/experiments/chromium-command-line-switches/#disable-gpu) as launch_args to disable the GPU acceleration.
  - set `javascript_enabled: false` as the PDF pages are static.

- Removed `networkidle0` and `networkidle2` as `load` should be enough to get the images from s3 and it will reduce the 500 millisecond wait.
- Fixed the address issue in organization edit form.