### PR TITLE
Fix draft invoice actions and zero-value submit guards

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
@@ -278,8 +278,18 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
     [submissionLineItems]
   );
 
+  const hasInvalidLineItems = useMemo(
+    () =>
+      activeLineItems.some(
+        item => Number(item?.quantity || 0) <= 0 || Number(item?.rate || 0) <= 0
+      ),
+    [activeLineItems]
+  );
+
   const canSubmitInvoice =
-    Boolean(formData.clientId) && activeLineItems.length > 0;
+    Boolean(formData.clientId) &&
+    activeLineItems.length > 0 &&
+    !hasInvalidLineItems;
 
   const isSentInvoice = ["sent", "viewed", "overdue", "paid"].includes(
     formData.status

--- a/app/javascript/src/components/Invoices/InvoiceList.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceList.tsx
@@ -32,6 +32,7 @@ import {
   Warning,
   FileText,
   Hourglass,
+  Trash,
   Funnel,
   X,
   CircleNotch,
@@ -61,6 +62,7 @@ interface InvoiceListProps {
   onMarkPaid?: (invoice: Invoice) => void;
   onWaive?: (invoice: Invoice) => void;
   onDownload?: (id: string) => void;
+  onDelete?: (id: string) => Promise<void> | void;
   onLoadMore?: () => void;
   isLoading?: boolean;
   hasMore?: boolean;
@@ -78,6 +80,7 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
   onMarkPaid,
   onWaive,
   onDownload,
+  onDelete,
   onLoadMore,
   isLoading = false,
   hasMore = false,
@@ -320,6 +323,15 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
               >
                 <PaperPlaneTilt className="h-4 w-4 mr-2" />
                 {i18n.t("invoices.sendInvoice")}
+              </DropdownMenuItem>
+            )}
+            {invoice.status === "draft" && (
+              <DropdownMenuItem
+                data-testid={`invoice-action-delete-${invoice.id}`}
+                onClick={() => onDelete?.(invoice.id)}
+              >
+                <Trash className="h-4 w-4 mr-2" />
+                {i18n.t("delete")}
               </DropdownMenuItem>
             )}
             {invoice.status === "overdue" && (

--- a/app/javascript/src/components/Invoices/index.tsx
+++ b/app/javascript/src/components/Invoices/index.tsx
@@ -416,6 +416,37 @@ const InvoicesPage: React.FC<InvoicesPageProps> = ({
     }
   };
 
+  const handleDeleteInvoiceFromList = async (id: string) => {
+    if (!id) return;
+
+    const shouldDelete = window.confirm(
+      i18n.t("invoices.deleteInvoiceConfirm")
+    );
+    if (!shouldDelete) return;
+
+    try {
+      setIsLoading(true);
+      await invoiceApi.deleteInvoice(id);
+
+      if (
+        String(selectedInvoiceId) === String(id) ||
+        String(previewData?.id) === String(id)
+      ) {
+        setSelectedInvoiceId(null);
+        setSelectedInvoice(null);
+        setPreviewData(null);
+        setViewMode("list");
+      }
+
+      await loadInvoices();
+    } catch (err) {
+      console.error("Error deleting invoice:", err);
+      toast.error(i18n.t("somethingWentWrong"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleSendReminderFromList = async (
     id: string,
     invoiceEmail?: { subject: string; message: string; recipients: string[] }
@@ -570,6 +601,7 @@ const InvoicesPage: React.FC<InvoicesPageProps> = ({
           onMarkPaid={handleMarkPaid}
           onWaive={handleWaiveInvoice}
           onDownload={handleDownload}
+          onDelete={handleDeleteInvoiceFromList}
           onLoadMore={loadMoreInvoices}
           isLoading={isListLoading || isLoading}
           isLoadingMore={isLoadingMore}


### PR DESCRIPTION
## Summary
- add `Delete` quick action for `draft` invoices in the new invoice list table dropdown
- wire draft deletion in the new invoices page (`window.confirm` + API delete + list refresh)
- block Save/Send in invoice editor when any active line item has `quantity <= 0` or `rate <= 0`

## Verification
- `rtk mise exec -- timeout 30 bin/vite build` (timed out at 30s after transform step)
- `rtk mise exec -- timeout 180 bin/vite build` (pass)
- Playwright local verification:
  - edit draft invoice: set `rate=0`, `quantity=00:00` -> Save and Send disabled
  - draft row actions menu includes: Invoice, Download, Send Invoice, Delete
- focused specs:
  - `rtk mise exec -- timeout 300 bundle exec rspec spec/system/invoices/edit_spec.rb spec/system/invoices/index_spec.rb`
  - result: 19 examples, 1 failure (`spec/system/invoices/edit_spec.rb:255`, existing currency-format assertion)

## Issue
- Closes #2158 after production verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoices can no longer be saved or sent when any line item has zero or negative quantity or rate values.

* **New Features**
  * Added delete functionality for draft invoices with confirmation. Deleting an invoice automatically refreshes the invoice list and returns you to the list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->