### PR TITLE
fix(my-leaves): resolve calendar selection and layout bugs on leave page

### DIFF
--- a/app/javascript/src/components/LeaveManagement/Container/Table/TableHeader.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/Table/TableHeader.tsx
@@ -4,14 +4,14 @@ import { i18n } from "../../../../i18n";
 
 const TableHeader = () => (
   <thead>
-    <tr className="flex w-full justify-between">
-      <th className="flex text-left text-xs font-normal tracking-widest text-muted-foreground lg:w-1/4">
+    <tr className="grid w-full grid-cols-[minmax(8rem,1.15fr)_minmax(12rem,1.9fr)_minmax(6rem,0.85fr)] gap-4 border-b border-border px-4 py-3">
+      <th className="text-left text-xs font-normal tracking-widest text-muted-foreground">
         {i18n.t("tableHeaders.date")}
       </th>
-      <th className="flex w-3/6 text-left text-xs font-normal tracking-widest text-muted-foreground lg:w-4/12">
+      <th className="text-left text-xs font-normal tracking-widest text-muted-foreground">
         {i18n.t("tableHeaders.description")}
       </th>
-      <th className="flex justify-end text-xs font-normal tracking-widest text-muted-foreground lg:w-3/12">
+      <th className="text-right text-xs font-normal tracking-widest text-muted-foreground">
         {i18n.t("hours").toUpperCase()}
       </th>
     </tr>

--- a/app/javascript/src/components/LeaveManagement/Container/Table/TableRow.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/Table/TableRow.tsx
@@ -45,11 +45,11 @@ const TableRow = ({ timeoffEntry }) => {
   const leaveName = customLeave?.name || leaveType?.name || holidayInfo?.name;
 
   return (
-    <tr className="flex items-center justify-between py-4">
-      <td className="flex text-left text-base font-normal tracking-widest lg:w-1/4">
+    <tr className="grid w-full grid-cols-[minmax(8rem,1.15fr)_minmax(12rem,1.9fr)_minmax(6rem,0.85fr)] items-center gap-4 px-4 py-4">
+      <td className="text-left text-base font-normal tracking-widest">
         {leaveDate}
       </td>
-      <td className="flex w-1/3 items-center whitespace-pre-wrap py-2.5 text-left text-base font-normal text-foreground lg:w-4/12">
+      <td className="flex items-center whitespace-pre-wrap py-2.5 text-left text-base font-normal text-foreground">
         <div
           className="mr-2 hidden h-6 w-6 items-center justify-center rounded-full text-white lg:flex"
           style={{ backgroundColor: leaveColor?.value }}
@@ -58,7 +58,7 @@ const TableRow = ({ timeoffEntry }) => {
         </div>
         <span>{leaveName}</span>
       </td>
-      <td className="flex w-1/3 flex-col whitespace-nowrap pb-2.5 text-right text-base lg:mt-0 lg:table-cell lg:w-3/12 lg:items-center lg:pl-8">
+      <td className="whitespace-nowrap pb-2.5 text-right text-base">
         {minToHHMM(duration)}
       </td>
     </tr>

--- a/app/javascript/src/components/LeaveManagement/Container/Table/index.tsx
+++ b/app/javascript/src/components/LeaveManagement/Container/Table/index.tsx
@@ -7,13 +7,13 @@ import TableRow from "./TableRow";
 const Table = ({ timeoffEntries = [] }) => (
   <table className="mt-4 min-w-full">
     <TableHeader />
-    <tbody className="flex flex-col bg-card">
+    <tbody className="divide-y divide-border bg-card">
       {timeoffEntries?.length ? (
         timeoffEntries.map((timeoffEntry, index) => (
           <TableRow key={index} timeoffEntry={timeoffEntry} />
         ))
       ) : (
-        <tr className="tracking-wide flex items-center justify-center text-base font-medium text-primary md:h-50">
+        <tr className="flex items-center justify-center py-8 text-base font-medium tracking-wide text-primary">
           <td>{i18n.t("reports.noDataFound")}</td>
         </tr>
       )}

--- a/app/javascript/src/components/LeaveManagement/LeaveManagementContent.tsx
+++ b/app/javascript/src/components/LeaveManagement/LeaveManagementContent.tsx
@@ -80,6 +80,10 @@ const LeaveManagementContent = ({
       ? (totalTimeoffEntriesDuration || 0) / (workingHoursPerDay * 60)
       : 0;
 
+  const leaveBreakdown = leaveBalance.filter(
+    item => item.type === "leave" || item.type === "custom_leave"
+  );
+
   const timeoffEntriesByDate = timeoffEntries.reduce((acc, entry) => {
     const key = entry.leaveDateIso || entry.leaveDate;
     if (!key) return acc;
@@ -211,14 +215,14 @@ const LeaveManagementContent = ({
         />
       </div>
 
-      {/* Leave Balance Cards */}
-      {leaveBalance && leaveBalance.length > 0 && (
+      {/* Leave balance breakdown (leave types only) */}
+      {leaveBreakdown.length > 0 && (
         <div>
           <h3 className="mb-4 text-lg font-semibold text-foreground">
             {getLeaveBalanaceDateText()}
           </h3>
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {leaveBalance.map((leaveType, index) => (
+            {leaveBreakdown.map((leaveType, index) => (
               <LeaveBlock
                 key={index}
                 leaveType={leaveType}
@@ -265,6 +269,7 @@ const LeaveManagementContent = ({
             <div className="flex justify-center p-4 sm:p-5">
               <Calendar
                 className="rounded-xl border border-border bg-background"
+                mode="single"
                 month={selectedDate}
                 onMonthChange={setSelectedDate}
                 onSelect={date => date && setSelectedDate(date)}

--- a/app/javascript/src/components/ui/calendar.tsx
+++ b/app/javascript/src/components/ui/calendar.tsx
@@ -21,16 +21,16 @@ function Calendar({
           "flex flex-col sm:flex-row gap-4 sm:gap-6 items-start justify-center",
         month: "space-y-3",
         month_caption:
-          "flex justify-center pt-1 relative items-center h-9 px-2 rounded-md bg-muted/40",
+          "relative flex h-10 items-center justify-center rounded-md bg-muted/40 px-10",
         caption_label: "text-sm font-semibold text-foreground",
-        nav: "space-x-1 flex items-center",
+        nav: "pointer-events-none absolute inset-x-1 top-1/2 flex -translate-y-1/2 items-center justify-between",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-background/80 p-0 border-border text-foreground/80 hover:text-foreground hover:bg-accent absolute left-1"
+          "pointer-events-auto static h-7 w-7 border-border bg-background/80 p-0 text-foreground/80 hover:bg-accent hover:text-foreground"
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-background/80 p-0 border-border text-foreground/80 hover:text-foreground hover:bg-accent absolute right-1"
+          "pointer-events-auto static h-7 w-7 border-border bg-background/80 p-0 text-foreground/80 hover:bg-accent hover:text-foreground"
         ),
         month_grid: "w-full border-separate border-spacing-y-1.5",
         weekdays: "grid grid-cols-7 gap-1",


### PR DESCRIPTION
## Summary
- remove duplicate leave-balance cards for optional/public holidays from `My Leaves` and keep a focused leave-type breakdown
- enable explicit single-date selection in the leave calendar (`mode="single"`)
- reposition calendar month nav controls so arrows stay attached to the calendar header area
- normalize leave-history table column layout with consistent grid proportions for date/description/hours

## Verification
- `rtk mise exec -- timeout 300 bundle exec rspec spec/system/settings/leaves_spec.rb spec/system/holidays_management_spec.rb` (fails in existing holiday/settings specs; details captured locally)
- `rtk mise exec -- timeout 30 bin/vite build` (pass)
- local browser QA on `http://127.0.0.1:3000/my-leaves`:
  - date selection changed from `Wed, 1 Apr` to `Fri, 3 Apr` after click
  - `Optional holidays`/`Public holidays` appear once each (no duplicate balance section)
  - calendar month nav buttons remain inside the calendar card bounds
  - leave-history header/rows render with grid layout for consistent spacing

Closes #2161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Leave Management table layout with improved spacing and visual alignment
  * Enhanced calendar navigation styling

* **Features**
  * Leave balance breakdown now displays filtered leave categories for clearer tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->