### PR TITLE
fix: prevent text overlapping in invoice PDF layout

### DIFF
--- a/app/views/pdfs/invoices.html.erb
+++ b/app/views/pdfs/invoices.html.erb
@@ -165,7 +165,7 @@
 </head>
 <body>
   <div class="main">
-    <div class="flex justify-between border-b-2 border-miru-gray-400 p-10 h-50">
+    <div class="flex justify-between border-b-2 border-miru-gray-400 p-10" style="min-height: 12.5rem;">
       <div class="flex" style="width: 60%;">
         <div class="h-20 w-20 mr-5" style="flex-shrink: 0;">
           <%=image_tag company_logo%>
@@ -185,7 +185,7 @@
       </div>
     </div>
 
-    <div class="flex justify-between border-b-2 border-miru-gray-400 px-10 py-5 h-36">
+    <div class="flex justify-between border-b-2 border-miru-gray-400 px-10 py-5" style="min-height: 9rem;">
       <div class="w-1/4" style="padding-right: 1rem;">
         <p class="font-normal text-xs text-miru-dark-purple-1000 flex">Billed to</p>
         <div>


### PR DESCRIPTION
- Add explicit width constraints and word-wrap to all sections
- Set fixed table column widths to prevent NAME/DATE overlap
- Increase address container width and add text wrapping

Before Changes:
<img width="820" height="754" alt="Invoice PDF Before" src="https://github.com/user-attachments/assets/317dc616-d15f-4aff-bdbf-2d12a1619ae7" />

After Changes:
<img width="720" height="678" alt="Invoice PDF After" src="https://github.com/user-attachments/assets/5ad4ce94-1eb5-47c4-8cb4-10e10d2a0f5e" />

Fixes #2020 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved invoice PDF layout with explicit column sizing to ensure consistent rendering across formats.
  * Enhanced text wrapping and word-break behavior for company, address, and line-item fields to prevent overflow and truncation.
  * Adjusted spacing and padding in header, billing, and table sections for more reliable alignment and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->