### PR TITLE
Fix per-project member rate mapping for invoice generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Invoice creation and editing now guard against duplicate draft line items, preserve zero-value amounts, and clamp totals to zero when the last line item is removed
 - Invoice line-item rows now prefer employee first/last names over description-backed fallback text so selected employee names render correctly on new invoices (rendering-only change, no DB impact)
+- Invoice line-item rate lookups now resolve project-member hourly rates per project consistently, preventing missing rates when generating invoices across multiple projects or after member-removal workflows
 - Time-tracking entry creation no longer shows a duplicate saved entry before refresh when the visible list rehydrates
 - Draft invoice line-item inputs now stay visually aligned with the standard invoice row layout while typing a new manual entry
 - Client creation forms now mark all required fields consistently and show a live "Missing required fields" summary when the submit button is disabled

--- a/app/presenters/project_members_presenter.rb
+++ b/app/presenters/project_members_presenter.rb
@@ -16,6 +16,6 @@ class ProjectMembersPresenter
   private
 
     def project_members_hourly_rate(project)
-      @_project_members_hourly_rate ||= project.project_members.pluck(:user_id, :hourly_rate).to_h
+      project.project_members.pluck(:user_id, :hourly_rate).to_h
     end
 end

--- a/spec/presenters/project_members_presenter_spec.rb
+++ b/spec/presenters/project_members_presenter_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectMembersPresenter do
+  describe "#project_to_member_hourly_rate" do
+    it "returns hourly rates scoped per project" do
+      company = create(:company)
+      client = create(:client, company:)
+      project_one = create(:project, client:)
+      project_two = create(:project, client:)
+      user_one = create(:user, current_workspace_id: company.id)
+      user_two = create(:user, current_workspace_id: company.id)
+
+      create(:project_member, project: project_one, user: user_one, hourly_rate: 20)
+      create(:project_member, project: project_two, user: user_two, hourly_rate: 35)
+
+      rates_by_project = described_class
+        .new(Project.where(id: [project_one.id, project_two.id]))
+        .project_to_member_hourly_rate
+
+      expect(rates_by_project[project_one.id][user_one.id]).to eq(20)
+      expect(rates_by_project[project_two.id][user_two.id]).to eq(35)
+      expect(rates_by_project[project_two.id]).not_to eq(rates_by_project[project_one.id])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fix `ProjectMembersPresenter` to resolve hourly rates per project instead of memoizing the first project's map for all projects
- add a focused presenter spec proving each project returns its own user/rate mapping
- add changelog entry under Unreleased

## Related
- Partial fix for #2182 (invoice line-item rate fallback consistency after member-removal workflows)

## Verification
- `SKIP_VITE_TEST_BUILD=1 mise exec -- gtimeout 180 bundle exec rspec spec/presenters/project_members_presenter_spec.rb`
  - Result: `1 example, 0 failures`
- `gbrain-code-check`
  - attempted twice, both failed with environment socket error: `The socket connection was closed unexpectedly`

## Notes
- Local environment still has a persistent Vite test-build loop when running standard rspec bootstrap; used `SKIP_VITE_TEST_BUILD=1` for this pure Ruby presenter spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invoice line-item hourly rate lookups to ensure accurate, per-project rate resolution. This prevents missing or incorrect rates when generating invoices across multiple projects and resolves issues that occurred following member-removal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->