### PR TITLE
Small changes: leaves and holidays module

### DIFF
--- a/app/javascript/src/components/LeaveManagement/Container/Table/TableRow.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/Table/TableRow.tsx
@@ -36,7 +36,7 @@ const TableRow = ({ timeoffEntry }) => {
         <span>{leaveName}</span>
       </td>
       <td className="flex w-1/3 flex-col whitespace-nowrap pb-2.5 text-right text-base lg:mt-0 lg:table-cell lg:w-3/12 lg:items-center lg:pl-8">
-        {minToHHMM(duration)}
+        {leaveType ? minToHHMM(duration) : "-:-"}
       </td>
     </tr>
   );

--- a/app/javascript/src/components/TimeoffEntries/TimeoffForm/DesktopTimeoffForm.tsx
+++ b/app/javascript/src/components/TimeoffEntries/TimeoffForm/DesktopTimeoffForm.tsx
@@ -37,6 +37,8 @@ const DesktopTimeoffForm = ({
     setEditTimeoffEntryId,
   } = useTimesheetEntries();
 
+  const holidayEntry = isHolidayEntry();
+
   return (
     <div className="mt-10 hidden min-h-24 justify-between rounded-lg p-4 shadow-2xl lg:flex">
       <div className="w-1/2">
@@ -124,9 +126,12 @@ const DesktopTimeoffForm = ({
             </div>
           </div>
           <TimeInput
-            className="h-8 w-20 rounded-sm bg-miru-gray-100 p-1 text-sm placeholder:text-miru-gray-1000"
+            disabled={holidayEntry}
             initTime={duration}
             name="timeInput"
+            className={`h-8 w-20 rounded-sm bg-miru-gray-100 p-1 text-sm placeholder:text-miru-gray-1000 ${
+              holidayEntry && "text-miru-dark-purple-200"
+            }`}
             onTimeChange={handleDurationChange}
           />
         </div>

--- a/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
+++ b/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import dayjs from "dayjs";
 import { minFromHHMM, minToHHMM } from "helpers";
 
+import companiesApi from "apis/companies";
 import timeoffEntryApi from "apis/timeoff-entry";
 import { HOLIDAY_TYPES } from "constants/index";
 import { useTimesheetEntries } from "context/TimesheetEntries";
@@ -49,6 +50,22 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
   const [holidayOptions, setHolidayOptions] = useState([]);
   const [showLeavesList, setShowLeavesList] = useState<boolean>(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
+  const [workingHoursPerDay, setWorkingHoursPerDay] = useState<string>("");
+
+  const fetchCompanyWorkingHours = async () => {
+    const res = await companiesApi.index();
+
+    const companyDetails = res.data.company_details;
+    const MinutesPerDay = minFromHHMM(
+      (companyDetails.working_hours / companyDetails.working_days).toString()
+    );
+    const hoursPerDay = minToHHMM(MinutesPerDay);
+    setWorkingHoursPerDay(hoursPerDay);
+  };
+
+  useEffect(() => {
+    fetchCompanyWorkingHours();
+  }, []);
 
   useEffect(() => {
     const tempLeaveTypes = [...leaveTypes];
@@ -96,6 +113,7 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
       const tempHolidayOptions =
         holidayList?.filter(holiday => holiday?.category === leaveTypeId) || [];
       setHolidayOptions([...tempHolidayOptions]);
+      setDuration(workingHoursPerDay);
       handleSuggestedHolidayBasedOnDate(tempHolidayOptions);
     } else {
       setIsShowHolidayList(false);

--- a/app/services/timeoff_entries/index_service.rb
+++ b/app/services/timeoff_entries/index_service.rb
@@ -24,7 +24,7 @@ module TimeoffEntries
         timeoff_entries:,
         employees: set_employees,
         leave_balance: process_leave_balance,
-        total_timeoff_entries_duration: timeoff_entries.sum(&:duration),
+        total_timeoff_entries_duration: timeoff_leave_entries.sum(&:duration),
         optional_timeoff_entries:,
         national_timeoff_entries:
       }
@@ -76,7 +76,7 @@ module TimeoffEntries
 
           summary_object = {
             id: leave_type.id,
-            name: leave_type.name,
+            name: "Available #{leave_type.name}",
             icon: leave_type.icon,
             color: leave_type.color,
             total_leave_type_days:,
@@ -106,13 +106,13 @@ module TimeoffEntries
 
         national_holidays = {
           id: "national",
-          name: "National Holidays",
+          name: "Available National Holidays",
           icon: "national",
           color: "national",
           timeoff_entries_duration: national_timeoff_entries.sum(:duration),
           type: "holiday",
           category: "national",
-          label: "#{national_timeoff_entries.count} out of #{total_national_holidays}"
+          label: "#{total_national_holidays - national_timeoff_entries.count} out of #{total_national_holidays}"
         }
 
         leave_balance << national_holidays
@@ -138,7 +138,7 @@ module TimeoffEntries
 
         optional_holidays = {
           id: "optional",
-          name: "Optional Holidays",
+          name: "Available Optional Holidays",
           icon: "optional",
           color: "optional",
           net_duration: net_days * 60 * @working_hours_per_day,
@@ -146,7 +146,7 @@ module TimeoffEntries
           timeoff_entries_duration: optional_timeoff_entries.sum(:duration),
           type: "holiday",
           category: "optional",
-          label: "#{total_optional_entries} out of #{no_of_allowed_optional_holidays} (this #{time_period_optional_holidays.to_s.gsub("per_", "")})"
+          label: "#{no_of_allowed_optional_holidays - total_optional_entries} out of #{no_of_allowed_optional_holidays} (this #{time_period_optional_holidays.to_s.gsub("per_", "")})"
         }
 
         leave_balance << optional_holidays
@@ -191,6 +191,10 @@ module TimeoffEntries
         return 0 if current_company.working_hours.to_i == 0
 
         current_company.working_hours.to_i / current_company.working_days.to_i
+      end
+
+      def timeoff_leave_entries
+        timeoff_entries.select { |entry| entry.leave_type_id.present? }
       end
   end
 end


### PR DESCRIPTION
### What
- As discussed excluded optional holidays and national holidays from table total calculation.
- Added "Available" word to leave blocks as it represents available leaves and holidays
- Made hours input disabled for optional holidays and national holidays, prefilling hours based on one working day of the organisation. (e.g: 8:00) 

### Preview:
<img width="1392" alt="Screenshot 2024-12-05 at 10 22 09 AM" src="https://github.com/user-attachments/assets/04ef143a-2e91-47e7-b9d3-7ef3561bada8">

<img width="1439" alt="Screenshot 2024-12-05 at 10 22 22 AM" src="https://github.com/user-attachments/assets/f3308eb0-432b-460b-8964-e7b5cc36e05a">


<img width="1424" alt="Screenshot 2024-12-05 at 10 21 45 AM" src="https://github.com/user-attachments/assets/9d4e16dd-f992-40d4-84b3-b64f4dfd0645">

