### PR TITLE
The ClientPaymentMailer#payment method throws a Postmark::InvalidEmai…

### DIFF
--- a/app/mailers/client_payment_mailer.rb
+++ b/app/mailers/client_payment_mailer.rb
@@ -34,6 +34,6 @@ class ClientPaymentMailer < ApplicationMailer
     end
 
     def can_send_mail?
-      @invoice.client_payment_sent_at.nil?
+      @invoice.client_payment_sent_at.nil? && @invoice.client.email.present?
     end
 end

--- a/spec/mailers/client_payment_mailer_spec.rb
+++ b/spec/mailers/client_payment_mailer_spec.rb
@@ -20,5 +20,18 @@ RSpec.describe ClientPaymentMailer, type: :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to match("Payment receipt")
     end
+
+    context "when client has no email" do
+      let(:client) { create :client, company:, email: nil }
+
+      it "does not send the email" do
+        expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+      end
+
+      it "does not update client_payment_sent_at" do
+        mail.deliver_now
+        expect(invoice.reload.client_payment_sent_at).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
…lRequestError: Zero recipients specified error when attempting to send a payment confirmation email to a client that has no email address configured.

Closes #2062 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment email delivery by adding validation to prevent sending emails when a client email address is missing.

* **Tests**
  * Added comprehensive test coverage for payment email scenarios when client contact information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->