### PR TITLE
fix: forward host context for MCP proxy tool calls

### DIFF
--- a/app/controllers/api/v1/mcp_controller.rb
+++ b/app/controllers/api/v1/mcp_controller.rb
@@ -22,6 +22,7 @@ class Api::V1::MCPController < Api::V1::ApplicationController
     def mcp_server_context
       {
         authorization: request.headers["Authorization"],
+        host: request.host_with_port,
         user_id: current_user.id,
         company_id: current_company.id,
         pro_access: current_company.pro_access?

--- a/app/mcp/api_proxy.rb
+++ b/app/mcp/api_proxy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rack/mock"
+require "uri"
 
 module MCP
   module Miru
@@ -58,11 +59,28 @@ module MCP
           end
 
           def default_headers(authorization:)
-            {
+            headers = {
               "HTTP_AUTHORIZATION" => authorization.to_s,
               "HTTP_ACCEPT" => "application/json",
               "CONTENT_TYPE" => "application/json"
             }
+
+            host = default_host
+            headers["HTTP_HOST"] = host if host.present?
+            headers
+          end
+
+          def default_host
+            uri = URI.parse(ENV.fetch("APP_BASE_URL", ""))
+            return if uri.host.blank?
+
+            if uri.port && uri.port != uri.default_port
+              "#{uri.host}:#{uri.port}"
+            else
+              uri.host
+            end
+          rescue URI::InvalidURIError
+            nil
           end
 
           def normalize_headers(headers)

--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -8,12 +8,17 @@ module MCP
           private
 
             def proxy_request(method:, path:, server_context:, params: nil, body: nil)
+              headers = {}
+              host = host_from(server_context)
+              headers["Host"] = host if host.present?
+
               MCP::Miru::ApiProxy.request(
                 method: method,
                 path: path,
                 params: params,
                 body: body,
-                authorization: authorization_from(server_context)
+                authorization: authorization_from(server_context),
+                headers: headers
               )
             end
 
@@ -91,6 +96,10 @@ module MCP
               return token if token.start_with?("Bearer ")
 
               token.present? ? "Bearer #{token}" : ""
+            end
+
+            def host_from(server_context)
+              context(server_context)[:host].to_s.strip
             end
 
             def merged_source_metadata(source_metadata)

--- a/spec/requests/api/v1/mcp/handle_spec.rb
+++ b/spec/requests/api/v1/mcp/handle_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe "Api::V1::MCP#handle", type: :request do
         expect(response).to have_http_status(:ok)
         expect(json_response["result"]).to be_present
       end
+
+      it "forwards request host to proxy-backed tool calls" do
+        allow(MCP::Miru::ApiProxy).to receive(:request).and_call_original
+
+        post mcp_path, params: tool_call_payload(name: "miru.workspace.whoami").to_json, headers: mcp_headers(cli_token:, mcp_method: "tools/call")
+
+        expect(response).to have_http_status(:ok)
+        expect(MCP::Miru::ApiProxy).to have_received(:request).with(
+          hash_including(
+            method: :get,
+            path: "/api/v1/users/_me",
+            headers: hash_including("Host" => "www.example.com")
+          )
+        )
+      end
     end
 
     context "with active trial" do
@@ -182,5 +197,17 @@ RSpec.describe "Api::V1::MCP#handle", type: :request do
         "MCP-Protocol-Version" => "2025-03-26",
         "MCP-Method" => mcp_method
       })
+    end
+
+    def tool_call_payload(name:, arguments: {})
+      {
+        jsonrpc: "2.0",
+        id: "tool-1",
+        method: "tools/call",
+        params: {
+          name: name,
+          arguments: arguments
+        }
+      }
     end
 end


### PR DESCRIPTION
## Summary
- forward request host from MCP HTTP controller into MCP server context
- include host header on internal ApiProxy requests for proxy-backed MCP tools
- add APP_BASE_URL-based host fallback in ApiProxy for stdio/proxy contexts
- add MCP request spec to guard host propagation for `tools/call`

## Why
Proxy-backed tools (for example `miru.workspace.whoami` and `miru.project.list`) returned 403 in production MCP calls due to Host Authorization mismatch in internal Rack::MockRequest execution.

## Verification
- `rtk mise exec -- bundle exec rspec spec/requests/api/v1/mcp/handle_spec.rb spec/mcp/tool_catalog_spec.rb spec/mcp/server_factory_spec.rb`
- `rtk mise exec -- bundle exec rubocop app/controllers/api/v1/mcp_controller.rb app/mcp/tools/base_tool.rb app/mcp/api_proxy.rb spec/requests/api/v1/mcp/handle_spec.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal request handling to properly propagate host information through the API proxy layer.

* **Tests**
  * Added test coverage for host header forwarding in proxy requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->