### PR TITLE
fix(time-tracking): restrict edits older than 7 days to admins

### DIFF
--- a/app/controllers/api/v1/timesheet_entry/bulk_action_controller.rb
+++ b/app/controllers/api/v1/timesheet_entry/bulk_action_controller.rb
@@ -14,6 +14,14 @@ class Api::V1::TimesheetEntry::BulkActionController < Api::V1::ApplicationContro
     target_project = ProjectPolicy::Scope.new(current_user, current_company).resolve.find(params[:project_id])
     updated_entries = timesheet_entries.where(id: ids)
     return render json: { error: I18n.t("timesheet_entry.update.failure", default: "No entries found") }, status: :unprocessable_entity if updated_entries.empty?
+    if standard_user? && updated_entries.any? { |entry| entry_locked_for_standard_user?(entry) }
+      return render json: {
+        error: I18n.t(
+          "timesheet_entry.update.locked",
+          default: "Only admins can edit entries older than 7 days"
+        )
+      }, status: 403
+    end
 
     updated_entries.update(project_id: target_project.id)
     entries = TimesheetEntriesPresenter.new(updated_entries).group_snippets_by_work_date
@@ -25,6 +33,14 @@ class Api::V1::TimesheetEntry::BulkActionController < Api::V1::ApplicationContro
 
     timesheet_entries = policy_scope(TimesheetEntry)
     entries_to_discard = timesheet_entries.where(id: ids_params)
+    if standard_user? && entries_to_discard.any? { |entry| entry_locked_for_standard_user?(entry) }
+      return render json: {
+        error: I18n.t(
+          "timesheet_entry.destroy.locked",
+          default: "Only admins can delete entries older than 7 days"
+        )
+      }, status: 403
+    end
     discarded_entries = entries_to_discard.discard_all
     if discarded_entries.any?
       render json: { notice: I18n.t("timesheet_entry.destroy.message") }
@@ -37,5 +53,13 @@ class Api::V1::TimesheetEntry::BulkActionController < Api::V1::ApplicationContro
 
     def ids_params
       params.require(:source).require(:ids)
+    end
+
+    def standard_user?
+      !current_user.has_role?(:admin, current_company)
+    end
+
+    def entry_locked_for_standard_user?(entry)
+      entry.work_date.present? && entry.work_date < 7.days.ago.to_date
     end
 end

--- a/app/javascript/src/components/TimeTracking/EntryCard.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import dayjs from "dayjs";
 import { minToHHMM } from "helpers";
 import { Trash, PencilSimple, Clock, Briefcase, Play } from "phosphor-react";
 import { Card, CardContent } from "../ui/card";
@@ -14,6 +15,7 @@ interface props {
   client: string;
   project: string;
   projectId: number;
+  work_date?: string;
   note: string;
   duration: number;
   source_label?: string;
@@ -31,14 +33,32 @@ interface props {
   }) => void;
 }
 
-const canEditTimeEntry = (billStatus, role) =>
-  billStatus != "billed" || role == Roles["OWNER"] || role == Roles["ADMIN"];
+const isPrivilegedRole = role =>
+  role === Roles["OWNER"] || role === Roles["ADMIN"];
+
+const isAdminRole = role => role === Roles["ADMIN"];
+
+const isOlderThanOneWeek = workDate => {
+  const parsedDate = dayjs(workDate);
+  if (!workDate || !parsedDate.isValid()) return false;
+
+  return dayjs().startOf("day").diff(parsedDate.startOf("day"), "day") > 7;
+};
+
+const canEditTimeEntry = (billStatus, role, workDate) => {
+  if (isOlderThanOneWeek(workDate)) return isAdminRole(role);
+
+  if (isPrivilegedRole(role)) return true;
+
+  return billStatus !== "billed";
+};
 
 const EntryCard: React.FC<props> = ({
   id,
   client,
   project,
   projectId,
+  work_date,
   note,
   duration,
   source_label,
@@ -51,11 +71,12 @@ const EntryCard: React.FC<props> = ({
   handleResumeTimer,
 }) => {
   const { isDesktop, companyRole } = useUserContext();
+  const canManageEntry = canEditTimeEntry(bill_status, companyRole, work_date);
   const sourceSkill = source_metadata?.skill;
   const sourceServer = source_metadata?.mcp_server;
 
   const handleCardClick = () => {
-    if (!isDesktop) {
+    if (!isDesktop && canManageEntry) {
       setEditEntryId(id);
       setNewEntryView(true);
     }
@@ -66,7 +87,7 @@ const EntryCard: React.FC<props> = ({
       className={cn(
         "group relative mb-4 overflow-hidden transition-all duration-200 hover:shadow-lg",
         "border-border bg-card hover:border-primary/60",
-        !isDesktop && "cursor-pointer active:scale-[0.99]",
+        !isDesktop && canManageEntry && "cursor-pointer active:scale-[0.99]",
         "before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:bg-primary before:opacity-0 before:transition-opacity hover:before:opacity-100"
       )}
       onClick={handleCardClick}
@@ -184,7 +205,7 @@ const EntryCard: React.FC<props> = ({
               </div>
             </div>
 
-            {canEditTimeEntry(bill_status, companyRole) && (
+            {canManageEntry && (
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"

--- a/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
+++ b/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import dayjs from "dayjs";
+import { PencilSimple, Trash } from "phosphor-react";
 import EntryCard from "./EntryCard";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { Button } from "../ui/button";
@@ -7,6 +8,8 @@ import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { minToHHMM } from "../../helpers";
 import { i18n } from "../../i18n";
+import { useUserContext } from "../../context/UserContext";
+import { Roles } from "../../constants";
 
 dayjs.extend(customParseFormat);
 
@@ -16,10 +19,14 @@ interface TimeEntriesDisplayProps {
   leaveTypeHashObj: Record<number, any>;
   holidaysHashObj: Record<number, any>;
   handleDeleteEntry: (id: number) => void;
+  handleDeleteTimeoffEntry: (id: number, leaveDate?: string | null) => void;
   handleDuplicate: (entry: any) => void;
   handleResumeTimer: (entry: any) => void;
   setEditEntryId: (id: number) => void;
+  setEditTimeoffEntryId: (id: number) => void;
   setNewEntryView: (value: boolean) => void;
+  setNewTimeoffEntryView: (value: boolean) => void;
+  setSelectedFullDate: (value: string) => void;
   dayInfo?: any[];
   view?: string;
 }
@@ -30,14 +37,19 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   leaveTypeHashObj,
   holidaysHashObj,
   handleDeleteEntry,
+  handleDeleteTimeoffEntry,
   handleDuplicate,
   handleResumeTimer,
   setEditEntryId,
+  setEditTimeoffEntryId,
   setNewEntryView,
+  setNewTimeoffEntryView,
+  setSelectedFullDate,
   dayInfo = [],
   view = "week",
 }) => {
   const [reviewMode, setReviewMode] = useState<"day" | "week">("day");
+  const { companyRole, isDesktop } = useUserContext();
   const dateFormats = [
     "YYYY-MM-DD",
     "MM-DD-YYYY",
@@ -77,6 +89,16 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   const canShowWeekReview = view === "week" && weekEntries.length > 0;
   const reviewEntries = reviewMode === "week" ? weekEntries : entries || [];
   const shouldRenderReviewPanel = hasEntries || canShowWeekReview;
+
+  const isAdminUser = companyRole === Roles["ADMIN"];
+
+  const isOlderThanOneWeek = (entryDate: string) => {
+    const parsedDate = dayjs(entryDate, dateFormats, true);
+    if (!parsedDate.isValid()) return false;
+
+    return dayjs().startOf("day").diff(parsedDate.startOf("day"), "day") > 7;
+  };
+
   const renderEntry = (entry: any, index: number) => {
     if (entry?.type === "leave") {
       const entryKey = entry?.id ? `leave-${entry.id}` : `leave-${index}`;
@@ -94,11 +116,39 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
       const entryDate =
         entry.display_date || entry.leave_date || selectedFullDate;
 
+      const canManageTimeoff =
+        !holidayDetails && (!isOlderThanOneWeek(entryDate) || isAdminUser);
+
+      const handleEditTimeoff = () => {
+        if (!canManageTimeoff) return;
+        setNewEntryView(false);
+        setEditEntryId(0);
+        setSelectedFullDate(
+          dayjs(entryDate, dateFormats, true).isValid()
+            ? dayjs(entryDate, dateFormats, true).format("YYYY-MM-DD")
+            : entryDate
+        );
+        setEditTimeoffEntryId(entry.id);
+        setNewTimeoffEntryView(true);
+      };
+
+      const handleDeleteTimeoff = () => {
+        if (!canManageTimeoff) return;
+        handleDeleteTimeoffEntry(entry.id, entryDate);
+      };
+
       return (
         <Card
           key={entryKey}
-          className="mb-4 border-border bg-card"
+          className={`mb-4 border-border bg-card ${
+            !isDesktop && canManageTimeoff ? "cursor-pointer" : ""
+          }`}
           data-testid="timeoff-entry-card"
+          onClick={() => {
+            if (!isDesktop) {
+              handleEditTimeoff();
+            }
+          }}
         >
           <CardContent className="p-6">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -132,6 +182,34 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
                   {minToHHMM(entry.duration)}
                 </div>
               </div>
+              {isDesktop && canManageTimeoff && (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 hover:bg-accent hover:text-primary"
+                    onClick={event => {
+                      event.stopPropagation();
+                      handleEditTimeoff();
+                    }}
+                    title={i18n.t("timeTracking.editEntry")}
+                  >
+                    <PencilSimple className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 hover:bg-destructive/10 hover:text-destructive"
+                    onClick={event => {
+                      event.stopPropagation();
+                      handleDeleteTimeoff();
+                    }}
+                    title={i18n.t("timeTracking.deleteEntry")}
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -147,6 +225,7 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
         client={entry.client}
         project={entry.project}
         projectId={entry.project_id}
+        work_date={entry.work_date || entry.display_date}
         note={entry.note}
         duration={entry.duration}
         source_label={entry.source_label}

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-import { timesheetEntryApi, timeTrackingApi } from "apis/api";
+import {
+  timeoffEntriesApi,
+  timesheetEntryApi,
+  timeTrackingApi,
+} from "apis/api";
 import Loader from "common/Loader/index";
 import withLayout from "common/Mobile/HOC/withLayout";
 import SearchTimeEntries from "common/SearchTimeEntries";
@@ -531,6 +535,17 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
     }
   };
 
+  const handleDeleteTimeoffEntry = async (
+    id: number,
+    leaveDate?: string | null
+  ) => {
+    const res = await timeoffEntriesApi.destroy(id);
+    if (res.status !== 200) return;
+
+    await handleFilterEntry(leaveDate || selectedFullDate, id);
+    await refreshVisibleEntries();
+  };
+
   const removeLocalStorageItems = () => {
     localStorage.removeItem("note");
     localStorage.removeItem("duration");
@@ -1004,10 +1019,14 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
                 leaveTypeHashObj={leaveTypeHashObj}
                 holidaysHashObj={holidaysHashObj}
                 handleDeleteEntry={handleDeleteEntry}
+                handleDeleteTimeoffEntry={handleDeleteTimeoffEntry}
                 handleDuplicate={handleDuplicate}
                 handleResumeTimer={handleResumeTimer}
                 setEditEntryId={setEditEntryId}
+                setEditTimeoffEntryId={setEditTimeoffEntryId}
                 setNewEntryView={setNewEntryView}
+                setNewTimeoffEntryView={setNewTimeoffEntryView}
+                setSelectedFullDate={setSelectedFullDate}
                 dayInfo={dayInfo}
                 view={view}
               />

--- a/app/policies/timeoff_entry_policy.rb
+++ b/app/policies/timeoff_entry_policy.rb
@@ -29,6 +29,24 @@ class TimeoffEntryPolicy < ApplicationPolicy
       return false
     end
 
-    user_owner_role? || user_admin_role? || user_employee_role?
+    return false if stale_entry_for_non_admin?
+    return true if user_owner_role? || user_admin_role?
+    return false unless user_employee_role?
+    return false unless record.user_id == user.id
+    return false if stale_entry_for_standard_user?
+
+    true
   end
+
+  private
+
+    def stale_entry_for_standard_user?
+      return false if record.leave_date.blank?
+
+      record.leave_date < 7.days.ago.to_date
+    end
+
+    def stale_entry_for_non_admin?
+      stale_entry_for_standard_user? && !user_admin_role?
+    end
 end

--- a/app/policies/timesheet_entry_policy.rb
+++ b/app/policies/timesheet_entry_policy.rb
@@ -22,28 +22,48 @@ class TimesheetEntryPolicy < ApplicationPolicy
   end
 
   def update?
-    (record.user_id == user.id && !record.billed?) ||
-      user.has_role?(:owner, record.project.client.company) || user.has_role?(:admin, record.project.client.company)
+    return false if stale_entry_for_non_admin?
+    return true if privileged_role_for_record?
+
+    record.user_id == user.id && !record.billed?
   end
 
   def destroy?
     update?
   end
 
-  class Scope < ApplicationPolicy
-    attr_reader :user, :scope
+  private
 
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
+    def privileged_role_for_record?
+      user.has_role?(:owner, record.project.client.company) ||
+        user.has_role?(:admin, record.project.client.company)
     end
 
-    def resolve
-      if user_owner_role? || user_admin_role?
-        user.current_workspace.timesheet_entries.kept
-      else
-        user.timesheet_entries.kept.in_workspace(user.current_workspace)
+    def stale_entry_for_standard_user?
+      return false if record.work_date.blank?
+
+      record.work_date < 7.days.ago.to_date
+    end
+
+    def stale_entry_for_non_admin?
+      stale_entry_for_standard_user? &&
+        !user.has_role?(:admin, record.project.client.company)
+    end
+
+    class Scope < ApplicationPolicy
+      attr_reader :user, :scope
+
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
+
+      def resolve
+        if user_owner_role? || user_admin_role?
+          user.current_workspace.timesheet_entries.kept
+        else
+          user.timesheet_entries.kept.in_workspace(user.current_workspace)
+        end
       end
     end
-  end
 end

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -721,9 +721,11 @@ en-GB:
       message: Timesheet created
     destroy:
       failure: Failed to delete timesheet entries
+      locked: Only admins can delete entries older than 7 days
       message: Timesheet deleted
     update:
       failure: Failed to update timesheet entries
+      locked: Only admins can edit entries older than 7 days
       message: Timesheet updated
   totp:
     disable_passkey_first: Disable required passkey sign in before enabling authenticator

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -721,9 +721,11 @@ en-US:
       message: Timesheet created
     destroy:
       failure: Failed to delete timesheet entries
+      locked: Only admins can delete entries older than 7 days
       message: Timesheet deleted
     update:
       failure: Failed to update timesheet entries
+      locked: Only admins can edit entries older than 7 days
       message: Timesheet updated
   totp:
     disable_passkey_first: Disable required passkey sign in before enabling authenticator

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,9 +724,11 @@ en:
       message: Timesheet created
     destroy:
       failure: Failed to delete timesheet entries
+      locked: Only admins can delete entries older than 7 days
       message: Timesheet deleted
     update:
       failure: Failed to update timesheet entries
+      locked: Only admins can edit entries older than 7 days
       message: Timesheet updated
   totp:
     disable_passkey_first: Disable required passkey sign in before enabling authenticator

--- a/spec/policies/timeoff_entry_policy_spec.rb
+++ b/spec/policies/timeoff_entry_policy_spec.rb
@@ -35,10 +35,30 @@ RSpec.describe TimeoffEntryPolicy, type: :policy do
   end
 
   permissions :update?, :destroy? do
-    it "permits owner, admin, and employee in the same workspace" do
+    it "permits owner and admin in the same workspace" do
       expect(described_class).to permit(owner, record)
       expect(described_class).to permit(admin, record)
+    end
+
+    it "permits employee for their own recent entries" do
       expect(described_class).to permit(employee, record)
+    end
+
+    it "forbids employee for entries older than a week" do
+      record.update!(leave_date: 8.days.ago.to_date)
+      expect(described_class).not_to permit(employee, record)
+    end
+
+    it "forbids owner for entries older than a week" do
+      record.update!(leave_date: 8.days.ago.to_date)
+      expect(described_class).not_to permit(owner, record)
+      expect(described_class).to permit(admin, record)
+    end
+
+    it "forbids employee from editing another employee entry" do
+      another_employee = create(:user, current_workspace_id: company.id)
+      another_employee.add_role :employee, company
+      expect(described_class).not_to permit(another_employee, record)
     end
 
     it "forbids client and other workspace users" do

--- a/spec/policies/timesheet_entry_policy_spec.rb
+++ b/spec/policies/timesheet_entry_policy_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
         expect(subject).to permit(user, timesheet_entry)
       end
 
+      it "is permitted to update entries older than a week" do
+        timesheet_entry.update!(work_date: 8.days.ago.to_date)
+        expect(subject).to permit(user, timesheet_entry)
+      end
+
       it "is not permitted to update timesheet_entry in different company" do
         client.update(company_id: company2.id)
         expect(subject).not_to permit(user, timesheet_entry)
@@ -44,6 +49,11 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
 
     permissions :destroy? do
       it "is permitted to destroy" do
+        expect(subject).to permit(user, timesheet_entry)
+      end
+
+      it "is permitted to destroy entries older than a week" do
+        timesheet_entry.update!(work_date: 8.days.ago.to_date)
         expect(subject).to permit(user, timesheet_entry)
       end
 
@@ -80,6 +90,11 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
           it "is permitted to update the entry" do
             expect(subject).to permit(user, timesheet_entry)
           end
+
+          it "is not permitted to update entries older than a week" do
+            timesheet_entry.update!(work_date: 8.days.ago.to_date)
+            expect(subject).not_to permit(user, timesheet_entry)
+          end
         end
 
         context "when entry is billed" do
@@ -112,6 +127,11 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
         expect(subject).not_to permit(user, timesheet_entry)
       end
 
+      it "is not permitted to destroy own entries older than a week" do
+        timesheet_entry.update!(user:, work_date: 8.days.ago.to_date)
+        expect(subject).not_to permit(user, timesheet_entry)
+      end
+
       it "is not permitted to destroy client in different company" do
         client.update(company_id: company2.id)
         expect(subject).not_to permit(user, timesheet_entry)
@@ -126,6 +146,24 @@ RSpec.describe TimesheetEntryPolicy, type: :policy do
 
         expect(scope.to_a).to match_array([timesheet_entry])
         expect(scope.to_a).not_to include(timesheet_entry1)
+      end
+    end
+  end
+
+  context "when user is an owner" do
+    before do
+      create(:employment, company:, user:)
+      user.add_role :owner, company
+    end
+
+    permissions :update?, :destroy? do
+      it "permits recent entries" do
+        expect(subject).to permit(user, timesheet_entry)
+      end
+
+      it "forbids entries older than a week" do
+        timesheet_entry.update!(work_date: 8.days.ago.to_date)
+        expect(subject).not_to permit(user, timesheet_entry)
       end
     end
   end

--- a/spec/requests/api/v1/timesheet_entries/bulk_actions/destroy_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/bulk_actions/destroy_spec.rb
@@ -39,5 +39,26 @@ RSpec.describe "Api::V1::TimesheetEntry::BulkActionController#destroy", type: :r
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "rejects employees when selected entries are older than a week" do
+      employee = create(:user, current_workspace_id: company.id)
+      create(:employment, company:, user: employee)
+      employee.add_role :employee, company
+      employee.remove_role :owner, company
+      employee.remove_role :admin, company
+      old_entry = create(
+        :timesheet_entry,
+        user: employee,
+        project:,
+        work_date: 8.days.ago.to_date
+      )
+
+      sign_out user
+      send_request :delete, api_v1_bulk_action_path,
+        params: { source: { ids: [old_entry.id] } },
+        headers: auth_headers(employee)
+
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 end

--- a/spec/requests/api/v1/timesheet_entries/bulk_actions/update_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/bulk_actions/update_spec.rb
@@ -43,5 +43,27 @@ RSpec.describe "Api::V1::TimesheetEntry::BulkActionController#update", type: :re
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "rejects employees when selected entries are older than a week" do
+      employee = create(:user, current_workspace_id: company.id)
+      create(:employment, company:, user: employee)
+      employee.add_role :employee, company
+      employee.remove_role :owner, company
+      employee.remove_role :admin, company
+      create(:project_member, project: project1, user: employee)
+      old_entry = create(
+        :timesheet_entry,
+        user: employee,
+        project: project1,
+        work_date: 8.days.ago.to_date
+      )
+
+      sign_out user
+      send_request :patch, api_v1_bulk_action_path,
+        params: { ids: [old_entry.id], project_id: project1.id },
+        headers: auth_headers(employee)
+
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 end


### PR DESCRIPTION
## Summary\n- enforce admin-only edit/delete for timesheet entries older than 7 days\n- enforce admin-only edit/delete for timeoff entries older than 7 days\n- block non-admin bulk update/destroy when stale entries are included\n- hide stale edit/delete controls in Time Tracking UI for non-admin users\n- add i18n keys for locked stale-entry messages in en/en-US/en-GB\n\n## Verification\n- focused specs: ....................................

Finished in 9.7 seconds (files took 1.53 seconds to load)
36 examples, 0 failures\n- vite build: Building with Vite ⚡️
vite v6.4.1 building for development...
transforming...
✓ 9043 modules transformed.
rendering chunks...
computing gzip size...
../../public/vite-dev/assets/check-box-unchecked-CYtaXMIu.png                          0.43 kB
../../public/vite-dev/assets/Step-BuYZBCJ1.svg                                         0.54 kB │ gzip:   0.34 kB
../../public/vite-dev/assets/saeloun-DHlyf7lN.svg                                      0.66 kB │ gzip:   0.40 kB
../../public/vite-dev/assets/back-arrow-By9Ya9R9.svg                                   0.74 kB │ gzip:   0.37 kB
../../public/vite-dev/assets/fileIcon-afW3Mh91.svg                                     0.88 kB │ gzip:   0.43 kB
../../public/vite-dev/assets/miru-logo-4xD4auR6.svg                                    1.29 kB │ gzip:   0.64 kB
../../public/vite-dev/assets/README-BLgp_DxF.txt                                       2.22 kB │ gzip:   1.01 kB
../../public/vite-dev/assets/password_icon-magyn7sV.svg                                2.73 kB │ gzip:   1.07 kB
../../public/vite-dev/assets/xls-BS418VvS.svg                                          3.34 kB │ gzip:   1.25 kB
../../public/vite-dev/.vite/manifest-assets.json                                       4.11 kB │ gzip:   0.75 kB
../../public/vite-dev/assets/password_icon_text-DrLYppgn.svg                           4.33 kB │ gzip:   1.90 kB
../../public/vite-dev/assets/ConnectMobile-BYukAOIk.svg                                4.33 kB │ gzip:   1.64 kB
../../public/vite-dev/assets/expenseIcon-Cg20Zquw.svg                                  4.33 kB │ gzip:   1.52 kB
../../public/vite-dev/assets/OFL-6sh3HU5t.txt                                          4.48 kB │ gzip:   2.01 kB
../../public/vite-dev/assets/RevenueHover-DipEcDUI.svg                                 4.64 kB │ gzip:   1.66 kB
../../public/vite-dev/assets/NoSearchResultsState-BZEb48hV.svg                         4.80 kB │ gzip:   1.09 kB
../../public/vite-dev/assets/Connect-EaMx-9ay.svg                                      4.82 kB │ gzip:   1.65 kB
../../public/vite-dev/assets/amex-UH5KVp3_.svg                                         4.91 kB │ gzip:   1.85 kB
../../public/vite-dev/assets/masterCard-CouE38pK.svg                                   5.05 kB │ gzip:   1.85 kB
../../public/vite-dev/assets/sConnectInvoice-DhxmeuVD.svg                              5.09 kB │ gzip:   1.69 kB
../../public/vite-dev/assets/miru-logo-watermark-DU9JlsBh.svg                          5.41 kB │ gzip:   2.24 kB
../../public/vite-dev/assets/OverdueOutstanding-U8EFD3YP.svg                           5.59 kB │ gzip:   2.26 kB
../../public/vite-dev/assets/PaypalLogo-J92LpX3N.svg                                   6.28 kB │ gzip:   2.52 kB
../../public/vite-dev/assets/OverdueOutstandingHover-DLLwrp4r.svg                      6.35 kB │ gzip:   2.69 kB
../../public/vite-dev/assets/ConnectPaypal-TWOFqqNK.svg                                6.70 kB │ gzip:   2.66 kB
../../public/vite-dev/assets/pConnectInvoice-CefFmIN6.svg                              6.76 kB │ gzip:   2.63 kB
../../public/vite-dev/assets/Manrope-D53BAC_Z.woff                                    42.17 kB
../../public/vite-dev/.vite/manifest.json                                             73.76 kB │ gzip:   7.86 kB
../../public/vite-dev/assets/Manrope-Dk0nYSXg.woff2                                   80.39 kB
../../public/vite-dev/assets/Manrope-ExtraLight-BKdSMU2_.ttf                          96.30 kB
../../public/vite-dev/assets/Manrope-Light-BGlNh7dm.ttf                               96.31 kB
../../public/vite-dev/assets/Manrope-Bold-CDzAm7oS.ttf                                96.36 kB
../../public/vite-dev/assets/Manrope-Regular-C78aYuil.ttf                             96.41 kB
../../public/vite-dev/assets/Manrope-Medium-B9VJXSsw.ttf                              96.49 kB
../../public/vite-dev/assets/Manrope-SemiBold-DppH2UXM.ttf                            96.53 kB
../../public/vite-dev/assets/Manrope-ExtraBold-DAQ5jq1v.ttf                           97.12 kB
../../public/vite-dev/assets/Manrope-VariableFont_wght-x4yvyEZv.ttf                  164.94 kB
../../public/vite-dev/assets/time-tracking-preview-dark-DlnIBqim.png                 230.50 kB
../../public/vite-dev/assets/time-tracking-preview-d5PXwuD5.png                      233.54 kB
../../public/vite-dev/assets/invoices-preview-dark-D0Z0EAgI.png                      300.17 kB
../../public/vite-dev/assets/404_animation-BbQTOZmw.gif                              310.75 kB
../../public/vite-dev/assets/invoices-preview-BaOnvwL0.png                           316.69 kB
../../public/vite-dev/assets/dashboard-preview-dark-DZsttbAV.png                     333.61 kB
../../public/vite-dev/assets/dashboard-preview-Bldxcggk.png                          334.87 kB
../../public/vite-dev/assets/payments-preview-dark-BK2D3Ybd.png                      414.34 kB
../../public/vite-dev/assets/payments-preview-QwWMz-Nm.png                           414.93 kB
../../public/vite-dev/assets/index-B3Pw0lVN.css                                        1.96 kB │ gzip:   0.66 kB
../../public/vite-dev/assets/currencyList-DpsRipQV.css                                 3.23 kB │ gzip:   0.73 kB
../../public/vite-dev/assets/index-B5Wig3UY.css                                        9.78 kB │ gzip:   1.71 kB
../../public/vite-dev/assets/index-CBf8Kkyg.css                                       23.31 kB │ gzip:   3.24 kB
../../public/vite-dev/assets/application-2db6rCsi.css                                141.40 kB │ gzip:  24.71 kB
../../public/vite-dev/assets/en-GB-BQ2EJmov.js                                         0.12 kB │ gzip:   0.14 kB │ map:     0.27 kB
../../public/vite-dev/assets/en-US-BQ2EJmov.js                                         0.12 kB │ gzip:   0.14 kB │ map:     0.27 kB
../../public/vite-dev/assets/useQuery-BYGvU58p.js                                      0.15 kB │ gzip:   0.15 kB │ map:     0.71 kB
../../public/vite-dev/assets/index-DayiWhbB.js                                         0.15 kB │ gzip:   0.16 kB │ map:     0.97 kB
../../public/vite-dev/assets/use-isomorphic-layout-effect.browser.esm-DION7xe9.js      0.16 kB │ gzip:   0.16 kB │ map:     0.50 kB
../../public/vite-dev/assets/index-D_QDdSMh.js                                         0.20 kB │ gzip:   0.19 kB │ map:     0.46 kB
../../public/vite-dev/assets/utils-B5ntXATR.js                                         0.22 kB │ gzip:   0.19 kB │ map:     0.68 kB
../../public/vite-dev/assets/index-D-CvWKst.js                                         0.22 kB │ gzip:   0.20 kB │ map:     1.35 kB
../../public/vite-dev/assets/index-C0pA4tnD.js                                         0.22 kB │ gzip:   0.21 kB │ map:     1.47 kB
../../public/vite-dev/assets/skeleton-B8z__4w2.js                                      0.24 kB │ gzip:   0.21 kB │ map:     0.66 kB
../../public/vite-dev/assets/debounce-C2CaBP2T.js                                      0.25 kB │ gzip:   0.21 kB │ map:     0.98 kB
../../public/vite-dev/assets/typeof-QjJsDpFa.js                                        0.32 kB │ gzip:   0.21 kB │ map:     0.86 kB
../../public/vite-dev/assets/index-Mbw06GBm.js                                         0.32 kB │ gzip:   0.23 kB │ map:     2.49 kB
../../public/vite-dev/assets/index-DXBmUBu8.js                                         0.35 kB │ gzip:   0.27 kB │ map:     0.69 kB
../../public/vite-dev/assets/MobileMoreOptions-B88n9PnW.js                             0.39 kB │ gzip:   0.30 kB │ map:     1.05 kB
../../public/vite-dev/assets/hhmmParser-NL6A4NWy.js                                    0.45 kB │ gzip:   0.31 kB │ map:     1.68 kB
../../public/vite-dev/assets/index-DYtE2DZX.js                                         0.53 kB │ gzip:   0.31 kB │ map:     5.52 kB
../../public/vite-dev/assets/textarea-BBOXrsMa.js                                      0.54 kB │ gzip:   0.36 kB │ map:     1.21 kB
../../public/vite-dev/assets/useInfiniteLoadTrigger-DB9Xe0MB.js                        0.54 kB │ gzip:   0.38 kB │ map:     2.19 kB
../../public/vite-dev/assets/utils-Bw-9zq6s.js                                         0.59 kB │ gzip:   0.38 kB │ map:     1.30 kB
../../public/vite-dev/assets/currency-C0rMqJj3.js                                      0.60 kB │ gzip:   0.40 kB │ map:     2.37 kB
../../public/vite-dev/assets/useThemeMode-C-HUgPmD.js                                  0.70 kB │ gzip:   0.42 kB │ map:     2.23 kB
../../public/vite-dev/assets/constants-BT_zPgP2.js                                     0.78 kB │ gzip:   0.38 kB │ map:     2.33 kB
../../public/vite-dev/assets/CustomRadio-DmftU9p1.js                                   0.82 kB │ gzip:   0.47 kB │ map:     2.64 kB
../../public/vite-dev/assets/Tooltip-BXsclzRH.js                                       0.83 kB │ gzip:   0.52 kB │ map:     2.39 kB
../../public/vite-dev/assets/objectWithoutPropertiesLoose-Be-TnzXC.js                  0.93 kB │ gzip:   0.55 kB │ map:     3.53 kB
../../public/vite-dev/assets/objectWithoutProperties-D1t-IxfV.js                       0.95 kB │ gzip:   0.47 kB │ map:     2.92 kB
../../public/vite-dev/assets/Avatar-Bf5tHxyS.js                                        0.99 kB │ gzip:   0.57 kB │ map:     3.48 kB
../../public/vite-dev/assets/InvalidLink-CvfR9GTR.js                                   1.01 kB │ gzip:   0.51 kB │ map:     2.08 kB
../../public/vite-dev/assets/alert-CyZXDnSv.js                                         1.02 kB │ gzip:   0.52 kB │ map:     2.66 kB
../../public/vite-dev/assets/card-IHEZwS5m.js                                          1.11 kB │ gzip:   0.43 kB │ map:     3.35 kB
../../public/vite-dev/assets/utils-jhe3vK0v.js                                         1.12 kB │ gzip:   0.58 kB │ map:     3.54 kB
../../public/vite-dev/assets/IconBase.esm-bjWqXZxG.js                                  1.21 kB │ gzip:   0.74 kB │ map:     5.41 kB
../../public/vite-dev/assets/SignUpSuccess-N-DOLERS.js                                 1.22 kB │ gzip:   0.62 kB │ map:     2.37 kB
../../public/vite-dev/assets/EmailVerificationSuccess-BKR9hfMK.js                      1.24 kB │ gzip:   0.60 kB │ map:     2.64 kB
../../public/vite-dev/assets/useInfiniteQuery-IiMoboRo.js                              1.27 kB │ gzip:   0.57 kB │ map:     4.72 kB
../../public/vite-dev/assets/getBadgeStatus-DC6SESAR.js                                1.42 kB │ gzip:   0.70 kB │ map:     3.26 kB
../../public/vite-dev/assets/Button-DLCs2VZ3.js                                        1.54 kB │ gzip:   0.68 kB │ map:     4.29 kB
../../public/vite-dev/assets/Circle.esm-CSuttjpK.js                                    1.55 kB │ gzip:   0.44 kB │ map:     4.40 kB
../../public/vite-dev/assets/index-DP-FCyue.js                                         1.59 kB │ gzip:   0.79 kB │ map:     3.28 kB
../../public/vite-dev/assets/table-B_ilaNMq.js                                         1.60 kB │ gzip:   0.55 kB │ map:     4.69 kB
../../public/vite-dev/assets/DotsThree.esm-HB_xYcqF.js                                 1.71 kB │ gzip:   0.48 kB │ map:     4.88 kB
../../public/vite-dev/assets/CaretLeft.esm-CUmaGRog.js                                 1.75 kB │ gzip:   0.55 kB │ map:     4.36 kB
../../public/vite-dev/assets/index-1HsIXIMu.js                                         1.79 kB │ gzip:   0.95 kB │ map:     6.50 kB
../../public/vite-dev/assets/Clock.es-BYC8nFOd.js                                      1.84 kB │ gzip:   0.66 kB │ map:     3.76 kB
../../public/vite-dev/assets/TrendUp.es-Dy1qY_RT.js                                    1.94 kB │ gzip:   0.75 kB │ map:     3.85 kB
../../public/vite-dev/assets/index-Cpjw2IcR.js                                         2.04 kB │ gzip:   1.01 kB │ map:     4.70 kB
../../public/vite-dev/assets/SearchTimeEntries-BjjCDDLj.js                             2.27 kB │ gzip:   1.09 kB │ map:     6.92 kB
../../public/vite-dev/assets/passkeys-H5_MaIwX.js                                      2.30 kB │ gzip:   0.92 kB │ map:     7.53 kB
../../public/vite-dev/assets/Plus.esm-CdqYY7Ri.js                                      2.31 kB │ gzip:   0.52 kB │ map:     6.20 kB
../../public/vite-dev/assets/Clock.esm-BOYGYPVU.js                                     2.32 kB │ gzip:   0.58 kB │ map:     5.92 kB
../../public/vite-dev/assets/CreditCard.es-CEudWcl8.js                                 2.40 kB │ gzip:   0.79 kB │ map:     4.35 kB
../../public/vite-dev/assets/ArrowLeft.esm-vw2yTblI.js                                 2.41 kB │ gzip:   0.59 kB │ map:     6.05 kB
../../public/vite-dev/assets/CheckCircle.esm-B3Mjc6uM.js                               2.45 kB │ gzip:   0.62 kB │ map:     6.13 kB
../../public/vite-dev/assets/TrendUp.esm-pCvMtJfY.js                                   2.57 kB │ gzip:   0.64 kB │ map:     5.92 kB
../../public/vite-dev/assets/CurrencyDollar.es-oOVB0hVo.js                             2.72 kB │ gzip:   0.94 kB │ map:     4.73 kB
../../public/vite-dev/assets/CurrencyDollar.esm-Dm5eUhxO.js                            2.82 kB │ gzip:   0.63 kB │ map:     6.48 kB
../../public/vite-dev/assets/Eye.esm-BW8IVvlE.js                                       2.83 kB │ gzip:   0.71 kB │ map:     6.42 kB
../../public/vite-dev/assets/index-DtmMjNQa.js                                         2.88 kB │ gzip:   0.72 kB │ map:     6.20 kB
../../public/vite-dev/assets/useMutation-BHzqLJIH.js                                   2.94 kB │ gzip:   1.25 kB │ map:     8.54 kB
../../public/vite-dev/assets/index-BlGhk5Sb.js                                         2.96 kB │ gzip:   1.38 kB │ map:    17.17 kB
../../public/vite-dev/assets/PencilSimple.esm-t0AuydLP.js                              3.12 kB │ gzip:   0.72 kB │ map:     6.86 kB
../../public/vite-dev/assets/Warning.esm-CtODTVe5.js                                   3.14 kB │ gzip:   0.68 kB │ map:     7.35 kB
../../public/vite-dev/assets/index-CuY-Nd6Q.js                                         3.15 kB │ gzip:   0.93 kB │ map:     8.63 kB
../../public/vite-dev/assets/Users.es-BaA7nQbp.js                                      3.18 kB │ gzip:   1.14 kB │ map:     5.08 kB
../../public/vite-dev/assets/XCircle.esm-BT1xAtZ2.js                                   3.18 kB │ gzip:   0.66 kB │ map:     8.18 kB
../../public/vite-dev/assets/index-D9gc2VGL.js                                         3.36 kB │ gzip:   1.41 kB │ map:     8.82 kB
../../public/vite-dev/assets/Warning.es-KESaLMAv.js                                    3.38 kB │ gzip:   1.11 kB │ map:     5.36 kB
../../public/vite-dev/assets/hoist-non-react-statics.cjs-C-Qo8PK8.js                   3.55 kB │ gzip:   1.37 kB │ map:    10.62 kB
../../public/vite-dev/assets/index-BB_Y-tLI.js                                         3.57 kB │ gzip:   1.63 kB │ map:    16.04 kB
../../public/vite-dev/assets/RouteConfig-i17kHzMe.js                                   3.68 kB │ gzip:   1.46 kB │ map:     6.28 kB
../../public/vite-dev/assets/filterUtils-BbblbuRR.js                                   3.79 kB │ gzip:   1.51 kB │ map:     8.39 kB
../../public/vite-dev/assets/Download.esm-BqJsiNo3.js                                  3.90 kB │ gzip:   0.81 kB │ map:     9.02 kB
../../public/vite-dev/assets/customParseFormat-DhZhMy5T.js                             3.91 kB │ gzip:   1.96 kB │ map:    10.11 kB
../../public/vite-dev/assets/index-fII1uzr9.js                                         3.91 kB │ gzip:   1.46 kB │ map:    10.16 kB
../../public/vite-dev/assets/CalendarBlank.esm-Dh4s3EUH.js                             3.99 kB │ gzip:   0.68 kB │ map:    10.32 kB
../../public/vite-dev/assets/checkbox-C5w04R5Y.js                                      4.03 kB │ gzip:   1.80 kB │ map:    16.35 kB
../../public/vite-dev/assets/CreditCard.esm-B1sTyEf5.js                                4.04 kB │ gzip:   0.71 kB │ map:    10.35 kB
../../public/vite-dev/assets/FileText.esm-CSxJpLHQ.js                                  4.19 kB │ gzip:   0.73 kB │ map:     9.83 kB
../../public/vite-dev/assets/chart-j_BpsnTR.js                                         4.41 kB │ gzip:   1.83 kB │ map:    14.78 kB
../../public/vite-dev/assets/index-DMFSw19o.js                                         4.42 kB │ gzip:   1.68 kB │ map:    26.18 kB
../../public/vite-dev/assets/CustomTextareaAutosize-DNHQku9w.js                        4.47 kB │ gzip:   2.03 kB │ map:    17.73 kB
../../public/vite-dev/assets/PaperPlaneTilt.esm-w0oAFZKX.js                            4.74 kB │ gzip:   0.88 kB │ map:    10.96 kB
../../public/vite-dev/assets/Trash.esm-CUUkiVF1.js                                     4.93 kB │ gzip:   0.75 kB │ map:    11.66 kB
../../public/vite-dev/assets/popover-Bcwi6892.js                                       5.43 kB │ gzip:   2.01 kB │ map:    21.77 kB
../../public/vite-dev/assets/EyeSlash.esm-CiNNC7GE.js                                  5.67 kB │ gzip:   1.18 kB │ map:    12.46 kB
../../public/vite-dev/assets/dayjs.min-CnXpKtDH.js                                     7.21 kB │ gzip:   3.15 kB │ map:    18.51 kB
../../public/vite-dev/assets/AddEditProject-C9p_d_q_.js                                7.73 kB │ gzip:   3.00 kB │ map:    31.07 kB
../../public/vite-dev/assets/index-DF8NXprA.js                                         8.40 kB │ gzip:   2.36 kB │ map:    21.90 kB
../../public/vite-dev/assets/index-Q7aFiOps.js                                         8.77 kB │ gzip:   3.01 kB │ map:    28.00 kB
../../public/vite-dev/assets/index-BHgVkYDE.js                                         8.95 kB │ gzip:   2.81 kB │ map:    24.30 kB
../../public/vite-dev/assets/index-D5KefFkG.js                                         9.84 kB │ gzip:   2.74 kB │ map:    25.36 kB
../../public/vite-dev/assets/ProjectsTable-CMVNjsV-.js                                10.04 kB │ gzip:   2.85 kB │ map:    26.46 kB
../../public/vite-dev/assets/useBaseQuery-B8tqcNpk.js                                 10.32 kB │ gzip:   3.67 kB │ map:    40.01 kB
../../public/vite-dev/assets/ClientsTable-BlA7JOrz.js                                 10.96 kB │ gzip:   3.25 kB │ map:    30.05 kB
../../public/vite-dev/assets/index-CK_O0Q0X.js                                        11.02 kB │ gzip:   3.55 kB │ map:    33.35 kB
../../public/vite-dev/assets/index-V0MIM3PM.js                                        11.12 kB │ gzip:   1.70 kB │ map:    27.92 kB
../../public/vite-dev/assets/ClientEditor-BHkevuZy.js                                 12.85 kB │ gzip:   3.74 kB │ map:    38.89 kB
../../public/vite-dev/assets/data-table-B9itic9s.js                                   12.92 kB │ gzip:   2.49 kB │ map:    35.02 kB
../../public/vite-dev/assets/index-BZP3qjwV.js                                        13.24 kB │ gzip:   3.76 kB │ map:    35.24 kB
../../public/vite-dev/assets/googleAnalytics-BaAqJtgw.js                              13.48 kB │ gzip:   4.77 kB │ map:    48.20 kB
../../public/vite-dev/assets/InvoiceLineItems-CI0a6HCj.js                             13.51 kB │ gzip:   3.22 kB │ map:    33.36 kB
../../public/vite-dev/assets/AreaChart-DG_W4zWZ.js                                    13.90 kB │ gzip:   4.70 kB │ map:    60.51 kB
../../public/vite-dev/assets/index-OUe0p51r.js                                        14.28 kB │ gzip:   4.40 kB │ map:    42.84 kB
../../public/vite-dev/assets/index-CEz2fo_5.js                                        14.39 kB │ gzip:   3.99 kB │ map:    38.63 kB
../../public/vite-dev/assets/index-CtjGqAm6.js                                        15.21 kB │ gzip:   4.08 kB │ map:    46.16 kB
../../public/vite-dev/assets/index-CkGbMJ7C.js                                        15.58 kB │ gzip:   5.05 kB │ map:    50.32 kB
../../public/vite-dev/assets/ReportsTable-DdAi1MsN.js                                 18.37 kB │ gzip:   4.11 kB │ map:    50.50 kB
../../public/vite-dev/assets/DashboardHome-BLMNToBr.js                                18.64 kB │ gzip:   5.08 kB │ map:    48.25 kB
../../public/vite-dev/assets/PaymentsTable-CL-5xOhz.js                                20.07 kB │ gzip:   5.99 kB │ map:    56.40 kB
../../public/vite-dev/assets/index-zWCCNlgh.js                                        20.16 kB │ gzip:   5.82 kB │ map:    63.01 kB
../../public/vite-dev/assets/dropdown-menu-DF11cLaf.js                                23.07 kB │ gzip:   6.98 kB │ map:   601.04 kB
../../public/vite-dev/assets/index-RGXOkYIy.js                                        23.88 kB │ gzip:   6.51 kB │ map:   129.40 kB
../../public/vite-dev/assets/index-BX8ZWBNv.js                                        25.01 kB │ gzip:   6.23 kB │ map:    70.07 kB
../../public/vite-dev/assets/TermsOfServiceModal-Dsx2cyPr.js                          27.95 kB │ gzip:   7.70 kB │ map:    47.61 kB
../../public/vite-dev/assets/ShareReportButton-dIYU873G.js                            28.69 kB │ gzip:   8.90 kB │ map:   117.75 kB
../../public/vite-dev/assets/TeamsRouteConfig-PIPIaIt1.js                             30.09 kB │ gzip:   6.06 kB │ map:    72.14 kB
../../public/vite-dev/assets/formik.esm-C0KukL7n.js                                   31.35 kB │ gzip:  10.62 kB │ map:   226.22 kB
../../public/vite-dev/assets/index-80LOzdJQ.js                                        31.40 kB │ gzip:   7.49 kB │ map:    83.34 kB
../../public/vite-dev/assets/index-Ds2m6c6H.js                                        31.78 kB │ gzip:  11.00 kB │ map:    82.62 kB
../../public/vite-dev/assets/index-3aM1Dwcn.js                                        31.80 kB │ gzip:   8.17 kB │ map:    96.17 kB
../../public/vite-dev/assets/array-Cs2LctBn.js                                        38.74 kB │ gzip:  13.04 kB │ map:   145.36 kB
../../public/vite-dev/assets/index-BYN-zIBe.js                                        39.31 kB │ gzip:  13.69 kB │ map:   112.65 kB
../../public/vite-dev/assets/ExpensesTable-DMzGIIO6.js                                39.65 kB │ gzip:   9.64 kB │ map:   131.71 kB
../../public/vite-dev/assets/index-DhUpvzuM.js                                        54.19 kB │ gzip:  14.48 kB │ map:   224.85 kB
../../public/vite-dev/assets/index-gl7lYxki.js                                        55.97 kB │ gzip:  13.89 kB │ map:   169.59 kB
../../public/vite-dev/assets/api-BUy4Falo.js                                          58.15 kB │ gzip:  21.68 kB │ map:   268.36 kB
../../public/vite-dev/assets/calendar-CRb4FR-b.js                                     65.97 kB │ gzip:  19.32 kB │ map:   412.19 kB
../../public/vite-dev/assets/zh-CN-ByA8zj2f.js                                        68.35 kB │ gzip:  24.83 kB │ map:   108.93 kB
../../public/vite-dev/assets/id-Dv14xXc8.js                                           76.42 kB │ gzip:  23.91 kB │ map:   118.70 kB
../../public/vite-dev/assets/nl-CaTnJ4qd.js                                           77.51 kB │ gzip:  25.47 kB │ map:   119.83 kB
../../public/vite-dev/assets/select-CV9nCEiE.js                                       78.98 kB │ gzip:  26.68 kB │ map:   411.34 kB
../../public/vite-dev/assets/tr-DLYOnntR.js                                           79.44 kB │ gzip:  25.72 kB │ map:   121.64 kB
../../public/vite-dev/assets/index-CHG-_Vrj.js                                        79.75 kB │ gzip:  28.08 kB │ map:   374.72 kB
../../public/vite-dev/assets/it--va0SP-L.js                                           80.13 kB │ gzip:  25.07 kB │ map:   122.59 kB
../../public/vite-dev/assets/pt-BR-DS-9NXpo.js                                        80.57 kB │ gzip:  25.52 kB │ map:   122.97 kB
../../public/vite-dev/assets/ko-DIJ7cRyM.js                                           81.85 kB │ gzip:  25.61 kB │ map:   123.19 kB
../../public/vite-dev/assets/es-B0Ro6IGq.js                                           81.97 kB │ gzip:  25.38 kB │ map:   124.46 kB
../../public/vite-dev/assets/de-BhKfYg9L.js                                           82.08 kB │ gzip:  25.75 kB │ map:   124.60 kB
../../public/vite-dev/assets/fr-Ch84eTx8.js                                           84.57 kB │ gzip:  25.90 kB │ map:   127.16 kB
../../public/vite-dev/assets/ja-CW7Pjx3X.js                                           89.96 kB │ gzip:  26.77 kB │ map:   131.37 kB
../../public/vite-dev/assets/ur-DeWe7mP3.js                                          105.69 kB │ gzip:  27.02 kB │ map:   147.80 kB
../../public/vite-dev/assets/proxy-oMf2j8fD.js                                       113.43 kB │ gzip:  37.38 kB │ map:   630.74 kB
../../public/vite-dev/assets/utils-BaiWc-0e.js                                       114.26 kB │ gzip:  32.99 kB │ map:   269.08 kB
../../public/vite-dev/assets/index-RBWvIise.js                                       130.16 kB │ gzip:  24.47 kB │ map:   336.44 kB
../../public/vite-dev/assets/index-Cd63RlVl.js                                       130.44 kB │ gzip:  31.46 kB │ map:   445.10 kB
../../public/vite-dev/assets/pa-CE33LXXi.js                                          134.97 kB │ gzip:  29.04 kB │ map:   176.95 kB
../../public/vite-dev/assets/gu-DYmJXK0z.js                                          141.09 kB │ gzip:  29.22 kB │ map:   183.28 kB
../../public/vite-dev/assets/mr-BCn8_zAA.js                                          141.78 kB │ gzip:  29.45 kB │ map:   183.85 kB
../../public/vite-dev/assets/hi-BpkXHBAF.js                                          146.79 kB │ gzip:  30.05 kB │ map:   191.55 kB
../../public/vite-dev/assets/bn-DDT9AnZc.js                                          149.48 kB │ gzip:  29.61 kB │ map:   191.70 kB
../../public/vite-dev/assets/RouteConfig-BGbg9C5K.js                                 154.37 kB │ gzip:  38.45 kB │ map:   463.81 kB
../../public/vite-dev/assets/kn-CqgZ3W7_.js                                          156.06 kB │ gzip:  29.42 kB │ map:   198.36 kB
../../public/vite-dev/assets/te-DBpFIA5E.js                                          163.25 kB │ gzip:  30.76 kB │ map:   205.64 kB
../../public/vite-dev/assets/ml-DMGQv82K.js                                          169.03 kB │ gzip:  30.67 kB │ map:   211.57 kB
../../public/vite-dev/assets/index-DiqZVaRC.js                                       170.76 kB │ gzip:  40.11 kB │ map:   644.87 kB
../../public/vite-dev/assets/ta-BaM1uJVj.js                                          177.74 kB │ gzip:  30.23 kB │ map:   220.44 kB
../../public/vite-dev/assets/index-BonFg_cv.js                                       203.39 kB │ gzip:  49.97 kB │ map:   323.03 kB
../../public/vite-dev/assets/CartesianChart-B_z0OwVT.js                              291.19 kB │ gzip:  89.36 kB │ map: 1,477.23 kB
../../public/vite-dev/assets/index-DtdCyYmH.js                                       490.82 kB │ gzip:  93.30 kB │ map: 1,376.84 kB
../../public/vite-dev/assets/application-Ddxqwaxe.js                                 526.42 kB │ gzip: 174.67 kB │ map: 2,420.35 kB
../../public/vite-dev/assets/currencyList-IYVnpsnt.js                              1,052.94 kB │ gzip: 225.58 kB │ map: 1,253.85 kB
✓ built in 7.20s
Build with Vite complete: /Users/sward/saeloun/miru-web/public/vite-dev
Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
node_modules/.pnpm/sonner@2.0.7_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/sonner/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/sonner@2.0.7_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/sonner/dist/index.mjs" was ignored.
node_modules/.pnpm/react-router@7.13.2_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-router/dist/development/index.mjs (11:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/react-router@7.13.2_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-router/dist/development/index.mjs" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useQuery.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useQuery.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/QueryErrorResetBoundary.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/QueryErrorResetBoundary.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useQueries.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useQueries.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useIsFetching.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useIsFetching.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useInfiniteQuery.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useInfiniteQuery.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/HydrationBoundary.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/HydrationBoundary.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useMutationState.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useMutationState.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useMutation.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useMutation.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQuery.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQuery.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQuery.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseInfiniteQuery.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseInfiniteQuery.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseInfiniteQuery.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQueries.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQueries.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useSuspenseQueries.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/IsRestoringProvider.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/IsRestoringProvider.js" was ignored.
node_modules/.pnpm/react-router@7.13.2_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-router/dist/development/dom-export.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/react-router@7.13.2_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-router/dist/development/dom-export.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/react-router@7.13.2_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-router/dist/development/dom-export.mjs" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/errorBoundaryUtils.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/errorBoundaryUtils.js" was ignored.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useBaseQuery.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useBaseQuery.js (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@tanstack+react-query@5.85.3_react@19.1.1/node_modules/@tanstack/react-query/build/modern/useBaseQuery.js" was ignored.
node_modules/.pnpm/@radix-ui+react-select@2.2.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_zln5r2fqyry2xxq2i27dq5biju/node_modules/@radix-ui/react-select/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-select@2.2.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_zln5r2fqyry2xxq2i27dq5biju/node_modules/@radix-ui/react-select/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-focus-guards@1.1.3_@types+react@19.1.9_react@19.1.1/node_modules/@radix-ui/react-focus-guards/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-focus-guards@1.1.3_@types+react@19.1.9_react@19.1.1/node_modules/@radix-ui/react-focus-guards/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-collection@1.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19_osprlkpgasstri7fv2i6vnhaiu/node_modules/@radix-ui/react-collection/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-collection@1.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19_osprlkpgasstri7fv2i6vnhaiu/node_modules/@radix-ui/react-collection/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-focus-scope@1.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@1_4uvcbewnlplvp5mhqj6vt3kzqu/node_modules/@radix-ui/react-focus-scope/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-focus-scope@1.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@1_4uvcbewnlplvp5mhqj6vt3kzqu/node_modules/@radix-ui/react-focus-scope/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-popper@1.2.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_4lta3jfbenganxe54t6yk3vk3a/node_modules/@radix-ui/react-popper/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-popper@1.2.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_4lta3jfbenganxe54t6yk3vk3a/node_modules/@radix-ui/react-popper/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-portal@1.1.9_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_vue2ayxlnamrr24i3o55w2q2ia/node_modules/@radix-ui/react-portal/dist/index.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@radix-ui+react-portal@1.1.9_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_vue2ayxlnamrr24i3o55w2q2ia/node_modules/@radix-ui/react-portal/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-portal@1.1.9_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_vue2ayxlnamrr24i3o55w2q2ia/node_modules/@radix-ui/react-portal/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-dismissable-layer@1.1.11_@types+react-dom@19.1.7_@types+react@19.1.9__@types+_4oi5p3jnzed5mtx5nqzfxyxaa4/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/@radix-ui+react-dismissable-layer@1.1.11_@types+react-dom@19.1.7_@types+react@19.1.9__@types+_4oi5p3jnzed5mtx5nqzfxyxaa4/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-dismissable-layer@1.1.11_@types+react-dom@19.1.7_@types+react@19.1.9__@types+_4oi5p3jnzed5mtx5nqzfxyxaa4/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-avatar@1.1.10_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._5qc66ks5idtunqcw6cbfdp4iwy/node_modules/@radix-ui/react-avatar/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-avatar@1.1.10_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._5qc66ks5idtunqcw6cbfdp4iwy/node_modules/@radix-ui/react-avatar/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-label@2.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__lrldt33w64hfmsp3jf7ak3odhe/node_modules/@radix-ui/react-label/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-label@2.1.7_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__lrldt33w64hfmsp3jf7ak3odhe/node_modules/@radix-ui/react-label/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-dialog@1.1.15_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._yotwrva3nbk2qrb5wdslthkhlq/node_modules/@radix-ui/react-dialog/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-dialog@1.1.15_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._yotwrva3nbk2qrb5wdslthkhlq/node_modules/@radix-ui/react-dialog/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-tooltip@1.2.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._cexoh4zuog3xkeo3tpvnedfbnm/node_modules/@radix-ui/react-tooltip/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-tooltip@1.2.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1._cexoh4zuog3xkeo3tpvnedfbnm/node_modules/@radix-ui/react-tooltip/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-presence@1.1.5_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_fyjvj4iyh7se3yoy2j4s3uqxke/node_modules/@radix-ui/react-presence/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-presence@1.1.5_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_fyjvj4iyh7se3yoy2j4s3uqxke/node_modules/@radix-ui/react-presence/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-checkbox@1.3.3_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_kbkxgkkeg6ve5j65b5gy3u5dj4/node_modules/@radix-ui/react-checkbox/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-checkbox@1.3.3_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_kbkxgkkeg6ve5j65b5gy3u5dj4/node_modules/@radix-ui/react-checkbox/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-tabs@1.1.13_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__j6vhadziphhgdduwjyeim7sykm/node_modules/@radix-ui/react-tabs/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-tabs@1.1.13_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__j6vhadziphhgdduwjyeim7sykm/node_modules/@radix-ui/react-tabs/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-dropdown-menu@2.1.16_@types+react-dom@19.1.7_@types+react@19.1.9__@types+reac_5j7aorf345ullhco6q7snwk6oe/node_modules/@radix-ui/react-dropdown-menu/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-dropdown-menu@2.1.16_@types+react-dom@19.1.7_@types+react@19.1.9__@types+reac_5j7aorf345ullhco6q7snwk6oe/node_modules/@radix-ui/react-dropdown-menu/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-popover@1.1.15_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_jodmf5xtlrmjwnfhbqb53cc2ai/node_modules/@radix-ui/react-popover/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-popover@1.1.15_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1_jodmf5xtlrmjwnfhbqb53cc2ai/node_modules/@radix-ui/react-popover/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-roving-focus@1.1.11_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react_atmliute22um6ex66tznhxztgm/node_modules/@radix-ui/react-roving-focus/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-roving-focus@1.1.11_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react_atmliute22um6ex66tznhxztgm/node_modules/@radix-ui/react-roving-focus/dist/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-menu@2.1.16_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__g6lvzsszhksmninjmvoiedjxvu/node_modules/@radix-ui/react-menu/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-menu@2.1.16_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9__g6lvzsszhksmninjmvoiedjxvu/node_modules/@radix-ui/react-menu/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/LazyMotion/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/LazyMotion/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/LayoutGroup/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/LayoutGroup/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/MotionConfig/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/MotionConfig/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/LayoutGroupContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/LayoutGroupContext.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/MotionContext/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/MotionContext/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/MotionConfigContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/MotionConfigContext.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/PresenceContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/PresenceContext.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/SwitchLayoutGroupContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/SwitchLayoutGroupContext.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-radio-group@1.3.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@1_w2z3mmh753t27q4rqejl4ryds4/node_modules/@radix-ui/react-radio-group/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-radio-group@1.3.8_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@1_w2z3mmh753t27q4rqejl4ryds4/node_modules/@radix-ui/react-radio-group/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/LazyContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/LazyContext.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/Reorder/Group.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/Reorder/Group.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/Reorder/Item.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/Reorder/Item.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/index.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/index.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-scroll-area@1.2.10_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@_4wjdtaztuj75ukow4atzgafcoy/node_modules/@radix-ui/react-scroll-area/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-scroll-area@1.2.10_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@_4wjdtaztuj75ukow4atzgafcoy/node_modules/@radix-ui/react-scroll-area/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/ReorderContext.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/context/ReorderContext.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/PresenceChild.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/PresenceChild.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-switch@1.2.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_5o2nzohla6uvpesjmvaca4pieu/node_modules/@radix-ui/react-switch/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-switch@1.2.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_5o2nzohla6uvpesjmvaca4pieu/node_modules/@radix-ui/react-switch/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/PopChild.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/components/AnimatePresence/PopChild.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/features/layout/MeasureLayout.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/features/layout/MeasureLayout.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/features/layout/MeasureLayout.mjs" was ignored.
node_modules/.pnpm/@radix-ui+react-slider@1.3.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_tmxqkshgixjt4brtrq4pzl5ouq/node_modules/@radix-ui/react-slider/dist/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/@radix-ui+react-slider@1.3.6_@types+react-dom@19.1.7_@types+react@19.1.9__@types+react@19.1.9_tmxqkshgixjt4brtrq4pzl5ouq/node_modules/@radix-ui/react-slider/dist/index.mjs" was ignored.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/index.mjs (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/index.mjs (1:0): Module level directives cause errors when bundled, "use client" in "node_modules/.pnpm/framer-motion@12.23.12_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/framer-motion/dist/es/motion/index.mjs" was ignored.

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.\n- browser verification (local Playwright):\n  - employee can edit recent entries\n  - employee cannot edit/delete stale entries\n  - admin can edit/delete stale entries\n\n## Issue\n- relates to #2149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time entries older than 7 days are now restricted to administrators for editing and deletion. Non-admin users can only manage their own recent entries within the 7-day window.
  * Added error messages when non-admins attempt to modify older time entries.

* **Tests**
  * Expanded authorization tests to verify the 7-day age-based access restrictions for timesheet and time-off entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->