### PR TITLE
fix(reminders): prevent duplicate weekly missed-entry emails

### DIFF
--- a/app/services/weekly_reminder_for_missed_entries_service.rb
+++ b/app/services/weekly_reminder_for_missed_entries_service.rb
@@ -7,14 +7,17 @@ class WeeklyReminderForMissedEntriesService
         notification_preference = NotificationPreference.find_by(user_id: user.id, company_id: company.id)
 
         if notification_preference&.can_receive_weekly_reminder?
-          check_entries_and_send_mail(user, company)
+          check_entries_and_send_mail(user, company, notification_preference)
         end
       end
     end
   end
 
-  def check_entries_and_send_mail(user, company)
+  def check_entries_and_send_mail(user, company, notification_preference = nil)
     return unless user_is_admin_or_employee?(user, company)
+
+    notification_preference ||= NotificationPreference.find_by(user_id: user.id, company_id: company.id)
+    return if notification_preference.blank?
 
     name = user.full_name
     company_name = company.name
@@ -27,7 +30,14 @@ class WeeklyReminderForMissedEntriesService
     entries_total_duration = entries.sum(&:duration)
 
     if entries_total_duration < limit
-      send_mail(recipients: user.email, name:, start_date:, end_date:, company_name:)
+      send_weekly_reminder_once(
+        notification_preference:,
+        recipients: user.email,
+        name:,
+        start_date:,
+        end_date:,
+        company_name:
+      )
     end
   end
 
@@ -45,6 +55,17 @@ class WeeklyReminderForMissedEntriesService
         end_date:,
         company_name:
       ).notify_user_about_missed_entries.deliver_later
+    end
+
+    # This lock makes the weekly reminder idempotent per user/company/week,
+    # even if the scheduled job is triggered multiple times across environments.
+    def send_weekly_reminder_once(notification_preference:, recipients:, name:, start_date:, end_date:, company_name:)
+      notification_preference.with_lock do
+        return if notification_preference.weekly_reminder_last_sent_for_week_start == start_date
+
+        send_mail(recipients:, name:, start_date:, end_date:, company_name:)
+        notification_preference.update!(weekly_reminder_last_sent_for_week_start: start_date)
+      end
     end
 
     def get_entries_for_period(user:, company:, start_date:, end_date:)

--- a/db/migrate/20260416194500_add_weekly_reminder_last_sent_for_week_start_to_notification_preferences.rb
+++ b/db/migrate/20260416194500_add_weekly_reminder_last_sent_for_week_start_to_notification_preferences.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeeklyReminderLastSentForWeekStartToNotificationPreferences < ActiveRecord::Migration[8.1]
+  def change
+    add_column :notification_preferences, :weekly_reminder_last_sent_for_week_start, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_143000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_194500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -571,6 +571,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_143000) do
     t.boolean "unsubscribed_from_all", default: false, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.date "weekly_reminder_last_sent_for_week_start"
     t.index ["company_id"], name: "index_notification_preferences_on_company_id"
     t.index ["user_id", "company_id"], name: "index_notification_preferences_on_user_id_and_company_id", unique: true
     t.index ["user_id"], name: "index_notification_preferences_on_user_id"

--- a/spec/services/weekly_reminder_for_missed_entries_service_spec.rb
+++ b/spec/services/weekly_reminder_for_missed_entries_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WeeklyReminderForMissedEntriesService do
       eligible_user.add_role :employee, company
       unsubscribed_user.add_role :employee, company
 
-      create(
+      eligible_preference = create(
         :notification_preference,
         :all_enabled,
         user: eligible_user,
@@ -33,7 +33,7 @@ RSpec.describe WeeklyReminderForMissedEntriesService do
 
       service.process
 
-      expect(service).to have_received(:check_entries_and_send_mail).with(eligible_user, company)
+      expect(service).to have_received(:check_entries_and_send_mail).with(eligible_user, company, eligible_preference)
       expect(service).not_to have_received(:check_entries_and_send_mail).with(unsubscribed_user, company)
     end
   end
@@ -41,6 +41,7 @@ RSpec.describe WeeklyReminderForMissedEntriesService do
   describe "#check_entries_and_send_mail" do
     let(:company) { create(:company, working_hours: "40") }
     let(:user) { create(:user, current_workspace_id: company.id) }
+    let(:notification_preference) { create(:notification_preference, :all_enabled, user:, company:) }
     let(:service) { described_class.new }
 
     before do
@@ -85,10 +86,34 @@ RSpec.describe WeeklyReminderForMissedEntriesService do
           )
         end
 
-        service.check_entries_and_send_mail(user, company)
+        service.check_entries_and_send_mail(user, company, notification_preference)
       end
 
       expect(service).to have_received(:send_mail).once
+    end
+
+    it "sends at most one reminder per user/company for a given week" do
+      travel_to Time.zone.local(2026, 4, 6, 14, 0, 0) do
+        monday_previous_week = Date.new(2026, 3, 30)
+
+        [0, 1, 2].each do |offset|
+          project = create(:project, client: create(:client, company:))
+          create(
+            :timesheet_entry,
+            user:,
+            project:,
+            duration: 480,
+            work_date: monday_previous_week + offset.days
+          )
+        end
+
+        2.times do
+          service.check_entries_and_send_mail(user, company, notification_preference)
+        end
+      end
+
+      expect(service).to have_received(:send_mail).once
+      expect(notification_preference.reload.weekly_reminder_last_sent_for_week_start).to eq(Date.new(2026, 3, 30))
     end
   end
 end


### PR DESCRIPTION
## Summary
- make weekly missed-entry reminders idempotent per user/company/week
- add a `weekly_reminder_last_sent_for_week_start` checkpoint on `notification_preferences`
- guard sending with `with_lock` so concurrent/scheduled duplicate runs cannot enqueue the same weekly reminder twice
- keep existing reminder eligibility and week-range logic intact

## Verification
- `rtk mise exec -- bundle exec rails db:migrate`
- `rtk mise exec -- timeout 300 bundle exec rspec spec/services/weekly_reminder_for_missed_entries_service_spec.rb`
- `rtk mise exec -- bundle exec rubocop app/services/weekly_reminder_for_missed_entries_service.rb spec/services/weekly_reminder_for_missed_entries_service_spec.rb db/migrate/20260416194500_add_weekly_reminder_last_sent_for_week_start_to_notification_preferences.rb`

Fixes #2099