### PR TITLE
Fix Add Client required-field clarity and missing-field guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Invoice creation and editing now guard against duplicate draft line items, preserve zero-value amounts, and clamp totals to zero when the last line item is removed
 - Time-tracking entry creation no longer shows a duplicate saved entry before refresh when the visible list rehydrates
 - Draft invoice line-item inputs now stay visually aligned with the standard invoice row layout while typing a new manual entry
+- Client creation forms now mark all required fields consistently and show a live "Missing required fields" summary when the submit button is disabled
 - Time-tracking entry flows now rehydrate saved state reliably on the same page and use more stable system-spec selectors
 - System-spec support code was consolidated by removing dead helper modules and stabilizing auth/request-capture teardown
 - Weekly reminder processing now better distinguishes legacy hour-based timesheet data from minute-based entries to avoid false reminder emails for users who met weekly hour targets

--- a/app/javascript/src/components/Clients/ClientForm/ClientEditor.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/ClientEditor.tsx
@@ -21,7 +21,11 @@ import { Button } from "../../ui/button";
 
 import { clientSchema, getInitialvalues } from "./formValidationSchema";
 import UploadLogo from "./UploadLogo";
-import { disableBtn, formatFormData } from "./utils";
+import {
+  disableBtn,
+  formatFormData,
+  getMissingRequiredClientFields,
+} from "./utils";
 
 import { currencyListOptions } from "../../OrganizationSetup/FinancialDetailsForm/utils";
 import { i18n } from "../../../i18n";
@@ -107,6 +111,20 @@ const ClientEditor = ({
           handleChange,
           handleBlur,
         } = props;
+
+        const fieldLabels = {
+          name: i18n.t("name"),
+          address1: i18n.t("clients.addressLine1"),
+          country: i18n.t("country"),
+          state: i18n.t("state"),
+          city: i18n.t("city"),
+          zipcode: i18n.t("zipcode"),
+          currency: i18n.t("currency"),
+        };
+
+        const missingRequiredFields = getMissingRequiredClientFields(
+          values
+        ).map(key => fieldLabels[key as keyof typeof fieldLabels]);
 
         return (
           <Form className="space-y-4">
@@ -360,6 +378,11 @@ const ClientEditor = ({
                 * Required: Name, Address Line 1, Country, State, City, Zipcode,
                 Currency
               </p>
+              {missingRequiredFields.length > 0 && (
+                <p className="mb-2 text-xs text-amber-600">
+                  Missing required fields: {missingRequiredFields.join(", ")}
+                </p>
+              )}
               <Button
                 type="submit"
                 className="w-full bg-gray-900 hover:bg-gray-800 text-white"

--- a/app/javascript/src/components/Clients/ClientForm/ClientEditor.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/ClientEditor.tsx
@@ -25,6 +25,7 @@ import {
   disableBtn,
   formatFormData,
   getMissingRequiredClientFields,
+  getRequiredClientFieldLabels,
 } from "./utils";
 
 import { currencyListOptions } from "../../OrganizationSetup/FinancialDetailsForm/utils";
@@ -112,19 +113,11 @@ const ClientEditor = ({
           handleBlur,
         } = props;
 
-        const fieldLabels = {
-          name: i18n.t("name"),
-          address1: i18n.t("clients.addressLine1"),
-          country: i18n.t("country"),
-          state: i18n.t("state"),
-          city: i18n.t("city"),
-          zipcode: i18n.t("zipcode"),
-          currency: i18n.t("currency"),
-        };
+        const fieldLabels = getRequiredClientFieldLabels();
 
         const missingRequiredFields = getMissingRequiredClientFields(
           values
-        ).map(key => fieldLabels[key as keyof typeof fieldLabels]);
+        ).map(key => fieldLabels[key]);
 
         return (
           <Form className="space-y-4">
@@ -379,7 +372,7 @@ const ClientEditor = ({
                 Currency
               </p>
               {missingRequiredFields.length > 0 && (
-                <p className="mb-2 text-xs text-amber-600">
+                <p className="mb-2 text-xs text-amber-600" aria-live="polite">
                   Missing required fields: {missingRequiredFields.join(", ")}
                 </p>
               )}

--- a/app/javascript/src/components/Clients/ClientForm/MobileClientEditor.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/MobileClientEditor.tsx
@@ -22,6 +22,7 @@ import {
   formatFormData,
   disableBtn,
   getMissingRequiredClientFields,
+  getRequiredClientFieldLabels,
 } from "./utils";
 
 import { currencyListOptions } from "../../OrganizationSetup/FinancialDetailsForm/utils";
@@ -115,19 +116,11 @@ const MobileClientEditor = ({
         >
           {(props: FormikProps<FormValues>) => {
             const { touched, errors, setFieldValue, values } = props;
-            const fieldLabels = {
-              name: i18n.t("name"),
-              address1: i18n.t("clients.addressLine1"),
-              country: i18n.t("country"),
-              state: i18n.t("state"),
-              city: i18n.t("city"),
-              zipcode: i18n.t("zipcode"),
-              currency: i18n.t("currency"),
-            };
+            const fieldLabels = getRequiredClientFieldLabels();
 
             const missingRequiredFields = getMissingRequiredClientFields(
               values
-            ).map(key => fieldLabels[key as keyof typeof fieldLabels]);
+            ).map(key => fieldLabels[key]);
 
             return (
               <Form>
@@ -373,7 +366,10 @@ const MobileClientEditor = ({
                     Zipcode, Currency
                   </p>
                   {missingRequiredFields.length > 0 && (
-                    <p className="mb-2 text-xs text-amber-600">
+                    <p
+                      className="mb-2 text-xs text-amber-600"
+                      aria-live="polite"
+                    >
                       Missing required fields:{" "}
                       {missingRequiredFields.join(", ")}
                     </p>

--- a/app/javascript/src/components/Clients/ClientForm/MobileClientEditor.tsx
+++ b/app/javascript/src/components/Clients/ClientForm/MobileClientEditor.tsx
@@ -18,7 +18,11 @@ import worldCountries from "world-countries";
 
 import { clientSchema, getInitialvalues } from "./formValidationSchema";
 import UploadLogo from "./UploadLogo";
-import { formatFormData, disableBtn } from "./utils";
+import {
+  formatFormData,
+  disableBtn,
+  getMissingRequiredClientFields,
+} from "./utils";
 
 import { currencyListOptions } from "../../OrganizationSetup/FinancialDetailsForm/utils";
 import { i18n } from "../../../i18n";
@@ -111,6 +115,19 @@ const MobileClientEditor = ({
         >
           {(props: FormikProps<FormValues>) => {
             const { touched, errors, setFieldValue, values } = props;
+            const fieldLabels = {
+              name: i18n.t("name"),
+              address1: i18n.t("clients.addressLine1"),
+              country: i18n.t("country"),
+              state: i18n.t("state"),
+              city: i18n.t("city"),
+              zipcode: i18n.t("zipcode"),
+              currency: i18n.t("currency"),
+            };
+
+            const missingRequiredFields = getMissingRequiredClientFields(
+              values
+            ).map(key => fieldLabels[key as keyof typeof fieldLabels]);
 
             return (
               <Form>
@@ -355,6 +372,12 @@ const MobileClientEditor = ({
                     * Required: Name, Address Line 1, Country, State, City,
                     Zipcode, Currency
                   </p>
+                  {missingRequiredFields.length > 0 && (
+                    <p className="mb-2 text-xs text-amber-600">
+                      Missing required fields:{" "}
+                      {missingRequiredFields.join(", ")}
+                    </p>
+                  )}
                   {client?.id ? (
                     <Button
                       className="w-full p-2 text-center text-base font-bold"

--- a/app/javascript/src/components/Clients/ClientForm/utils.ts
+++ b/app/javascript/src/components/Clients/ClientForm/utils.ts
@@ -1,3 +1,43 @@
+import { i18n } from "../../../i18n";
+
+type SelectOption = { value?: string } | null | undefined;
+
+interface ClientRequiredValues {
+  name?: string;
+  address1?: string;
+  country?: SelectOption;
+  state?: string;
+  city?: string;
+  zipcode?: string;
+  currency?: SelectOption;
+}
+
+export const REQUIRED_CLIENT_FIELD_KEYS = [
+  "name",
+  "address1",
+  "country",
+  "state",
+  "city",
+  "zipcode",
+  "currency",
+] as const;
+
+export type RequiredClientFieldKey =
+  (typeof REQUIRED_CLIENT_FIELD_KEYS)[number];
+
+export const getRequiredClientFieldLabels = (): Record<
+  RequiredClientFieldKey,
+  string
+> => ({
+  name: i18n.t("name"),
+  address1: i18n.t("clients.addressLine1"),
+  country: i18n.t("country"),
+  state: i18n.t("state"),
+  city: i18n.t("city"),
+  zipcode: i18n.t("zipcode"),
+  currency: i18n.t("currency"),
+});
+
 export const formatFormData = (
   formData,
   values,
@@ -63,22 +103,13 @@ export const disableBtn = (values, errors, submitting) => {
   return true;
 };
 
-export const getMissingRequiredClientFields = values => {
-  const requiredFieldKeys = [
-    "name",
-    "address1",
-    "country",
-    "state",
-    "city",
-    "zipcode",
-    "currency",
-  ];
-
-  return requiredFieldKeys.filter(key => {
+export const getMissingRequiredClientFields = (
+  values: ClientRequiredValues
+): RequiredClientFieldKey[] =>
+  REQUIRED_CLIENT_FIELD_KEYS.filter(key => {
     if (key === "country" || key === "currency") {
       return !values[key]?.value;
     }
 
     return !values[key];
   });
-};

--- a/app/javascript/src/components/Clients/ClientForm/utils.ts
+++ b/app/javascript/src/components/Clients/ClientForm/utils.ts
@@ -62,3 +62,23 @@ export const disableBtn = (values, errors, submitting) => {
 
   return true;
 };
+
+export const getMissingRequiredClientFields = values => {
+  const requiredFieldKeys = [
+    "name",
+    "address1",
+    "country",
+    "state",
+    "city",
+    "zipcode",
+    "currency",
+  ];
+
+  return requiredFieldKeys.filter(key => {
+    if (key === "country" || key === "currency") {
+      return !values[key]?.value;
+    }
+
+    return !values[key];
+  });
+};

--- a/spec/system/clients/add_client_required_fields_spec.rb
+++ b/spec/system/clients/add_client_required_fields_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add client required field guidance", type: :system, js: true do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :admin, company
+    sign_in(user)
+  end
+
+  def open_add_client_dialog
+    visit "/clients"
+    click_button "Add New Client"
+    expect(page).to have_selector("[role='dialog']", wait: 10)
+  end
+
+  it "shows and updates the missing required fields summary on desktop", :aggregate_failures do
+    open_add_client_dialog
+
+    expect(page).to have_text(
+      /Missing required fields:\s*Name, Address line 1, Country, State, City, Zipcode, Currency/
+    )
+    expect(page).to have_button("Add New Client", disabled: true)
+
+    fill_in "Name *", with: "Acme QA Client"
+
+    expect(page).to have_text(
+      /Missing required fields:\s*Address line 1, Country, State, City, Zipcode, Currency/
+    )
+  end
+
+  it "shows and updates the missing required fields summary on mobile", :aggregate_failures do
+    page.current_window.resize_to(390, 844)
+    open_add_client_dialog
+
+    expect(page).to have_text(
+      /Missing required fields:\s*Name, Address line 1, Country, State, City, Zipcode, Currency/
+    )
+    expect(page).to have_button("Add New Client", disabled: true)
+
+    fill_in "Name *", with: "Acme QA Client Mobile"
+
+    expect(page).to have_text(
+      /Missing required fields:\s*Address line 1, Country, State, City, Zipcode, Currency/
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- mark all Add Client required fields consistently in the form labels
- add a dynamic `Missing required fields` summary so users can see why submit stays disabled
- apply the same missing-field summary logic to mobile and desktop client editors
- add an Unreleased changelog entry
- add system specs for required-field summary behavior in desktop and mobile viewports

Fixes #2185

## Verification
- `rtk mise exec -- timeout 30 bin/vite build` (pass)
- `rtk mise exec -- timeout 900 bundle exec rspec spec/system/clients/create_spec.rb` (pass)
- `rtk mise exec -- timeout 900 bundle exec rspec spec/system/clients/add_client_required_fields_spec.rb` (pass)
- real-browser verification on local worktree server (`http://127.0.0.1:3100`):
  - Add New Client shows all required markers
  - dynamic missing-fields summary updates after entering Name

Screenshots:
- `tmp/issue-2185-required-fields.png`
- `tmp/issue-2185-missing-required-fields.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Client creation forms now mark required fields consistently on desktop and mobile.
  * When the submit button is disabled, an accessible, live "Missing required fields" summary lists which fields need completion.
* **Tests**
  * Added system tests verifying the missing-fields summary, disabled submit state, and live updates when fields are filled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->