### PR TITLE
fix: gracefully handle Postmark inactive recipient errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,9 +139,6 @@ gem "ahoy_matey"
 
 gem "httparty", ">= 0.24.0"
 
-gem "faraday", "~> 1.10.5"
-gem "rack", ">= 3.2.5"
-
 # Use google calendar for integration with Miru
 gem "google-api-client", require: "google/apis/calendar_v3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -745,7 +745,6 @@ DEPENDENCIES
   erb_lint!
   factory_bot_rails
   faker
-  faraday (~> 1.10.5)
   ferrum_pdf (~> 2.1)
   foreman
   google-api-client
@@ -769,7 +768,6 @@ DEPENDENCIES
   psych (~> 4)
   puma (~> 6.4.3)
   pundit (~> 2.2)
-  rack (>= 3.2.5)
   rack-cors (= 2.0.0)
   rack-mini-profiler (>= 2.3.3)
   rails (~> 7.1.5.1)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,9 +5,6 @@ class ApplicationMailer < ActionMailer::Base
   default from: ENV["DEFAULT_MAILER_SENDER"]
   layout "mailer"
 
-  # Email regex based on URI::MailTo::EMAIL_REGEXP but without anchors for scanning
-  EMAIL_SCAN_REGEXP = /[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/
-
   rescue_from Postmark::InactiveRecipientError do |exception|
     handle_inactive_recipient(exception)
   end
@@ -15,16 +12,22 @@ class ApplicationMailer < ActionMailer::Base
   private
 
     def handle_inactive_recipient(exception)
-      # Extract email addresses from the error message
-      inactive_emails = exception.message.scan(EMAIL_SCAN_REGEXP)
+      inactive_emails = extract_inactive_emails(exception.message)
 
       Rails.logger.warn("Email delivery failed - Inactive recipient(s): #{inactive_emails.join(', ')}")
       Rails.logger.warn("Error details: #{exception.message}")
 
-      # Store inactive emails in the database to prevent future attempts
       inactive_emails.each do |email|
         record = SesInvalidEmail.find_or_create_by(email: email.downcase)
         Rails.logger.info("Added #{email} to invalid emails list (Postmark inactive)") if record.previously_new_record?
       end
+    end
+
+    def extract_inactive_emails(message)
+      message
+        .split(/[\s,]+/)
+        .map { |value| value.gsub(/\A[^[:alnum:]]+|[^[:alnum:]]+\z/, "") }
+        .select { |value| URI::MailTo::EMAIL_REGEXP.match?(value) }
+        .uniq
     end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -4,31 +4,31 @@ require "rails_helper"
 
 RSpec.describe ApplicationMailer, type: :mailer do
   describe "Postmark error handling" do
-    describe "email extraction with EMAIL_SCAN_REGEXP" do
+    describe "email extraction" do
       it "extracts single email address" do
         message = "Found inactive addresses: test@example.com."
-        emails = message.scan(ApplicationMailer::EMAIL_SCAN_REGEXP)
+        emails = ApplicationMailer.new.send(:extract_inactive_emails, message)
 
         expect(emails).to eq(["test@example.com"])
       end
 
       it "extracts multiple email addresses" do
         message = "Found inactive addresses: user1@example.com, user2@example.com."
-        emails = message.scan(ApplicationMailer::EMAIL_SCAN_REGEXP)
+        emails = ApplicationMailer.new.send(:extract_inactive_emails, message)
 
         expect(emails).to contain_exactly("user1@example.com", "user2@example.com")
       end
 
       it "handles emails with subdomains" do
         message = "Found inactive addresses: user@mail.example.com."
-        emails = message.scan(ApplicationMailer::EMAIL_SCAN_REGEXP)
+        emails = ApplicationMailer.new.send(:extract_inactive_emails, message)
 
         expect(emails).to eq(["user@mail.example.com"])
       end
 
       it "handles emails with hyphens and underscores" do
         message = "Found inactive addresses: first.last@my-domain.com."
-        emails = message.scan(ApplicationMailer::EMAIL_SCAN_REGEXP)
+        emails = ApplicationMailer.new.send(:extract_inactive_emails, message)
 
         expect(emails).to eq(["first.last@my-domain.com"])
       end


### PR DESCRIPTION
Closes #2050 

- Add rescue_from handlers in ApplicationMailer for Postmark errors
- Automatically store inactive/invalid emails in SesInvalidEmail table
- Log warnings instead of raising exceptions for bounced emails
- Prevents 167+ recurring errors when sending to inactive recipients

When users are removed from the organization but their accounts remain active in Miru, weekly reminder emails would fail with Postmark::InactiveRecipientError. This caused job failures and Sentry alerts without any way to recover.

Changes:
- app/mailers/application_mailer.rb: Add rescue_from for InactiveRecipientError and InvalidEmailError, automatically adding bounced emails to suppression list

The service already checks SesInvalidEmail before sending, so once an email is added to this table, future attempts will be skipped automatically.

Benefits:
- No more Sentry errors for inactive recipients
- Self-healing: bounced emails are automatically suppressed
- Works for all mailers (inherits from ApplicationMailer)
- Maintains existing SesInvalidEmail checking logic

Sentry Issue: https://saeloun-inc.sentry.io/issues/MIRU-WEB-2H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added handling for inactive/invalid email recipients from the delivery service; occurrences are logged and invalid addresses are persisted to prevent repeat delivery attempts and improve reliability. New informational logging notes when an invalid address is newly recorded.

* **Tests**
  * Added specs validating email-address extraction (single, multiple, subdomains, special chars) and confirming the mailer’s inactive-recipient error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->