### PR TITLE
fix: prevent invoice update failure when removing line items without …

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,3 @@
+---
+ignore:
+  - GHSA-96qw-h329-v5rg

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem "premailer-rails", "~> 1.12"
 gem "money"
 
 # aws storage account
-gem "aws-sdk-s3", require: false
+gem "aws-sdk-s3", ">= 1.208.0", require: false
 
 # Ransack gem for advanced searching
 gem "ransack", "~> 4.1"
@@ -137,7 +137,7 @@ gem "rubyzip"
 
 gem "ahoy_matey"
 
-gem "httparty"
+gem "httparty", ">= 0.24.0"
 
 # Use google calendar for integration with Miru
 gem "google-api-client", require: "google/apis/calendar_v3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,21 +114,24 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.850.0)
-    aws-sdk-core (3.186.0)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1206.0)
+    aws-sdk-core (3.241.4)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.62.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.119.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
+      logger
+    aws-sdk-kms (1.121.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.212.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.2)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -173,6 +176,7 @@ GEM
     crass (1.0.6)
     css_parser (1.21.1)
       addressable
+    csv (3.3.5)
     data_migrate (9.3.0)
       activerecord (>= 6.1)
       railties (>= 6.1)
@@ -300,7 +304,8 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
-    httparty (0.21.0)
+    httparty (0.24.2)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
@@ -378,7 +383,8 @@ GEM
       i18n (>= 0.6.4, <= 2)
     msgpack (1.6.0)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
     multipart-post (2.3.0)
     mutex_m (0.3.0)
     net-imap (0.5.12)
@@ -722,7 +728,7 @@ DEPENDENCIES
   administrate
   ahoy_matey
   annotate
-  aws-sdk-s3
+  aws-sdk-s3 (>= 1.208.0)
   bootsnap (>= 1.4.4)
   bullet (~> 7.1)
   bundler-audit
@@ -743,7 +749,7 @@ DEPENDENCIES
   foreman
   google-api-client
   hash_dot
-  httparty
+  httparty (>= 0.24.0)
   image_processing (>= 1.2)
   jbuilder (~> 2.11)
   letter_opener

--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -73,8 +73,8 @@ class InvoiceLineItem < ApplicationRecord
   private
 
     def unlock_timesheet_entry
-      if invoice.draft?
-        timesheet_entry.update!(locked: false)
-      end
+      return unless invoice.draft? && timesheet_entry.present?
+
+      timesheet_entry.update!(locked: false)
     end
 end

--- a/app/services/timeoff_entries/index_service.rb
+++ b/app/services/timeoff_entries/index_service.rb
@@ -68,11 +68,7 @@ module TimeoffEntries
           net_days = net_hours.abs / @working_hours_per_day
           extra_hours = net_hours.abs % @working_hours_per_day
 
-          if net_hours.abs < @working_hours_per_day
-            label = "#{net_hours} hours"
-          else
-            label = "#{net_days} days #{extra_hours} hours"
-          end
+          label = "#{net_days} days #{extra_hours} hours"
 
           summary_object = {
             id: leave_type.id,

--- a/spec/requests/internal_api/v1/invoices/update_spec.rb
+++ b/spec/requests/internal_api/v1/invoices/update_spec.rb
@@ -28,6 +28,46 @@ RSpec.describe "InternalApi::V1::Invoices#update", type: :request do
         expect(json_response["reference"]).to eq("foo")
       end
 
+      context "when removing invoice line items without timesheet entries" do
+        let(:invoice) { company.invoices.first }
+        let!(:line_item_1) { create(:invoice_line_item, invoice:, timesheet_entry: nil) }
+        let!(:line_item_2) { create(:invoice_line_item, invoice:, timesheet_entry: nil) }
+
+        it "successfully removes line items" do
+          send_request :patch, internal_api_v1_invoice_path(
+            id: invoice.id, params: {
+              invoice: {
+                invoice_line_items_attributes: [
+                  { id: line_item_1.id, _destroy: true },
+                  { id: line_item_2.id, _destroy: true }
+                ]
+              }
+            }), headers: auth_headers(user)
+          expect(response).to have_http_status(:ok)
+          expect(invoice.reload.invoice_line_items).not_to include(line_item_1, line_item_2)
+        end
+      end
+
+      context "when removing invoice line items with timesheet entries" do
+        let(:invoice) { company.invoices.first }
+        let(:timesheet_entry) { create(:timesheet_entry, locked: true) }
+        let!(:line_item) { create(:invoice_line_item, invoice:, timesheet_entry:) }
+
+        it "successfully removes line items and unlocks timesheet entries" do
+          send_request :patch, internal_api_v1_invoice_path(
+            id: invoice.id, params: {
+              invoice: {
+                invoice_line_items_attributes: [
+                  { id: line_item.id, _destroy: true }
+                ]
+              }
+            }), headers: auth_headers(user)
+          expect(response).to have_http_status(:ok)
+          expect(invoice.reload.invoice_line_items).not_to include(line_item)
+          expect(timesheet_entry.reload.locked).to be false
+        end
+      end
+
       context "when client doesn't exist" do
         it "throws 404" do
           send_request :patch, internal_api_v1_invoice_path(


### PR DESCRIPTION
…timesheet entries

- Fix invoice line item deletion to handle items without associated timesheet entries
- Update InvoiceLineItem model to properly manage orphaned line items
- Add TimeoffEntries index service improvements
- Add specs for invoice line item deletion scenarios
- Update invoice update request specs
- Skip shakapacker vulnerability GHSA-96qw-h329-v5rg in bundle-audit
- Update Gemfile dependencies
- ignore shakapacker GHSA-96qw-h329-v5rg vulnerability in bundle-audit
- Add .bundler-audit.yml to skip the shakapacker environment variable leak
- vulnerability (GHSA-96qw-h329-v5rg) until upgrade to version 9.5.0+ is planned.

Resolves #2039
Resolves #2040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS S3 and HTTParty gem dependencies with minimum version constraints.
  * Added security advisory configuration.

* **Improvements**
  * Enhanced invoice line item handling and timesheet entry management through optimized processes.

* **Tests**
  * Added comprehensive test coverage for timesheet entry behavior and invoice removal operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->