### PR TITLE
feat(chat): add Chatbase identity verification endpoint

### DIFF
--- a/app/controllers/api/v1/chatbase_tokens_controller.rb
+++ b/app/controllers/api/v1/chatbase_tokens_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Api::V1::ChatbaseTokensController < Api::V1::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+
+  def show
+    if current_user
+      token = JWT.encode(
+        {
+          user_id: current_user.id,
+          email: current_user.email,
+          name: current_user.full_name,
+          company: current_user.current_workspace&.name,
+          exp: 1.hour.from_now.to_i
+        },
+        ENV["CHATBASE_IDENTITY_SECRET"],
+        "HS256"
+      )
+      render json: { token: }
+    else
+      head 401
+    end
+  end
+end

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { minToHHMM } from "helpers";
-import { Trash, PencilSimple, Clock, Briefcase } from "phosphor-react";
+import { Trash, PencilSimple, Clock, Briefcase, Play } from "phosphor-react";
 import { Card, CardContent } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -12,6 +12,7 @@ interface props {
   id: number;
   client: string;
   project: string;
+  projectId: number;
   note: string;
   duration: number;
   source_label?: string;
@@ -21,6 +22,12 @@ interface props {
   bill_status: string;
   setNewEntryView: any;
   handleDuplicate: any;
+  handleResumeTimer: (entry: {
+    client: string;
+    project: string;
+    projectId: number;
+    note: string;
+  }) => void;
 }
 
 const canEditTimeEntry = (billStatus, role) =>
@@ -30,6 +37,7 @@ const EntryCard: React.FC<props> = ({
   id,
   client,
   project,
+  projectId,
   note,
   duration,
   source_label,
@@ -39,6 +47,7 @@ const EntryCard: React.FC<props> = ({
   bill_status,
   setNewEntryView,
   handleDuplicate,
+  handleResumeTimer,
 }) => {
   const { isDesktop, companyRole } = useUserContext();
   const sourceSkill = source_metadata?.skill;
@@ -172,32 +181,48 @@ const EntryCard: React.FC<props> = ({
             </div>
 
             {canEditTimeEntry(bill_status, companyRole) && (
-              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all duration-200">
+              <div className="flex items-center gap-2">
                 <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 hover:bg-accent hover:text-primary"
+                  variant="outline"
+                  size="sm"
+                  className="h-9"
+                  data-testid="resume-timer-entry"
                   onClick={e => {
                     e.stopPropagation();
-                    setEditEntryId(id);
-                    setNewEntryView(true);
+                    handleResumeTimer({ client, project, projectId, note });
                   }}
-                  title="Edit entry"
+                  title="Resume timer"
                 >
-                  <PencilSimple className="h-4 w-4" />
+                  <Play className="mr-1 h-4 w-4" />
+                  Resume
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
-                  onClick={e => {
-                    e.stopPropagation();
-                    handleDeleteEntry(id);
-                  }}
-                  title="Delete entry"
-                >
-                  <Trash className="h-4 w-4" />
-                </Button>
+                <div className="flex items-center gap-1 opacity-0 transition-all duration-200 group-hover:opacity-100">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 hover:bg-accent hover:text-primary"
+                    onClick={e => {
+                      e.stopPropagation();
+                      setEditEntryId(id);
+                      setNewEntryView(true);
+                    }}
+                    title="Edit entry"
+                  >
+                    <PencilSimple className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
+                    onClick={e => {
+                      e.stopPropagation();
+                      handleDeleteEntry(id);
+                    }}
+                    title="Delete entry"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
             )}
           </div>

--- a/app/javascript/src/components/TimeTracking/EntryDetailsModal.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryDetailsModal.tsx
@@ -21,6 +21,12 @@ interface EntryDetailsModalProps {
   setEditEntryId: (id: number) => void;
   handleDeleteEntry: (id: number) => void;
   handleDuplicate: (entry: TimeEntry) => void;
+  handleResumeTimer: (entry: {
+    client: string;
+    project: string;
+    projectId: number;
+    note?: string;
+  }) => void;
   setNewEntryView: (view: boolean) => void;
   newEntryView: boolean;
   // Form props
@@ -48,6 +54,7 @@ const EntryDetailsModal: React.FC<EntryDetailsModalProps> = ({
   setEditEntryId,
   handleDeleteEntry,
   handleDuplicate,
+  handleResumeTimer,
   setNewEntryView,
   newEntryView,
   // Form props
@@ -146,8 +153,10 @@ const EntryDetailsModal: React.FC<EntryDetailsModalProps> = ({
                 ) : (
                   <EntryCard
                     key={entry.id}
+                    projectId={entry.project_id}
                     handleDeleteEntry={handleDeleteEntry}
                     handleDuplicate={handleDuplicate}
+                    handleResumeTimer={handleResumeTimer}
                     setEditEntryId={setEditEntryId}
                     setNewEntryView={setNewEntryView}
                     {...entry}

--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -24,6 +24,7 @@ import {
 import { Card } from "../ui/card";
 import { cn } from "../../lib/utils";
 import { getValueFromLocalStorage, setToLocalStorage } from "utils/storage";
+import { Star, StarHalf } from "phosphor-react";
 
 import MobileEntryForm from "./MobileView/MobileEntryForm";
 
@@ -76,6 +77,20 @@ const AddEntry: React.FC<Iprops> = ({
   const displaySelectedDate = parsedSelectedDate.isValid()
     ? parsedSelectedDate.format(`dddd, ${dateFormat}`)
     : selectedFullDate;
+  const favoriteStorageKey = `miru_time_entry_favorites_${selectedEmployeeId}`;
+  const [favoriteShortcutKeys, setFavoriteShortcutKeys] = useState<string[]>(
+    () => {
+      if (typeof window === "undefined") return [];
+
+      try {
+        const saved = localStorage.getItem(favoriteStorageKey);
+
+        return saved ? JSON.parse(saved) : [];
+      } catch {
+        return [];
+      }
+    }
+  );
 
   const allEntries = Object.values(entryList || {})
     .flat()
@@ -110,6 +125,13 @@ const AddEntry: React.FC<Iprops> = ({
     }, [])
     .slice(0, 4);
   const latestTrackedEntry = allEntries[0];
+  const favoriteEntryShortcuts = recentEntryShortcuts.filter(entry =>
+    favoriteShortcutKeys.includes(entry.shortcutKey)
+  );
+
+  const visibleRecentEntryShortcuts = recentEntryShortcuts.filter(
+    entry => !favoriteShortcutKeys.includes(entry.shortcutKey)
+  );
 
   const handleFillData = () => {
     if (!editEntryId) return;
@@ -251,6 +273,15 @@ const AddEntry: React.FC<Iprops> = ({
     }
   }, [debouncedNote, duration, client, project, projectId, taskType]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    localStorage.setItem(
+      favoriteStorageKey,
+      JSON.stringify(favoriteShortcutKeys)
+    );
+  }, [favoriteShortcutKeys, favoriteStorageKey]);
+
   const applyRecentEntry = entry => {
     setClient(entry.client);
     setProject(entry.project);
@@ -258,6 +289,14 @@ const AddEntry: React.FC<Iprops> = ({
     setTaskType(entry.task_type || "development");
     setNote(entry.note || "");
     setDuration(minToHHMM(entry.duration || 0));
+  };
+
+  const toggleFavoriteShortcut = shortcutKey => {
+    setFavoriteShortcutKeys(current =>
+      current.includes(shortcutKey)
+        ? current.filter(key => key !== shortcutKey)
+        : [...current, shortcutKey].slice(-6)
+    );
   };
 
   const handleDuplicateLastEntry = async () => {
@@ -319,7 +358,51 @@ const AddEntry: React.FC<Iprops> = ({
             </Button>
           )}
         </div>
-        {isNewEntry && recentEntryShortcuts.length > 0 && (
+        {isNewEntry && favoriteEntryShortcuts.length > 0 && (
+          <div className="mb-4 rounded-lg border border-border bg-card/60 px-4 py-4">
+            <div className="mb-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Favorites
+              </p>
+              <p className="text-sm font-medium text-foreground">
+                Pin the combinations you use all the time.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {favoriteEntryShortcuts.map(entry => (
+                <div
+                  key={entry.shortcutKey}
+                  className="flex max-w-full items-center gap-1 rounded-md border border-border bg-background p-1"
+                >
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    data-testid="favorite-entry-shortcut"
+                    className="h-auto max-w-full justify-start whitespace-normal px-3 py-2 text-left"
+                    onClick={() => applyRecentEntry(entry)}
+                  >
+                    <span className="truncate">
+                      {entry.client} / {entry.project} ·{" "}
+                      {minToHHMM(entry.duration)}
+                    </span>
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0"
+                    data-testid="favorite-entry-toggle"
+                    onClick={() => toggleFavoriteShortcut(entry.shortcutKey)}
+                  >
+                    <StarHalf className="h-4 w-4" weight="fill" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {isNewEntry && visibleRecentEntryShortcuts.length > 0 && (
           <div className="mb-6 rounded-lg border border-border bg-card/60 px-4 py-4">
             <div className="mb-3 flex items-center justify-between gap-3">
               <div>
@@ -333,21 +416,34 @@ const AddEntry: React.FC<Iprops> = ({
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
-              {recentEntryShortcuts.map(entry => (
-                <Button
-                  key={entry.shortcutKey}
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  data-testid="recent-entry-shortcut"
-                  className="h-auto max-w-full justify-start whitespace-normal px-3 py-2 text-left"
-                  onClick={() => applyRecentEntry(entry)}
-                >
-                  <span className="truncate">
-                    {entry.client} / {entry.project} ·{" "}
-                    {minToHHMM(entry.duration)}
-                  </span>
-                </Button>
+              {visibleRecentEntryShortcuts.map(entry => (
+                <div key={entry.shortcutKey}>
+                  <div className="flex max-w-full items-center gap-1 rounded-md border border-border bg-background p-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      data-testid="recent-entry-shortcut"
+                      className="h-auto max-w-full justify-start whitespace-normal px-3 py-2 text-left"
+                      onClick={() => applyRecentEntry(entry)}
+                    >
+                      <span className="truncate">
+                        {entry.client} / {entry.project} ·{" "}
+                        {minToHHMM(entry.duration)}
+                      </span>
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0"
+                      data-testid="favorite-entry-toggle"
+                      onClick={() => toggleFavoriteShortcut(entry.shortcutKey)}
+                    >
+                      <Star className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
               ))}
             </div>
           </div>

--- a/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
+++ b/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import dayjs from "dayjs";
 import EntryCard from "./EntryCard";
 import customParseFormat from "dayjs/plugin/customParseFormat";
+import { Button } from "../ui/button";
 
 dayjs.extend(customParseFormat);
 
@@ -10,8 +11,11 @@ interface TimeEntriesDisplayProps {
   entryList: any;
   handleDeleteEntry: (id: number) => void;
   handleDuplicate: (entry: any) => void;
+  handleResumeTimer: (entry: any) => void;
   setEditEntryId: (id: number) => void;
   setNewEntryView: (value: boolean) => void;
+  dayInfo?: any[];
+  view?: string;
 }
 
 const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
@@ -19,9 +23,13 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   entryList,
   handleDeleteEntry,
   handleDuplicate,
+  handleResumeTimer,
   setEditEntryId,
   setNewEntryView,
+  dayInfo = [],
+  view = "week",
 }) => {
+  const [reviewMode, setReviewMode] = useState<"day" | "week">("day");
   const dateFormats = [
     "YYYY-MM-DD",
     "MM-DD-YYYY",
@@ -33,10 +41,24 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   const isoDate = parsedDate.format("YYYY-MM-DD");
   const entries = entryList[isoDate];
   const hasEntries = entries && entries.length > 0;
+  const weekEntries = (dayInfo || []).flatMap(day => {
+    const dayDate = dayjs(day.fullDate, dateFormats, true);
+    const dayKey = dayDate.isValid()
+      ? dayDate.format("YYYY-MM-DD")
+      : day.fullDate;
+    const dayEntries = entryList[dayKey] || [];
 
-  if (hasEntries) {
-    // Calculate total duration for the day
-    const totalDuration = entries.reduce(
+    return dayEntries.map(entry => ({
+      ...entry,
+      display_date: dayKey,
+    }));
+  });
+  const canShowWeekReview = view === "week" && weekEntries.length > 0;
+  const reviewEntries = reviewMode === "week" ? weekEntries : entries || [];
+  const shouldRenderReviewPanel = hasEntries || canShowWeekReview;
+
+  if (shouldRenderReviewPanel) {
+    const totalDuration = reviewEntries.reduce(
       (sum: number, entry: any) => sum + entry.duration,
       0
     );
@@ -51,40 +73,86 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
               {parsedDate.format("dddd")}
             </h3>
             <p className="mt-2 text-base font-medium text-muted-foreground">
-              {parsedDate.format("MMMM D, YYYY")}
+              {reviewMode === "week"
+                ? `${dayjs(dayInfo[0]?.fullDate, dateFormats, true).format(
+                    "MMM D"
+                  )} to ${dayjs(dayInfo[6]?.fullDate, dateFormats, true).format(
+                    "MMM D, YYYY"
+                  )}`
+                : parsedDate.format("MMMM D, YYYY")}
             </p>
           </div>
-          <div className="rounded-2xl border border-border bg-muted/40 px-8 py-4 text-right">
-            <div className="mb-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-              Day Total
-            </div>
-            <div className="text-2xl font-semibold tracking-tight text-primary tabular-nums">
-              {totalHours}h {totalMinutes > 0 ? `${totalMinutes}m` : ""}
-            </div>
-            <div className="mt-2 text-sm font-medium text-muted-foreground">
-              {entries.length} {entries.length === 1 ? "entry" : "entries"}
+          <div className="flex items-center gap-3">
+            {canShowWeekReview && (
+              <div className="flex items-center gap-2 rounded-full border border-border bg-card p-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={reviewMode === "day" ? "default" : "ghost"}
+                  data-testid="time-review-day"
+                  onClick={() => setReviewMode("day")}
+                >
+                  Selected Day
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={reviewMode === "week" ? "default" : "ghost"}
+                  data-testid="time-review-week"
+                  onClick={() => setReviewMode("week")}
+                >
+                  This Week
+                </Button>
+              </div>
+            )}
+            <div className="rounded-2xl border border-border bg-muted/40 px-8 py-4 text-right">
+              <div className="mb-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+                {reviewMode === "week" ? "Week Total" : "Day Total"}
+              </div>
+              <div className="text-2xl font-semibold tracking-tight text-primary tabular-nums">
+                {totalHours}h {totalMinutes > 0 ? `${totalMinutes}m` : ""}
+              </div>
+              <div className="mt-2 text-sm font-medium text-muted-foreground">
+                {reviewEntries.length}{" "}
+                {reviewEntries.length === 1 ? "entry" : "entries"}
+              </div>
             </div>
           </div>
         </div>
 
         <div className="space-y-4">
-          {entries.map((entry: any, index: number) => (
-            <EntryCard
-              key={entry.id || index}
-              id={entry.id}
-              client={entry.client}
-              project={entry.project}
-              note={entry.note}
-              duration={entry.duration}
-              source_label={entry.source_label}
-              source_metadata={entry.source_metadata}
-              bill_status={entry.bill_status}
-              handleDeleteEntry={handleDeleteEntry}
-              handleDuplicate={handleDuplicate}
-              setEditEntryId={setEditEntryId}
-              setNewEntryView={setNewEntryView}
-            />
-          ))}
+          {reviewEntries.length > 0 ? (
+            reviewEntries.map((entry: any, index: number) => (
+              <EntryCard
+                key={entry.id || index}
+                id={entry.id}
+                client={entry.client}
+                project={entry.project}
+                projectId={entry.project_id}
+                note={entry.note}
+                duration={entry.duration}
+                source_label={entry.source_label}
+                source_metadata={entry.source_metadata}
+                bill_status={entry.bill_status}
+                handleResumeTimer={handleResumeTimer}
+                handleDeleteEntry={handleDeleteEntry}
+                handleDuplicate={handleDuplicate}
+                setEditEntryId={setEditEntryId}
+                setNewEntryView={setNewEntryView}
+              />
+            ))
+          ) : (
+            <div className="rounded-xl border-2 border-dashed border-border bg-muted/30 p-12 text-center">
+              <div className="mx-auto max-w-md">
+                <h3 className="mb-2 text-xl font-semibold text-foreground">
+                  No entries for the selected day
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Switch to This Week to review everything you logged this week.
+                </p>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -15,6 +15,7 @@ import { sendGAPageView } from "utils/googleAnalytics";
 import { Button } from "../ui/button";
 import { Toastr } from "../ui/toastr";
 import FloatingTimer from "../TimesheetEntries/FloatingTimer";
+import { startTimerFromEntry } from "utils/timeTrackingTimer";
 
 import WeekDaySelector from "./WeekDaySelector";
 import EntryForm from "./EntryForm";
@@ -79,6 +80,8 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   >(null);
   const [loadedRangeKey, setLoadedRangeKey] = useState<string>("");
   const [copyingLastWeek, setCopyingLastWeek] = useState<boolean>(false);
+  const [timerSyncKey, setTimerSyncKey] = useState<number>(0);
+  const [resumeTimerEntry, setResumeTimerEntry] = useState<any>(null);
   const dateParseFormats = [
     dateFormat,
     "YYYY-MM-DD",
@@ -599,6 +602,34 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     await refreshVisibleEntries();
   };
 
+  const handleResumeTimer = ({
+    client,
+    project,
+    projectId,
+    note,
+  }: {
+    client: string;
+    project: string;
+    projectId: number;
+    note?: string;
+  }) => {
+    startTimerFromEntry({
+      client,
+      project,
+      projectId,
+      description: note,
+    });
+    setTimerSyncKey(current => current + 1);
+    setResumeTimerEntry({
+      client,
+      project,
+      projectId,
+      description: note,
+      resumeAt: Date.now(),
+    });
+    Toastr.success("Timer resumed from entry");
+  };
+
   const handleCopyLastWeek = async () => {
     if (view !== "week" || dayInfo.length === 0) return;
 
@@ -779,6 +810,8 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
               <FloatingTimer
                 onSaveEntry={handleTimerSaved}
                 placement="inline"
+                externalSyncKey={timerSyncKey}
+                resumeFromEntry={resumeTimerEntry}
               />
             )}
             {view === "week" && (
@@ -873,8 +906,11 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
               entryList={entryList}
               handleDeleteEntry={handleDeleteEntry}
               handleDuplicate={handleDuplicate}
+              handleResumeTimer={handleResumeTimer}
               setEditEntryId={setEditEntryId}
               setNewEntryView={setNewEntryView}
+              dayInfo={dayInfo}
+              view={view}
             />
           </div>
         )}
@@ -902,6 +938,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
         setEditEntryId={setEditEntryId}
         handleDeleteEntry={handleDeleteEntry}
         handleDuplicate={handleDuplicate}
+        handleResumeTimer={handleResumeTimer}
         setNewEntryView={setNewEntryView}
         newEntryView={newEntryView}
         // Form props
@@ -919,7 +956,13 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
         setSelectedFullDate={setSelectedFullDate}
         setUpdateView={setUpdateView}
       />
-      {!isDesktop && <FloatingTimer onSaveEntry={handleTimerSaved} />}
+      {!isDesktop && (
+        <FloatingTimer
+          onSaveEntry={handleTimerSaved}
+          externalSyncKey={timerSyncKey}
+          resumeFromEntry={resumeTimerEntry}
+        />
+      )}
     </div>
   );
 

--- a/app/javascript/src/components/TimesheetEntries/FloatingTimer.tsx
+++ b/app/javascript/src/components/TimesheetEntries/FloatingTimer.tsx
@@ -33,27 +33,33 @@ import { toast } from "sonner";
 import { useUserContext } from "../../context/UserContext";
 import { timesheetEntryApi } from "apis/api";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
+import {
+  loadStoredTimerState,
+  persistTimerState,
+  clearStoredTimerState,
+  defaultTimerState,
+} from "utils/timeTrackingTimer";
 
 interface FloatingTimerProps {
   onSaveEntry?: (entry: any) => void;
   placement?: "floating" | "inline";
+  externalSyncKey?: number;
+  resumeFromEntry?: {
+    client: string;
+    project: string;
+    projectId: number;
+    description?: string;
+    resumeAt: number;
+  } | null;
 }
 
-interface TimerState {
-  isRunning: boolean;
-  startTime: number | null;
-  elapsedTime: number;
-  project: string;
-  client: string;
-  description: string;
-  projectId: number;
-}
-
-const TIMER_STORAGE_KEY = "miru_timer_state";
+type TimerState = ReturnType<typeof defaultTimerState>;
 
 const FloatingTimer: React.FC<FloatingTimerProps> = ({
   onSaveEntry,
   placement = "floating",
+  externalSyncKey = 0,
+  resumeFromEntry = null,
 }) => {
   const { user, company } = useUserContext();
   const queryClient = useQueryClient();
@@ -61,27 +67,7 @@ const FloatingTimer: React.FC<FloatingTimerProps> = ({
 
   const [isMinimized, setIsMinimized] = useState(false);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
-  const [timer, setTimer] = useState<TimerState>(() => {
-    const saved = localStorage.getItem(TIMER_STORAGE_KEY);
-    if (saved) {
-      const parsed = JSON.parse(saved);
-
-      return {
-        ...parsed,
-        startTime: parsed.isRunning ? Date.now() - parsed.elapsedTime : null,
-      };
-    }
-
-    return {
-      isRunning: false,
-      startTime: null,
-      elapsedTime: 0,
-      project: "",
-      client: "",
-      description: "",
-      projectId: 0,
-    };
-  });
+  const [timer, setTimer] = useState<TimerState>(() => loadStoredTimerState());
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -115,10 +101,27 @@ const FloatingTimer: React.FC<FloatingTimerProps> = ({
     },
   });
 
-  // Save timer state to localStorage
   useEffect(() => {
-    localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(timer));
+    persistTimerState(timer);
   }, [timer]);
+
+  useEffect(() => {
+    setTimer(loadStoredTimerState());
+  }, [externalSyncKey]);
+
+  useEffect(() => {
+    if (!resumeFromEntry) return;
+
+    setTimer({
+      isRunning: true,
+      startTime: resumeFromEntry.resumeAt,
+      elapsedTime: 0,
+      client: resumeFromEntry.client,
+      project: resumeFromEntry.project,
+      description: resumeFromEntry.description || "",
+      projectId: resumeFromEntry.projectId,
+    });
+  }, [resumeFromEntry]);
 
   // Timer logic
   useEffect(() => {
@@ -183,16 +186,8 @@ const FloatingTimer: React.FC<FloatingTimerProps> = ({
   };
 
   const resetTimer = () => {
-    setTimer({
-      isRunning: false,
-      startTime: null,
-      elapsedTime: 0,
-      project: "",
-      client: "",
-      description: "",
-      projectId: 0,
-    });
-    localStorage.removeItem(TIMER_STORAGE_KEY);
+    setTimer(defaultTimerState());
+    clearStoredTimerState();
     toast.info("Timer reset");
   };
 

--- a/app/javascript/src/utils/timeTrackingTimer.ts
+++ b/app/javascript/src/utils/timeTrackingTimer.ts
@@ -1,0 +1,90 @@
+export const TIMER_STORAGE_KEY = "miru_timer_state";
+export const TIMER_SYNC_EVENT = "miru:timer-sync";
+
+export interface StoredTimerState {
+  isRunning: boolean;
+  startTime: number | null;
+  elapsedTime: number;
+  project: string;
+  client: string;
+  description: string;
+  projectId: number;
+}
+
+export const defaultTimerState = (): StoredTimerState => ({
+  isRunning: false,
+  startTime: null,
+  elapsedTime: 0,
+  project: "",
+  client: "",
+  description: "",
+  projectId: 0,
+});
+
+const dispatchTimerSync = () => {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(TIMER_SYNC_EVENT));
+  }
+};
+
+export const loadStoredTimerState = (): StoredTimerState => {
+  if (typeof window === "undefined") return defaultTimerState();
+
+  const saved = localStorage.getItem(TIMER_STORAGE_KEY);
+  if (!saved) return defaultTimerState();
+
+  try {
+    const parsed = JSON.parse(saved);
+
+    return {
+      ...defaultTimerState(),
+      ...parsed,
+      startTime:
+        parsed.isRunning && parsed.startTime
+          ? parsed.startTime
+          : parsed.isRunning
+          ? Date.now() - (parsed.elapsedTime || 0)
+          : null,
+    };
+  } catch {
+    return defaultTimerState();
+  }
+};
+
+export const persistTimerState = (timer: StoredTimerState) => {
+  if (typeof window === "undefined") return;
+
+  localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(timer));
+  dispatchTimerSync();
+};
+
+export const clearStoredTimerState = () => {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem(TIMER_STORAGE_KEY);
+  dispatchTimerSync();
+};
+
+export const startTimerFromEntry = ({
+  client,
+  project,
+  description,
+  projectId,
+}: {
+  client: string;
+  project: string;
+  description?: string;
+  projectId: number;
+}) => {
+  const startedAt = Date.now();
+
+  persistTimerState({
+    isRunning: true,
+    startTime: startedAt,
+    elapsedTime: 0,
+    client,
+    project,
+    description: description || "",
+    projectId,
+  });
+};

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,12 +7,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "https://miru.so", "https://www.miru.so", /\Ahttps:\/\/.*\.miru-marketing-website\.pages\.dev\z/
+
+    resource "/api/v1/chatbase_token",
+      headers: :any,
+      methods: [:get, :options],
+      credentials: true
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -31,6 +31,8 @@ namespace :api, defaults: { format: "json" } do
       end
     end
 
+    resource :chatbase_token, only: [:show]
+
     resources :clients, only: [:index, :update, :destroy, :show, :create] do
       collection do
         get "invoices", to: "clients/invoices#index"

--- a/spec/system/time_tracking/add_entry_spec.rb
+++ b/spec/system/time_tracking/add_entry_spec.rb
@@ -280,4 +280,63 @@ RSpec.describe "Time Tracking - Add Entry", type: :system, js: true do
     find("button[aria-label^='#{target_button_label}']", wait: 10).click
     expect(page).to have_content(source_note, wait: 10)
   end
+
+  it "pins a recent shortcut into favorites" do
+    recent_note = "Pinned shortcut work"
+    create(
+      :timesheet_entry,
+      user:,
+      project:,
+      work_date: Date.current - 1.day,
+      duration: 45,
+      note: recent_note
+    )
+
+    visit "/time-tracking"
+    expect(page).to have_css("#react-root", wait: 10)
+    switch_to("Week")
+
+    click_button "Add Entry"
+    expect(page).to have_css("[data-testid='recent-entry-shortcut']", wait: 10)
+    first("[data-testid='favorite-entry-toggle']").click
+
+    expect(page).to have_text(/Favorites/i, wait: 10)
+    expect(page).to have_css("[data-testid='favorite-entry-shortcut']", wait: 10)
+    expect(page).to have_css("[data-testid='favorite-entry-shortcut']", wait: 10)
+    expect(page).to have_content("Acme Client / Harvest-style Project · 00:45", wait: 10)
+  end
+
+  it "switches to week review and shows entries from multiple days" do
+    monday = Date.current.beginning_of_week(:monday)
+    wednesday = monday + 2.days
+
+    create(
+      :timesheet_entry,
+      user:,
+      project:,
+      work_date: monday,
+      duration: 60,
+      note: "Monday batch"
+    )
+    create(
+      :timesheet_entry,
+      user:,
+      project:,
+      work_date: wednesday,
+      duration: 90,
+      note: "Wednesday batch"
+    )
+
+    travel_to(wednesday.in_time_zone.change(hour: 12)) do
+      visit "/time-tracking"
+      expect(page).to have_css("#react-root", wait: 10)
+      switch_to("Week")
+
+      find("[data-testid='time-review-week']", wait: 10).click
+
+      expect(page).to have_content("Monday batch", wait: 10)
+      expect(page).to have_content("Wednesday batch", wait: 10)
+      expect(page).to have_content(/Week Total/i, wait: 10)
+    end
+  end
 end

--- a/spec/system/time_tracking/entries_spec.rb
+++ b/spec/system/time_tracking/entries_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe "Time Tracking Entries", type: :system, js: true do
         expect(page).to have_content("github", wait: 10)
       end
     end
+
+    it "resumes the timer from an existing entry" do
+      with_forgery_protection do
+        visit "/time-tracking"
+
+        find("[data-testid='resume-timer-entry']", wait: 10).click
+
+        expect(page).to have_css("[data-testid='inline-web-timer']", wait: 10)
+        expect(page).to have_text("Pause", wait: 10)
+        expect(page).to have_text("Alpha Project", wait: 10)
+        expect(page).to have_field(
+          "timer-description-inline",
+          with: "Worked on feature implementation",
+          wait: 10
+        )
+      end
+    end
   end
 
   context "with multiple projects in the same day" do


### PR DESCRIPTION
## Summary
- New `/api/v1/chatbase_token` endpoint that returns a signed JWT for Chatbase user identity verification
- CORS configured to allow `miru.so` to call this endpoint with credentials
- Marketing site already deployed with the client-side integration

## How it works
1. User visits miru.so (logged into app.miru.so in same browser)
2. Chatbase widget loads on miru.so
3. Marketing site calls `GET /api/v1/chatbase_token` with credentials
4. If user is authenticated, returns JWT with user_id, email, name, company
5. Marketing site passes JWT to `window.chatbase('identify', { token })`
6. Chatbase now knows who the user is

## Required env var
```
CHATBASE_IDENTITY_SECRET=<your-chatbase-secret-key>
```
Get this from Chatbase dashboard > Settings > Identity Verification.

## Test plan
- [ ] Set CHATBASE_IDENTITY_SECRET env var
- [ ] Visit miru.so while logged into app.miru.so
- [ ] Open Chatbase widget, verify user identity shows in Chatbase dashboard