### PR TITLE
Fix typo in SENTRY_DSN sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  config.dsn = ENV["SENTRY_DNS"]
+  config.dsn = ENV["SENTRY_DSN"]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   # Set traces_sample_rate to 1.0 to capture 100%


### PR DESCRIPTION
In env.example it is DSN but here in code, it was expecting DNS,
this pr fixes the typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the Sentry configuration to ensure proper error reporting setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->