### PR TITLE
The invoice number is not available for use after an invoice is delete bug fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.25.4)
     mission_control-jobs (0.2.1)
       importmap-rails
@@ -375,6 +376,9 @@ GEM
       net-protocol
     newrelic_rpm (9.8.0)
     nio4r (2.7.3)
+    nokogiri (1.18.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.7-x86_64-darwin)
@@ -669,6 +673,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23

--- a/app/views/internal_api/v1/partial/_client_list.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_client_list.json.jbuilder
@@ -6,6 +6,6 @@ json.email client.email
 json.phone client.phone
 json.address client.current_address
 json.currency client.currency
-json.previousInvoiceNumber client.invoices&.last&.invoice_number || 0
+json.previousInvoiceNumber client.invoices.active.last&.invoice_number || 0
 json.client_members client.send_invoice_emails(@virtual_verified_invitations_allowed)
 json.logo client[:logo] ? polymorphic_url(client[:logo]) : ""

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -78,6 +78,13 @@ RSpec.describe Invoice, type: :model do
         "#{Invoice::ARCHIVED_PREFIX}-#{@current_invoice.id}-"
       )
     end
+
+    it "reuses invoice number after discard for new invoice" do
+      invoice_number = @current_invoice.invoice_number
+      @current_invoice.discard!
+      new_invoice = create(:invoice, client: @current_invoice.client, company:, invoice_number:)
+      expect(new_invoice.invoice_number).to eq(invoice_number)
+    end
   end
 
   describe "Scopes" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe Invoice, type: :model do
       @current_invoice.discard!
       expect { @current_invoice.discard! }.to raise_error(Discard::RecordNotDiscarded)
     end
+
+    it "update invoice number" do
+      @current_invoice.discard!
+      expect(@current_invoice.invoice_number).to start_with(
+        "#{Invoice::ARCHIVED_PREFIX}-#{@current_invoice.id}-"
+      )
+    end
   end
 
   describe "Scopes" do


### PR DESCRIPTION
Github task - https://github.com/saeloun/miru-web/issues/1964

Changes

1. Invoice after_discard updating invoice_number with prefix
 2. Added active scope for Invoice for new invoice generation

https://github.com/user-attachments/assets/ee6ae5d5-1406-4578-b139-db29c66a9e6d


