### PR TITLE
fix(company-settings): include EIN and US taxpayer ID in companies in…

### DIFF
--- a/app/views/api/v1/companies/index.json.jbuilder
+++ b/app/views/api/v1/companies/index.json.jbuilder
@@ -22,6 +22,8 @@ json.company_details do
   json.tax_id current_company.tax_id
   json.vat_number current_company.vat_number
   json.gst_number current_company.gst_number
+  json.ein current_company.ein
+  json.us_taxpayer_id current_company.us_taxpayer_id
   json.address do
     json.partial! "internal_api/v1/partial/address", locals: { address: }
   end

--- a/spec/requests/api/v1/companies/index_spec.rb
+++ b/spec/requests/api/v1/companies/index_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Companies::index", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, ein: "12-3456789", us_taxpayer_id: "987-65-4321") }
   let(:user) { create(:user, current_workspace_id: company.id) }
 
   before do

--- a/spec/support/shared_examples/api/v1/companies_index_shared_example.rb
+++ b/spec/support/shared_examples/api/v1/companies_index_shared_example.rb
@@ -17,5 +17,7 @@ shared_examples "Api::V1::Companies::index success response" do
     expect(json_response["company_details"]["address"]["state"]).to eq(address.state)
     expect(json_response["company_details"]["address"]["country"]).to eq(address.country)
     expect(json_response["company_details"]["address"]["pin"]).to eq(address.pin)
+    expect(json_response["company_details"]["ein"]).to eq(company.ein)
+    expect(json_response["company_details"]["us_taxpayer_id"]).to eq(company.us_taxpayer_id)
   end
 end


### PR DESCRIPTION
Fixes #2197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The companies API now includes two tax identity fields in company details: ein (Employer Identification Number) and us_taxpayer_id.

* **Tests**
  * Test suite expanded to assert the presence and values of the new tax identity fields in company API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->