### PR TITLE
Fix: S3 checksum conflict in ActiveStorage uploads (MIRU-WEB-3G)

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,6 +14,11 @@ cloudflare:
   region: <%= ENV['CLOUDFLARE_R2_REGION'] %>
   bucket: <%= ENV['CLOUDFLARE_R2_BUCKET_NAME'] %>
   endpoint: <%= ENV['CLOUDFLARE_R2_ENDPOINT'] %>
+  # Disable automatic checksum calculation to avoid conflicts with content_md5
+  # AWS SDK >= 1.208.0 adds checksum_algorithm by default, which conflicts with ActiveStorage's content_md5
+  # Setting to 'when_required' reverts to previous behavior compatible with S3-compatible services
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
fixing "You can only specify one non-default checksum at a time" error with aws-sdk-s3 >= 1.208.0.

Closes #2052 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare S3 storage configuration to optimize checksum validation behavior, improving compatibility with S3-compatible services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->