### PR TITLE
fix: handle UTF-16LE encoding errors in Rack request parsing

### DIFF
--- a/config/initializers/encoding_sanitizer.rb
+++ b/config/initializers/encoding_sanitizer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "delegate"
+
 # Middleware to handle encoding compatibility issues in requests.
 # Fixes Encoding::CompatibilityError when UTF-16LE encoded data is sent in
 # query strings or POST bodies (e.g., from certain browsers, bots, or malformed requests).
@@ -9,14 +11,19 @@ class EncodingSanitizer
   end
 
   def call(env)
-    # Sanitize URL-related env vars
-    %w[QUERY_STRING REQUEST_URI PATH_INFO HTTP_REFERER].each do |key|
-      sanitize_encoding(env, key)
-    end
+    begin
+      # Sanitize URL-related env vars
+      %w[QUERY_STRING REQUEST_URI PATH_INFO HTTP_REFERER].each do |key|
+        sanitize_encoding(env, key)
+      end
 
-    # Wrap rack.input to sanitize POST body
-    if env["rack.input"]
-      env["rack.input"] = SanitizedInput.new(env["rack.input"])
+      # Wrap rack.input to sanitize POST body
+      if env["rack.input"]
+        env["rack.input"] = SanitizedInput.new(env["rack.input"])
+      end
+    rescue => e
+      # Log error but don't crash the request
+      Rails.logger.error("EncodingSanitizer error: #{e.message}")
     end
 
     @app.call(env)
@@ -41,35 +48,27 @@ class EncodingSanitizer
     end
 
     # Wrapper for rack.input that sanitizes encoding on read
-    class SanitizedInput
+    class SanitizedInput < SimpleDelegator
       def initialize(input)
-        @input = input
+        super(input)
       end
 
       def read(*args)
-        data = @input.read(*args)
+        data = __getobj__.read(*args)
         return data unless data.is_a?(String)
 
         sanitize(data)
       end
 
       def gets(*args)
-        data = @input.gets(*args)
+        data = __getobj__.gets(*args)
         return data unless data.is_a?(String)
 
         sanitize(data)
       end
 
       def each(&block)
-        @input.each { |line| block.call(sanitize(line)) }
-      end
-
-      def rewind
-        @input.rewind
-      end
-
-      def close
-        @input.close if @input.respond_to?(:close)
+        __getobj__.each { |line| block.call(sanitize(line)) }
       end
 
       private

--- a/spec/middleware/encoding_sanitizer_spec.rb
+++ b/spec/middleware/encoding_sanitizer_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe EncodingSanitizer do
         expect(status).to eq(200)
         expect(response_env["QUERY_STRING"].encoding).to eq(Encoding::UTF_8)
         expect(response_env["QUERY_STRING"]).to be_valid_encoding
+        expect(response_env["QUERY_STRING"]).to include("test")
+        expect(response_env["QUERY_STRING"]).to include("value")
       end
     end
 
@@ -127,6 +129,29 @@ RSpec.describe EncodingSanitizer do
         sanitized.each { |line| lines << line }
 
         expect(lines.all?(&:valid_encoding?)).to be true
+      end
+    end
+
+    describe "#gets" do
+      it "sanitizes line-by-line reads" do
+        body = "line1\nline2"
+        input = StringIO.new(body)
+        sanitized = described_class.new(input)
+
+        first_line = sanitized.gets
+        expect(first_line).to be_valid_encoding
+        expect(first_line).to eq("line1\n")
+      end
+    end
+
+    describe "#close" do
+      it "delegates close to underlying input" do
+        input = StringIO.new("test")
+        sanitized = described_class.new(input)
+
+        allow(input).to receive(:close)
+        sanitized.close
+        expect(input).to have_received(:close)
       end
     end
   end


### PR DESCRIPTION
Fixes production Encoding::CompatibilityError in rack/query_parser.rb
Closes #2031 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented encoding errors from malformed or non‑UTF‑8 request data by adding request sanitization early in request processing; query strings and request bodies are now normalized to valid UTF‑8 to avoid encoding-related failures.

* **Tests**
  * Added comprehensive tests for encoding sanitization covering multiple encodings, invalid byte sequences, and request-body/stream behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->