### PR TITLE
Zerobounce integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,5 @@ SOLID_QUEUE_USERNAME: <some_username>
 SOLID_QUEUE_PASSWORD: <some_password>
 MISSION_CONTROL_ENABLED=true
 POSTMARK_API_TOKEN= "<Replace with postmark API Token>"
+ZERO_BOUNCE_API_KEY= "<Replace with Zerobounce API_KEY>"
+ENABLE_EMAIL_VALIDATION=true

--- a/Gemfile
+++ b/Gemfile
@@ -233,3 +233,6 @@ gem "administrate"
 gem "psych", "~> 4"
 
 gem "postmark-rails"
+
+# Zerobounce email validation
+gem "zerobounce-sdk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
     docile (1.4.0)
     dockerfile-rails (1.2.5)
       rails
+    domain_name (0.6.20240107)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -289,6 +290,9 @@ GEM
     hash_dot (2.5.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -349,6 +353,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     memoist (0.16.2)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1203)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
@@ -373,6 +381,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     newrelic_rpm (9.8.0)
     nio4r (2.7.3)
     nokogiri (1.16.7-arm64-darwin)
@@ -500,6 +509,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.3.9)
     rolify (6.0.1)
@@ -662,6 +676,9 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
+    zerobounce-sdk (1.1.1)
+      dotenv (~> 2.8.1)
+      rest-client (~> 2.1)
 
 PLATFORMS
   arm64-darwin-21
@@ -749,6 +766,7 @@ DEPENDENCIES
   vcr (~> 6.1)
   web-console (>= 4.1.0)
   webmock (~> 3.14.0)
+  zerobounce-sdk
 
 RUBY VERSION
    ruby 3.2.4p170

--- a/config/initializers/zerobounce.rb
+++ b/config/initializers/zerobounce.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "zerobounce"
+
+Zerobounce.configure do |config|
+  config.apikey = "0d422e5b9ad94f599bbf03e5c666a886"
+end


### PR DESCRIPTION
What
- Added ZeroBounce integration

Why
- To validate user emails before the actual email is sent on sign up.

TODOS
- Add specs.
- Check other places in app where we need to use it.