### PR TITLE
Fix invoice line-item employee name rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Invoice creation and editing now guard against duplicate draft line items, preserve zero-value amounts, and clamp totals to zero when the last line item is removed
+- Invoice line-item rows now prefer employee first/last names over description-backed fallback text so selected employee names render correctly on new invoices
 - Time-tracking entry creation no longer shows a duplicate saved entry before refresh when the visible list rehydrates
 - Draft invoice line-item inputs now stay visually aligned with the standard invoice row layout while typing a new manual entry
 - Client creation forms now mark all required fields consistently and show a live "Missing required fields" summary when the submit button is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - Invoice creation and editing now guard against duplicate draft line items, preserve zero-value amounts, and clamp totals to zero when the last line item is removed
-- Invoice line-item rows now prefer employee first/last names over description-backed fallback text so selected employee names render correctly on new invoices
+- Invoice line-item rows now prefer employee first/last names over description-backed fallback text so selected employee names render correctly on new invoices (rendering-only change, no DB impact)
 - Time-tracking entry creation no longer shows a duplicate saved entry before refresh when the visible list rehydrates
 - Draft invoice line-item inputs now stay visually aligned with the standard invoice row layout while typing a new manual entry
 - Client creation forms now mark all required fields consistently and show a live "Missing required fields" summary when the submit button is disabled

--- a/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
@@ -1,14 +1,38 @@
 import React from "react";
 
 import dayjs from "dayjs";
-import { currencyFormat, minToHHMM, lineTotalCalc } from "helpers";
+import {
+  currencyFormat,
+  getLineItemDisplayName,
+  minToHHMM,
+  lineTotalCalc,
+} from "helpers";
 
-const LineItem = ({ currency, item, dateFormat, strikeAmount = "" }) => {
+type LineItemProps = {
+  currency: string;
+  dateFormat: string;
+  strikeAmount?: string;
+  item: {
+    amount?: number | string | null;
+    date: string;
+    description: string;
+    first_name?: string | null;
+    last_name?: string | null;
+    lineTotal?: number | string | null;
+    name?: string | null;
+    quantity: number | string;
+    rate: number | string;
+  };
+};
+
+const LineItem = ({
+  currency,
+  item,
+  dateFormat,
+  strikeAmount = "",
+}: LineItemProps) => {
   const date = dayjs(item.date).format(dateFormat);
-  const displayName =
-    [item.first_name, item.last_name].filter(Boolean).join(" ").trim() ||
-    item.name ||
-    "";
+  const displayName = getLineItemDisplayName(item);
 
   return (
     <>

--- a/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
+++ b/app/javascript/src/components/Invoices/Invoice/LineItem.tsx
@@ -5,13 +5,16 @@ import { currencyFormat, minToHHMM, lineTotalCalc } from "helpers";
 
 const LineItem = ({ currency, item, dateFormat, strikeAmount = "" }) => {
   const date = dayjs(item.date).format(dateFormat);
+  const displayName =
+    [item.first_name, item.last_name].filter(Boolean).join(" ").trim() ||
+    item.name ||
+    "";
 
   return (
     <>
       <tr>
         <td className="px-1 pt-5 pb-2 text-left text-base font-medium text-foreground ">
-          {item.name}
-          {item.first_name} {item.last_name}
+          {displayName}
         </td>
         <td className="px-1 pt-5 pb-2 text-right text-base font-medium text-foreground ">
           {date}

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
@@ -2,7 +2,13 @@ import React, { useRef, useState, useEffect } from "react";
 
 import CustomDatePicker from "common/CustomDatePicker";
 import dayjs from "dayjs";
-import { minFromHHMM, minToHHMM, lineTotalCalc, currencyFormat } from "helpers";
+import {
+  currencyFormat,
+  getLineItemDisplayName,
+  lineTotalCalc,
+  minFromHHMM,
+  minToHHMM,
+} from "helpers";
 import { DeleteIcon, CalendarIcon } from "miruIcons";
 import TextareaAutosize from "react-textarea-autosize";
 import { i18n } from "../../../../i18n";
@@ -15,10 +21,7 @@ const LineItemEditorRow = ({
   selectedOption,
   dateFormat,
 }) => {
-  const strName =
-    [item.first_name, item.last_name].filter(Boolean).join(" ").trim() ||
-    item.name ||
-    "";
+  const strName = getLineItemDisplayName(item);
   const [name, setName] = useState<string>(strName);
   const [lineItemDate, setLineItemDate] = useState(
     dayjs(item.date, "YYYY-MM-DD").format(dateFormat)
@@ -32,6 +35,10 @@ const LineItemEditorRow = ({
   const [showDatePicker, setShowDatePicker] = useState<boolean>(false);
   const [showCalendarIcon, setShowCalendarIcon] = useState<boolean>(false);
   const datePickerRef = useRef(null);
+
+  useEffect(() => {
+    setName(strName);
+  }, [strName]);
 
   useEffect(() => {
     const names = name.split(" ");

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
@@ -16,8 +16,8 @@ const LineItemEditorRow = ({
   dateFormat,
 }) => {
   const strName =
+    [item.first_name, item.last_name].filter(Boolean).join(" ").trim() ||
     item.name ||
-    [item.first_name, item.last_name].filter(Boolean).join(" ") ||
     "";
   const [name, setName] = useState<string>(strName);
   const [lineItemDate, setLineItemDate] = useState(

--- a/app/javascript/src/helpers/index.ts
+++ b/app/javascript/src/helpers/index.ts
@@ -8,6 +8,7 @@ import { useDebounce } from "./debounce";
 import { getDisplayAvatarUrl, getGravatarUrl } from "./gravatar";
 import { minFromHHMM, minToHHMM } from "./hhmmParser";
 import { lineTotalCalc } from "./lineTotalCalc";
+import { getLineItemDisplayName } from "./lineItemDisplayName";
 import { getNumberWithOrdinal } from "./ordinal";
 import { useOutsideClick } from "./outsideClick";
 import useKeypress from "./useKeyPress";
@@ -26,6 +27,7 @@ export {
   minFromHHMM,
   minToHHMM,
   lineTotalCalc,
+  getLineItemDisplayName,
   useDebounce,
   useOutsideClick,
   useKeypress,

--- a/app/javascript/src/helpers/lineItemDisplayName.ts
+++ b/app/javascript/src/helpers/lineItemDisplayName.ts
@@ -1,0 +1,16 @@
+type LineItemDisplayNameInput = {
+  first_name?: string | null;
+  last_name?: string | null;
+  name?: string | null;
+};
+
+export const getLineItemDisplayName = (
+  item: LineItemDisplayNameInput
+): string => {
+  const fullName = [item.first_name, item.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return fullName || item.name || "";
+};


### PR DESCRIPTION
## Summary
- prefer employee first/last name over item.name fallback when initializing line-item editor rows
- render a single displayName in invoice line-item rows to avoid description text leaking into the name field
- add changelog entry under Unreleased

## Related
- Closes #2189

## Verification
- Attempted focused specs: spec/system/invoices/create_spec.rb:163 and spec/system/invoices/editor_preview_spec.rb
  - blocked locally by a persistent Vite pre-suite build loop (Building with Vite repeated indefinitely)
- Attempted rtk mise exec -- timeout 30 bin/vite build
  - timeout wrapper did not terminate child process in this environment
- Attempted browser verification on app boot from this worktree
  - blocked by same Vite build loop during request handling

Given the environment blocker, verification is partial and documented here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice line items now preferentially show the selected employee’s full name (first + last) with consistent spacing instead of falling back to description-derived text.
  * Editable line-item name fields now stay in sync with the derived display name so rendered and editable values match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->