### PR TITLE
Fix calendar/date/time picker visibility across invoice and time-entry flows

### DIFF
--- a/app/javascript/src/common/CustomDatePicker/index.tsx
+++ b/app/javascript/src/common/CustomDatePicker/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { getMonth, getYear } from "date-fns";
 import dayjs from "dayjs";
 import { useOutsideClick } from "helpers";
-import { CaretCircleLeftIcon, CaretCircleRightIcon } from "miruIcons";
+import { CaretLeft, CaretRight } from "phosphor-react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -42,7 +42,7 @@ const CustomDatePicker = ({
   ];
 
   useOutsideClick(wrapperRef, () => {
-    setVisibility(false);
+    setVisibility?.(false);
   });
 
   const parseDate = dateValue => {
@@ -68,10 +68,10 @@ const CustomDatePicker = ({
   return (
     <DatePicker
       inline
-      calendarClassName="miru-calendar"
+      calendarClassName="miru-datepicker miru-datepicker--single"
       selected={parseDate(date)}
       maxDate={maxDate}
-      wrapperClassName="datePicker"
+      wrapperClassName="datePicker miru-datepicker-wrapper"
       renderCustomHeader={({
         date,
         changeYear,
@@ -99,11 +99,17 @@ const CustomDatePicker = ({
 
         return (
           <div className="headerWrapper">
-            <button disabled={prevMonthButtonDisabled} onClick={decreaseMonth}>
-              <CaretCircleLeftIcon color="#5b34ea" size={16} />
+            <button
+              type="button"
+              className="miru-datepicker-nav-btn"
+              disabled={prevMonthButtonDisabled}
+              onClick={decreaseMonth}
+            >
+              <CaretLeft size={14} weight="bold" />
             </button>
             <div>
               <select
+                className="miru-datepicker-select"
                 value={months[getMonth(date)]}
                 onChange={({ target: { value } }) =>
                   changeMonth(months.indexOf(value))
@@ -116,6 +122,7 @@ const CustomDatePicker = ({
                 ))}
               </select>
               <select
+                className="miru-datepicker-select"
                 value={getYear(date)}
                 onChange={({ target: { value } }) => changeYear(value)}
               >
@@ -126,8 +133,13 @@ const CustomDatePicker = ({
                 ))}
               </select>
             </div>
-            <button disabled={nextDisabled} onClick={increaseMonth}>
-              <CaretCircleRightIcon color="#5b34ea" size={16} />
+            <button
+              type="button"
+              className="miru-datepicker-nav-btn"
+              disabled={nextDisabled}
+              onClick={increaseMonth}
+            >
+              <CaretRight size={14} weight="bold" />
             </button>
           </div>
         );

--- a/app/javascript/src/common/CustomDateRangePicker/index.tsx
+++ b/app/javascript/src/common/CustomDateRangePicker/index.tsx
@@ -2,11 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { getMonth, getYear } from "date-fns";
 import dayjs from "dayjs";
-import {
-  CaretCircleLeftIcon,
-  CaretCircleRightIcon,
-  LeftArrowIcon,
-} from "miruIcons";
+import { LeftArrowIcon } from "miruIcons";
+import { CaretLeft, CaretRight } from "phosphor-react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { i18n } from "../../i18n";
@@ -202,8 +199,8 @@ const CustomDateRangePicker = ({
   return (
     <DatePicker
       inline
-      calendarClassName="miru-calendar-date-range"
-      wrapperClassName="datePicker absolute"
+      calendarClassName="miru-datepicker miru-datepicker--range"
+      wrapperClassName="datePicker absolute miru-datepicker-wrapper"
       maxDate={
         selectedInput === fromInput && dateRange.to
           ? new Date(dateRange.to)
@@ -223,10 +220,14 @@ const CustomDateRangePicker = ({
         prevMonthButtonDisabled,
         nextMonthButtonDisabled,
       }) => (
-        <div className="bg-background ">
+        <div className="bg-background">
           <div className="mt-2 flex justify-start">
-            <button type="button" onClick={hideCustomFilter}>
-              <LeftArrowIcon color="#5b34ea" size={10} />
+            <button
+              type="button"
+              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-primary hover:bg-accent"
+              onClick={hideCustomFilter}
+            >
+              <LeftArrowIcon color="currentColor" size={10} />
             </button>
             <p className="ml-2 text-sm font-medium">
               {i18n.t("customDateRange")}
@@ -240,8 +241,8 @@ const CustomDateRangePicker = ({
                 placeholder={i18n.t("from")}
                 ref={textInput}
                 type="text"
-                className={`mr-1 h-8 w-32 rounded bg-muted p-1 ${
-                  selectedInput === fromInput && "border-2 border-primary"
+                className={`mr-1 h-9 w-36 rounded-md border border-input bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
+                  selectedInput === fromInput && "border-primary"
                 }`}
                 value={
                   dateRange.from
@@ -265,8 +266,8 @@ const CustomDateRangePicker = ({
                 placeholder={i18n.t("to")}
                 ref={toInputRef}
                 type="text"
-                className={`ml-1 h-8 w-32 rounded bg-muted p-1 ${
-                  selectedInput === toInput && "border-2 border-primary"
+                className={`ml-1 h-9 w-36 rounded-md border border-input bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
+                  selectedInput === toInput && "border-primary"
                 }`}
                 value={
                   dateRange.to
@@ -285,13 +286,15 @@ const CustomDateRangePicker = ({
           <div className="headerWrapper mt-4">
             <button
               type="button"
+              className="miru-datepicker-nav-btn"
               disabled={prevMonthButtonDisabled}
               onClick={decreaseMonth}
             >
-              <CaretCircleLeftIcon color="#5b34ea" size={16} />
+              <CaretLeft size={14} weight="bold" />
             </button>
             <div>
               <select
+                className="miru-datepicker-select"
                 value={months[getMonth(date)]}
                 onChange={({ target: { value } }) =>
                   changeMonth(months.indexOf(value))
@@ -304,6 +307,7 @@ const CustomDateRangePicker = ({
                 ))}
               </select>
               <select
+                className="miru-datepicker-select"
                 value={getYear(date)}
                 onChange={({ target: { value } }) => changeYear(value)}
               >
@@ -316,10 +320,11 @@ const CustomDateRangePicker = ({
             </div>
             <button
               type="button"
+              className="miru-datepicker-nav-btn"
               disabled={nextMonthButtonDisabled}
               onClick={increaseMonth}
             >
-              <CaretCircleRightIcon color="#5b34ea" size={16} />
+              <CaretRight size={14} weight="bold" />
             </button>
           </div>
         </div>

--- a/app/javascript/src/common/CustomDateRangeWIthInput/index.tsx
+++ b/app/javascript/src/common/CustomDateRangeWIthInput/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { getMonth, getYear } from "date-fns";
 import dayjs from "dayjs";
-import { CaretCircleLeftIcon, CaretCircleRightIcon } from "miruIcons";
+import { CaretLeft, CaretRight } from "phosphor-react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -229,8 +229,8 @@ const CustomDateRangeWithInput = ({
             placeholder=" From "
             ref={textInput}
             type="text"
-            className={`mr-1 h-8 w-32 rounded bg-muted p-1 text-sm text-foreground ${
-              selectedInput === fromInput && "border-2 border-primary"
+            className={`mr-1 h-9 w-36 rounded-md border border-input bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
+              selectedInput === fromInput && "border-primary"
             }`}
             value={
               dateRange.from ? dayjs(dateRange.from).format("DD MMM YYYY") : ""
@@ -251,8 +251,8 @@ const CustomDateRangeWithInput = ({
             placeholder=" To "
             ref={toInputRef}
             type="text"
-            className={`ml-1 h-8 w-32 rounded bg-muted p-1 text-sm text-foreground ${
-              selectedInput === toInput && "border-2 border-primary"
+            className={`ml-1 h-9 w-36 rounded-md border border-input bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
+              selectedInput === toInput && "border-primary"
             }`}
             value={
               dateRange.to ? dayjs(dateRange.to).format("DD MMM YYYY") : ""
@@ -271,8 +271,8 @@ const CustomDateRangeWithInput = ({
         {showCustomCalendar && (
           <DatePicker
             inline
-            calendarClassName="miru-calendar-date-range"
-            wrapperClassName="datePicker absolute"
+            calendarClassName="miru-datepicker miru-datepicker--range"
+            wrapperClassName="datePicker absolute miru-datepicker-wrapper"
             maxDate={
               selectedInput === fromInput && dateRange.to
                 ? new Date(dateRange.to)
@@ -292,16 +292,19 @@ const CustomDateRangeWithInput = ({
               prevMonthButtonDisabled,
               nextMonthButtonDisabled,
             }) => (
-              <div className="bg-background ">
+              <div className="bg-background">
                 <div className="headerWrapper mt-4">
                   <button
+                    type="button"
+                    className="miru-datepicker-nav-btn"
                     disabled={prevMonthButtonDisabled}
                     onClick={decreaseMonth}
                   >
-                    <CaretCircleLeftIcon color="#5b34ea" size={16} />
+                    <CaretLeft size={14} weight="bold" />
                   </button>
                   <div>
                     <select
+                      className="miru-datepicker-select"
                       value={months[getMonth(date)]}
                       onChange={({ target: { value } }) =>
                         changeMonth(months.indexOf(value))
@@ -314,6 +317,7 @@ const CustomDateRangeWithInput = ({
                       ))}
                     </select>
                     <select
+                      className="miru-datepicker-select"
                       value={getYear(date)}
                       onChange={({ target: { value } }) => changeYear(value)}
                     >
@@ -325,10 +329,12 @@ const CustomDateRangeWithInput = ({
                     </select>
                   </div>
                   <button
+                    type="button"
+                    className="miru-datepicker-nav-btn"
                     disabled={nextMonthButtonDisabled}
                     onClick={increaseMonth}
                   >
-                    <CaretCircleRightIcon color="#5b34ea" size={16} />
+                    <CaretRight size={14} weight="bold" />
                   </button>
                 </div>
               </div>

--- a/app/javascript/src/common/CustomYearPicker/SingleYearDatePicker.tsx
+++ b/app/javascript/src/common/CustomYearPicker/SingleYearDatePicker.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { getMonth } from "date-fns";
 import dayjs from "dayjs";
 import { useOutsideClick } from "helpers";
-import { CaretCircleLeftIcon, CaretCircleRightIcon } from "miruIcons";
+import { CaretLeft, CaretRight } from "phosphor-react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -40,7 +40,7 @@ const SingleYearDatePicker = ({
   ];
 
   useOutsideClick(wrapperRef, () => {
-    setVisibility(false);
+    setVisibility?.(false);
   });
 
   const parseDate = dateString => dayjs(dateString, dateFormat).toDate();
@@ -50,11 +50,11 @@ const SingleYearDatePicker = ({
   return (
     <DatePicker
       inline
-      calendarClassName="miru-calendar"
+      calendarClassName="miru-datepicker miru-datepicker--single"
       maxDate={dayjs(`${selectedYear}-12-31`).toDate()}
       minDate={dayjs(`${selectedYear}-01-01`).toDate()}
       selected={parseDate(date)}
-      wrapperClassName="datePicker"
+      wrapperClassName="datePicker miru-datepicker-wrapper"
       renderCustomHeader={({
         date,
         changeMonth,
@@ -64,14 +64,17 @@ const SingleYearDatePicker = ({
         nextMonthButtonDisabled,
       }) => (
         <div className="headerWrapper">
-          <button disabled={prevMonthButtonDisabled} onClick={decreaseMonth}>
-            <CaretCircleLeftIcon
-              color={prevMonthButtonDisabled ? "#ADA4CE" : "#5b34ea"}
-              size={16}
-            />
+          <button
+            type="button"
+            className="miru-datepicker-nav-btn"
+            disabled={prevMonthButtonDisabled}
+            onClick={decreaseMonth}
+          >
+            <CaretLeft size={14} weight="bold" />
           </button>
           <div>
             <select
+              className="miru-datepicker-select"
               value={months[getMonth(date)]}
               onChange={({ target: { value } }) =>
                 changeMonth(months.indexOf(value))
@@ -84,11 +87,13 @@ const SingleYearDatePicker = ({
               ))}
             </select>
           </div>
-          <button disabled={nextMonthButtonDisabled} onClick={increaseMonth}>
-            <CaretCircleRightIcon
-              color={nextMonthButtonDisabled ? "#ADA4CE" : "#5b34ea"}
-              size={16}
-            />
+          <button
+            type="button"
+            className="miru-datepicker-nav-btn"
+            disabled={nextMonthButtonDisabled}
+            onClick={increaseMonth}
+          >
+            <CaretRight size={14} weight="bold" />
           </button>
         </div>
       )}

--- a/app/javascript/src/components/ui/animated-time-input.tsx
+++ b/app/javascript/src/components/ui/animated-time-input.tsx
@@ -304,12 +304,12 @@ const AnimatedTimeInput: React.FC<AnimatedTimeInputProps> = ({
 
   const inputVariants = {
     initial: {
-      borderColor: "#e5e7eb",
+      borderColor: "hsl(var(--input))",
       boxShadow: "none",
     },
     focus: {
-      borderColor: "#3b82f6",
-      boxShadow: "0 0 0 3px rgba(59, 130, 246, 0.1)",
+      borderColor: "hsl(var(--ring))",
+      boxShadow: "0 0 0 3px hsl(var(--ring) / 0.18)",
       transition: {
         type: "spring",
         stiffness: 300,
@@ -317,8 +317,8 @@ const AnimatedTimeInput: React.FC<AnimatedTimeInputProps> = ({
       },
     },
     error: {
-      borderColor: "#ef4444",
-      boxShadow: "0 0 0 3px rgba(239, 68, 68, 0.1)",
+      borderColor: "hsl(var(--destructive))",
+      boxShadow: "0 0 0 3px hsl(var(--destructive) / 0.2)",
     },
   };
 
@@ -425,7 +425,7 @@ const AnimatedTimeInput: React.FC<AnimatedTimeInputProps> = ({
       },
     }),
     hover: {
-      backgroundColor: "#f3f4f6",
+      backgroundColor: "hsl(var(--accent))",
       x: 4,
       transition: {
         type: "spring",
@@ -561,7 +561,7 @@ const AnimatedTimeInput: React.FC<AnimatedTimeInputProps> = ({
                     custom={index}
                     className={cn(
                       "w-full flex items-center justify-between px-3 py-2 text-left text-sm rounded-md transition-colors",
-                      "hover:bg-muted hover:text-gray-900",
+                      "hover:bg-muted hover:text-foreground",
                       "focus:bg-muted focus:text-foreground focus:outline-none"
                     )}
                     onClick={e => {

--- a/app/javascript/src/components/ui/calendar.tsx
+++ b/app/javascript/src/components/ui/calendar.tsx
@@ -17,37 +17,40 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        month_caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
+        months:
+          "flex flex-col sm:flex-row gap-4 sm:gap-6 items-start justify-center",
+        month: "space-y-3",
+        month_caption:
+          "flex justify-center pt-1 relative items-center h-9 px-2 rounded-md bg-muted/40",
+        caption_label: "text-sm font-semibold text-foreground",
         nav: "space-x-1 flex items-center",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1"
+          "h-7 w-7 bg-background/80 p-0 border-border text-foreground/80 hover:text-foreground hover:bg-accent absolute left-1"
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1"
+          "h-7 w-7 bg-background/80 p-0 border-border text-foreground/80 hover:text-foreground hover:bg-accent absolute right-1"
         ),
-        month_grid: "w-full border-collapse space-y-1",
-        weekdays: "flex",
+        month_grid: "w-full border-separate border-spacing-y-1.5",
+        weekdays: "grid grid-cols-7 gap-1",
         weekday:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        week: "flex w-full mt-2",
-        day: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].outside)]:bg-muted/50 [&:has([aria-selected])]:bg-muted first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+          "h-9 inline-flex items-center justify-center text-muted-foreground font-medium text-[0.8rem] uppercase tracking-wide",
+        week: "grid grid-cols-7 gap-1",
+        day: "h-9 w-9 text-center text-sm p-0 relative rounded-md [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].outside)]:bg-accent/60 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "h-9 w-9 p-0 font-medium text-foreground rounded-md hover:bg-accent/70 aria-selected:opacity-100"
         ),
         range_end: "day-range-end",
         selected:
-          "bg-primary text-white hover:bg-primary hover:text-white focus:bg-primary focus:text-white",
-        today: "bg-muted text-foreground",
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        today: "bg-accent text-foreground font-semibold",
         outside:
-          "day-outside text-muted-foreground opacity-50 aria-selected:bg-muted/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
-        disabled: "text-muted-foreground opacity-50",
-        range_middle: "aria-selected:bg-muted aria-selected:text-foreground",
+          "day-outside text-muted-foreground/70 opacity-70 aria-selected:bg-accent/60 aria-selected:text-muted-foreground aria-selected:opacity-80",
+        disabled: "text-muted-foreground/50 opacity-50",
+        range_middle:
+          "aria-selected:bg-primary/15 aria-selected:text-foreground rounded-md",
         hidden: "invisible",
         ...classNames,
       }}

--- a/app/javascript/src/components/ui/date-picker.tsx
+++ b/app/javascript/src/components/ui/date-picker.tsx
@@ -23,7 +23,7 @@ export function DatePicker({
         <Button
           variant={"outline"}
           className={cn(
-            "w-full justify-start text-left font-normal",
+            "w-full justify-start text-left font-normal border-input bg-background hover:bg-accent/60",
             !date && "text-muted-foreground",
             className
           )}
@@ -32,7 +32,7 @@ export function DatePicker({
           {date ? format(date, "PPP") : <span>{placeholder}</span>}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
+      <PopoverContent className="w-auto p-2 rounded-xl border-border bg-popover shadow-lg">
         <Calendar
           mode="single"
           selected={date}

--- a/app/javascript/src/components/ui/date-range-picker.tsx
+++ b/app/javascript/src/components/ui/date-range-picker.tsx
@@ -28,7 +28,7 @@ export function DateRangePicker({
             id="date"
             variant={"outline"}
             className={cn(
-              "w-full justify-start text-left font-normal",
+              "w-full justify-start text-left font-normal border-input bg-background hover:bg-accent/60",
               !date && "text-muted-foreground"
             )}
           >
@@ -47,7 +47,10 @@ export function DateRangePicker({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
+        <PopoverContent
+          className="w-auto p-2 rounded-xl border-border bg-popover shadow-lg"
+          align="start"
+        >
           <Calendar
             initialFocus
             mode="range"

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -907,3 +907,184 @@ input[type="number"]::-webkit-outer-spin-button {
 input[type="number"] {
   -moz-appearance: textfield;
 }
+
+/* Unified date/time picker styling (react-datepicker + native date/time fields) */
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker) {
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.875rem;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  font-family: inherit;
+  box-shadow: 0 14px 40px hsl(var(--foreground) / 0.12);
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__triangle {
+  display: none;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__header {
+  background: hsl(var(--muted) / 0.45);
+  border-bottom: 1px solid hsl(var(--border));
+  border-top-left-radius: 0.875rem;
+  border-top-right-radius: 0.875rem;
+  padding-top: 0.5rem;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__current-month {
+  color: hsl(var(--foreground));
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__month {
+  margin: 0.4rem 0.7rem 0.7rem;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day-names,
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__week {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.2rem;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day-name {
+  width: 2.35rem;
+  height: 2.1rem;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day {
+  width: 2.35rem;
+  height: 2.2rem;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.55rem;
+  color: hsl(var(--foreground));
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--today {
+  background: hsl(var(--accent) / 0.85);
+  font-weight: 700;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--keyboard-selected {
+  background: hsl(var(--primary) / 0.15);
+  color: hsl(var(--foreground));
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--selected,
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--in-selecting-range,
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--in-range {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--outside-month {
+  color: hsl(var(--muted-foreground));
+  opacity: 0.6;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--disabled {
+  color: hsl(var(--muted-foreground));
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+:is(.miru-datepicker-wrapper .react-datepicker, .react-datepicker.miru-datepicker)
+  .react-datepicker__day--disabled:hover {
+  background: transparent;
+}
+
+.headerWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.3rem 0.25rem 0.2rem;
+}
+
+.headerWrapper > div {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.miru-datepicker-nav-btn {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 0.5rem;
+  border: 1px solid hsl(var(--border));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+}
+
+.miru-datepicker-nav-btn:hover:not(:disabled) {
+  background: hsl(var(--accent));
+}
+
+.miru-datepicker-nav-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.miru-datepicker-select {
+  height: 1.8rem;
+  border: 1px solid hsl(var(--input));
+  border-radius: 0.5rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  padding: 0 0.5rem;
+  font-size: 0.8rem;
+}
+
+.miru-datepicker--range .react-datepicker__month-container {
+  width: 100%;
+}
+
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"] {
+  color: hsl(var(--foreground));
+  background-color: hsl(var(--background));
+  border-color: hsl(var(--input));
+}
+
+.dark input[type="date"]::-webkit-calendar-picker-indicator,
+.dark input[type="time"]::-webkit-calendar-picker-indicator,
+.dark input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.88) brightness(1.05);
+}


### PR DESCRIPTION
## Summary
- unify shared calendar/date/time picker styling to a clean shadcn-like visual system
- fix dark/light contrast issues in invoice create/edit and line-item date pickers
- modernize shared datepicker headers/nav/select controls across custom picker components
- normalize animated time input states to theme tokens instead of hardcoded light colors

## Verification
- `rtk mise exec -- timeout 30 bin/vite build`
- `rtk mise exec -- bundle exec rspec spec/system/settings/holidays_spec.rb spec/system/time_tracking/add_entry_spec.rb`
- Playwright manual checks:
  - `/invoices/new` (light + dark, date picker open)
  - `/invoices/1433/edit` (light + dark, top-level and line-item date pickers open)
  - `/time-tracking` add-entry form (dark mode)
  - console errors on validated flows: 0

## Notes
- Existing invoice-currency system spec failures in `spec/system/invoices/create_spec.rb` and `spec/system/invoices/edit_spec.rb` are pre-existing and unrelated to this picker styling patch.
- Issue #2153 is already closed; this patch applies the same calendar cleanliness/visibility direction project-wide.