### PR TITLE
fix(time-tracking): prefill PTO edit form in week review

### DIFF
--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -979,7 +979,11 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
                 setUpdateView={setUpdateView}
               />
             )}
-            {newTimeoffEntryView && <TimeoffForm />}
+            {newTimeoffEntryView && (
+              <TimeoffForm
+                isDisplayEditTimeoffEntryForm={Boolean(editTimeoffEntryId)}
+              />
+            )}
             <AddEntryButton
               copyingLastWeek={copyingLastWeek}
               handleCopyLastWeek={handleCopyLastWeek}

--- a/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
+++ b/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
@@ -90,7 +90,13 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
     if (isDisplayEditTimeoffEntryForm) {
       handleFillData();
     }
-  }, [isDisplayEditTimeoffEntryForm]);
+  }, [
+    isDisplayEditTimeoffEntryForm,
+    editTimeoffEntryId,
+    selectedFullDate,
+    entryList,
+    leaveTypes,
+  ]);
 
   useEffect(() => {
     if (isHolidayEntry()) {
@@ -134,14 +140,27 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
     return null;
   };
 
-  const handleFillData = () => {
-    const timeoffEntry = entryList[selectedFullDate]?.find(
+  const findEditableTimeoffEntry = () => {
+    const selectedDateEntries = entryList[selectedFullDate] || [];
+    const matchingSelectedDateEntry = selectedDateEntries.find(
       entry => entry.id === editTimeoffEntryId
     );
+    if (matchingSelectedDateEntry) return matchingSelectedDateEntry;
+
+    const allEntries = Object.values(entryList || {}).flat();
+
+    return allEntries.find(entry => entry.id === editTimeoffEntryId);
+  };
+
+  const handleFillData = () => {
+    const timeoffEntry = findEditableTimeoffEntry();
 
     if (timeoffEntry) {
       setDuration(minToHHMM(timeoffEntry?.duration || 0));
       setNote(timeoffEntry?.note || "");
+      if (timeoffEntry?.leave_date) {
+        setSelectedDate(dayjs(timeoffEntry.leave_date).format("YYYY-MM-DD"));
+      }
 
       if (timeoffEntry?.holiday_info_id) {
         const currentHolidayId = timeoffEntry.holiday_info_id || 0;

--- a/spec/requests/api/v1/timesheet_entries/destroy_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/destroy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Api::V1::TimesheetEntry#destroy", type: :request do
   let(:client) { create(:client, company:) }
   let(:project) { create(:project, client:) }
   let!(:timesheet_entry) {
-    create(:timesheet_entry, user:, project:, work_date: Time.now - 30.days)
+    create(:timesheet_entry, user:, project:, work_date: Time.current)
   }
 
   context "when user is an admin" do
@@ -55,6 +55,19 @@ RSpec.describe "Api::V1::TimesheetEntry#destroy", type: :request do
 
       expect(json_response["notice"]).to match("Timesheet deleted")
       expect(timesheet_entry.reload).to be_discarded
+    end
+
+    context "when entry is older than one week" do
+      before do
+        timesheet_entry.update!(work_date: 30.days.ago)
+      end
+
+      it "returns forbidden" do
+        send_request :delete, api_v1_timesheet_entry_path(timesheet_entry), headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response["errors"]).to include("You are not authorized to perform this action.")
+      end
     end
   end
 

--- a/spec/requests/api/v1/timesheet_entries/update_spec.rb
+++ b/spec/requests/api/v1/timesheet_entries/update_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V1::TimesheetEntry#update", type: :request do
       :timesheet_entry,
       user:,
       project:,
-      work_date: Time.now - 30.days,
+      work_date: Time.current,
       duration: 10,
       note: "Test note",
       bill_status: :unbilled
@@ -137,6 +137,27 @@ RSpec.describe "Api::V1::TimesheetEntry#update", type: :request do
           project_id: project.id,
           timesheet_entry: {
             bill_status: :unbilled
+          }
+        }, headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response["errors"]).to include("You are not authorized to perform this action.")
+      end
+    end
+
+    context "when the entry is older than one week" do
+      before do
+        timesheet_entry.update!(work_date: 30.days.ago)
+      end
+
+      it "returns forbidden for updates" do
+        send_request :patch, api_v1_timesheet_entry_path(timesheet_entry.id), params: {
+          project_id: project.id,
+          timesheet_entry: {
+            duration: 20,
+            work_date: Time.current,
+            note: "Updated Note",
+            bill_status: :billed
           }
         }, headers: auth_headers(user)
 

--- a/spec/system/time_tracking/views_spec.rb
+++ b/spec/system/time_tracking/views_spec.rb
@@ -113,6 +113,39 @@ RSpec.describe "Time Tracking Views", type: :system, js: true do
     end
   end
 
+  it "pre-fills leave edit form from week review and allows updating" do
+    leave = create(:leave, company:, year: Date.current.year)
+    leave_type = create(:leave_type, leave:, name: "Paid Time Off")
+    leave_date = Date.current.beginning_of_week
+    leave_date += 1.day if leave_date == Date.current
+    create(
+      :timeoff_entry,
+      user:,
+      leave_type:,
+      leave_date:,
+      duration: 480,
+      note: "Editable week review PTO"
+    )
+
+    with_forgery_protection do
+      visit "/time-tracking"
+      find("[data-testid='time-review-week']", wait: 10).click
+
+      within("[data-testid='timeoff-entry-card']", text: "Editable week review PTO") do
+        find("button[title='Edit entry']", wait: 10).click
+      end
+
+      expect(page).to have_field("notes", with: "Editable week review PTO", wait: 10)
+      expect(page).to have_button("Update Entry", disabled: false, wait: 10)
+
+      fill_in "notes", with: "Editable week review PTO updated"
+      click_button "Update Entry"
+
+      find("[data-testid='time-review-week']", wait: 10).click
+      expect(page).to have_content("Editable week review PTO updated", wait: 10)
+    end
+  end
+
   it "lets an admin switch to another user" do
     employee = create(:user, first_name: "Jane", last_name: "Developer", current_workspace_id: company.id)
     create(:employment, company:, user: employee)


### PR DESCRIPTION
## Summary
- Pass `isDisplayEditTimeoffEntryForm` from Time Tracking into `TimeoffForm` when editing PTO entries.
- Make time-off form hydration react to edit-mode dependencies (`editTimeoffEntryId`, `selectedFullDate`, `entryList`, `leaveTypes`).
- Add fallback lookup across all day buckets so edit works even when selected-date key and entry bucket differ.
- Pre-fill selected date from entry `leave_date` in edit mode.
- Add system regression coverage for week-review PTO edit prefill and enabled update action.

## Verification
- `rtk mise exec -- timeout 240 bundle exec rspec spec/system/time_tracking/views_spec.rb:115`
- `rtk mise exec -- pnpm eslint app/javascript/src/components/TimeTracking/index.tsx app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx`
- `rtk mise exec -- bundle exec rubocop spec/system/time_tracking/views_spec.rb`
- `rtk mise exec -- timeout 30 bin/vite build`
- Playwright local verification (manual script): `output/playwright/local-pto-edit-verified.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeoff form now correctly distinguishes create vs. edit mode and pre-fills date, duration and notes when editing entries.
* **Refactor**
  * Edit-form initialization reliably re-runs when related data changes to ensure accurate pre-fill behavior.
* **Tests**
  * Added system test for editing a timeoff entry and updated request specs to assert permission behavior for older timesheet entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->