### PR TITLE
fix(stripe): harden webhook sync and billing state; document remainin…

### DIFF
--- a/app/controllers/api/v1/payment_settings_controller.rb
+++ b/app/controllers/api/v1/payment_settings_controller.rb
@@ -17,6 +17,8 @@ class Api::V1::PaymentSettingsController < Api::V1::ApplicationController
     render :connect_stripe, locals: { stripe_connected_account: account }
   rescue ActiveRecord::RecordNotUnique
     render :connect_stripe, locals: { stripe_connected_account: current_company.reload.stripe_connected_account }
+  rescue Stripe::StripeError => e
+    render json: { errors: stripe_connect_error_message(e) }, status: 422
   end
 
   def destroy
@@ -149,5 +151,13 @@ class Api::V1::PaymentSettingsController < Api::V1::ApplicationController
 
     def save_stripe_settings
       PaymentProviders::CreateStripeProviderService.process(current_company)
+    end
+
+    def stripe_connect_error_message(error)
+      if error.message.to_s.include?("signed up for Connect")
+        "Stripe Connect is not enabled for this Stripe account. Enable Connect in Stripe Dashboard and try again."
+      else
+        error.message
+      end
     end
 end

--- a/app/controllers/api/v1/payment_settings_controller.rb
+++ b/app/controllers/api/v1/payment_settings_controller.rb
@@ -155,9 +155,9 @@ class Api::V1::PaymentSettingsController < Api::V1::ApplicationController
 
     def stripe_connect_error_message(error)
       if error.message.to_s.include?("signed up for Connect")
-        "Stripe Connect is not enabled for this Stripe account. Enable Connect in Stripe Dashboard and try again."
+        I18n.t("errors.stripe.connect_not_enabled")
       else
-        error.message
+        I18n.t("errors.stripe.generic", message: error.message.to_s)
       end
     end
 end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -83,6 +83,7 @@ class Api::V1::SubscriptionsController < Api::V1::ApplicationController
         billing_exempt: current_company.billing_exempt,
         subscription_status: current_company.current_subscription_status,
         subscription_ends_at: current_company.subscription_ends_at,
+        cancel_at_period_end: current_company.cancel_at_period_end,
         subscription_interval: current_company.try(:subscription_interval),
         has_stripe_customer: current_company.stripe_customer_id.present?,
         team_member_limit: current_company.team_member_limit,

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -42,6 +42,7 @@ type BillingSummary = {
   billing_exempt: boolean;
   subscription_status: string | null;
   subscription_ends_at: string | null;
+  cancel_at_period_end?: boolean;
   subscription_interval?: string | null;
   has_stripe_customer: boolean;
   team_member_limit: number;
@@ -325,6 +326,12 @@ const Billing = () => {
     ],
   } as const;
 
+  const isCurrentProPlan = summary?.plan_tier === "paid";
+  const currentPlanCadenceLabel =
+    summary?.subscription_interval === "year"
+      ? i18n.t("billingSettings.yearly")
+      : i18n.t("billingSettings.monthly");
+
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
       {billingResult === "success" && (
@@ -430,6 +437,26 @@ const Billing = () => {
                   </AlertDescription>
                 </Alert>
               )}
+
+              {summary.plan_tier === "paid" &&
+                summary.cancel_at_period_end &&
+                summary.subscription_ends_at && (
+                  <Alert>
+                    <AlertTitle>
+                      {i18n.t(
+                        "billingSettings.alerts.subscriptionScheduledToCancel"
+                      )}
+                    </AlertTitle>
+                    <AlertDescription>
+                      {i18n.t(
+                        "billingSettings.alerts.subscriptionScheduledToCancelOn",
+                        {
+                          date: formatDate(summary.subscription_ends_at),
+                        }
+                      )}
+                    </AlertDescription>
+                  </Alert>
+                )}
 
               {summary.team_member_limit_reached && !summary.pro_access && (
                 <Alert>
@@ -671,7 +698,13 @@ const Billing = () => {
                       })}
                     </Badge>
                   )}
-                  <Badge>{i18n.t("billingSettings.recommended")}</Badge>
+                  <Badge>
+                    {isCurrentProPlan
+                      ? `${i18n.t(
+                          "billingSettings.currentPlan"
+                        )} (${currentPlanCadenceLabel})`
+                      : i18n.t("billingSettings.recommended")}
+                  </Badge>
                 </div>
               </div>
               <p className="mt-2 text-2xl font-semibold text-foreground">

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -327,10 +327,19 @@ const Billing = () => {
   } as const;
 
   const isCurrentProPlan = summary?.plan_tier === "paid";
-  const currentPlanCadenceLabel =
-    summary?.subscription_interval === "year"
-      ? i18n.t("billingSettings.yearly")
-      : i18n.t("billingSettings.monthly");
+  const cadenceLabel = (
+    interval: string | null | undefined,
+    fallback = i18n.t("billingSettings.unknown")
+  ) => {
+    if (interval === "year") return i18n.t("billingSettings.yearly");
+
+    if (interval === "month") return i18n.t("billingSettings.monthly");
+
+    if (!interval) return fallback;
+
+    return i18n.t("billingSettings.unknown");
+  };
+  const currentPlanCadenceLabel = cadenceLabel(summary?.subscription_interval);
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-6">
@@ -405,11 +414,10 @@ const Billing = () => {
                     {i18n.t("billingSettings.billingCadence")}
                   </p>
                   <p className="mt-1 text-base font-medium text-foreground">
-                    {summary.subscription_interval === "year"
-                      ? i18n.t("billingSettings.yearly")
-                      : summary.subscription_interval === "month"
-                      ? i18n.t("billingSettings.monthly")
-                      : i18n.t("billingSettings.notSubscribedYet")}
+                    {cadenceLabel(
+                      summary.subscription_interval,
+                      i18n.t("billingSettings.notSubscribedYet")
+                    )}
                   </p>
                 </div>
               </div>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1806,6 +1806,7 @@ const en = {
     billingCadence: "Billing cadence",
     monthly: "Monthly",
     yearly: "Yearly",
+    unknown: "Unknown",
     notSubscribedYet: "Not subscribed yet",
     startTrial: "Start 30-day Pro trial",
     startingTrial: "Starting trial...",

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1851,6 +1851,9 @@ const en = {
       proTrialEnded: "Pro trial ended",
       proTrialEndedDescription:
         "Your workspace has returned to the free plan. Upgrade in Stripe to restore Pro access.",
+      subscriptionScheduledToCancel: "Subscription scheduled to cancel",
+      subscriptionScheduledToCancelOn:
+        "Your Pro access remains active until %{date}.",
       seatLimitReached: "Seat limit reached",
       seatLimitReachedDescription:
         "Upgrade in Stripe to add more than 3 members to this workspace.",

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -165,13 +165,15 @@ class Company < ApplicationRecord
     stripe_subscription_id: nil,
     subscription_status:,
     subscription_ends_at: nil,
-    subscription_interval: nil
+    subscription_interval: nil,
+    cancel_at_period_end: false
   )
     attrs = {
       stripe_customer_id:,
       subscription_status:,
       subscription_ends_at:,
-      plan_tier: stripe_subscription_access?(subscription_status) ? "paid" : "free"
+      plan_tier: stripe_subscription_access?(subscription_status) ? "paid" : "free",
+      cancel_at_period_end:
     }
 
     attrs[:stripe_subscription_id] = stripe_subscription_id if has_attribute?(:stripe_subscription_id)
@@ -184,7 +186,8 @@ class Company < ApplicationRecord
     attrs = {
       plan_tier: "free",
       subscription_status: "canceled",
-      subscription_ends_at: nil
+      subscription_ends_at: nil,
+      cancel_at_period_end: false
     }
 
     attrs[:stripe_subscription_id] = nil if has_attribute?(:stripe_subscription_id)

--- a/app/services/handle_stripe_checkout_event_service.rb
+++ b/app/services/handle_stripe_checkout_event_service.rb
@@ -7,6 +7,7 @@ class HandleStripeCheckoutEventService
   STRIPE_CHECKOUT_SESSION_COMPLETED_EVENT = "checkout.session.completed"
   STRIPE_CHECKOUT_SESSION_EXPIRED_EVENT = "checkout.session.expired"
   STRIPE_PAYMENT_INTENT_FAILED_EVENT = "payment_intent.payment_failed"
+  STRIPE_PAYMENT_INTENT_SUCCEEDED_EVENT = "payment_intent.succeeded"
   STRIPE_CUSTOMER_SUBSCRIPTION_CREATED_EVENT = "customer.subscription.created"
   STRIPE_CUSTOMER_SUBSCRIPTION_UPDATED_EVENT = "customer.subscription.updated"
   STRIPE_CUSTOMER_SUBSCRIPTION_DELETED_EVENT = "customer.subscription.deleted"
@@ -53,6 +54,12 @@ class HandleStripeCheckoutEventService
         end
       when STRIPE_PAYMENT_INTENT_FAILED_EVENT
         if InvoicePayment::StripePaymentFailed.process(event)
+          set_response({ success: true }, :ok)
+        else
+          set_response({ message: "Invalid payload!" }, 400)
+        end
+      when STRIPE_PAYMENT_INTENT_SUCCEEDED_EVENT
+        if InvoicePayment::StripePaymentSucceeded.process(event)
           set_response({ success: true }, :ok)
         else
           set_response({ message: "Invalid payload!" }, 400)

--- a/app/services/handle_stripe_checkout_event_service.rb
+++ b/app/services/handle_stripe_checkout_event_service.rb
@@ -59,11 +59,8 @@ class HandleStripeCheckoutEventService
           set_response({ message: "Invalid payload!" }, 400)
         end
       when STRIPE_PAYMENT_INTENT_SUCCEEDED_EVENT
-        if InvoicePayment::StripePaymentSucceeded.process(event)
-          set_response({ success: true }, :ok)
-        else
-          set_response({ message: "Invalid payload!" }, 400)
-        end
+        InvoicePayment::StripePaymentSucceeded.process(event)
+        set_response({ success: true }, :ok)
       when STRIPE_CUSTOMER_SUBSCRIPTION_CREATED_EVENT,
         STRIPE_CUSTOMER_SUBSCRIPTION_UPDATED_EVENT,
         STRIPE_CUSTOMER_SUBSCRIPTION_DELETED_EVENT

--- a/app/services/invoice_payment/stripe_checkout_fulfillment.rb
+++ b/app/services/invoice_payment/stripe_checkout_fulfillment.rb
@@ -11,10 +11,13 @@ class InvoicePayment::StripeCheckoutFulfillment < ApplicationService
   end
 
   def process
-    @invoice = Invoice.find(event.data.object.metadata.invoice_id)
-    if is_valid_event?
-      InvoicePayment::Settle.process(payment_params, invoice)
-    end
+    @invoice = find_invoice
+    return false if invoice.blank?
+
+    return false unless is_valid_event?
+    return true if duplicate_payment?
+
+    InvoicePayment::Settle.process(payment_params, invoice)
     rescue StandardError => error
       Rails.logger.error error.message
       Rails.logger.error error.backtrace.join("\n")
@@ -24,9 +27,11 @@ class InvoicePayment::StripeCheckoutFulfillment < ApplicationService
   private
 
     def is_valid_event?
-      invoice.stripe_payment_intent == data_object.payment_intent &&
-      is_checkout_status_complete? &&
-      is_payment_status_paid?
+      return false unless is_checkout_status_complete? && is_payment_status_paid?
+
+      return true if invoice.stripe_payment_intent.blank? || data_object.payment_intent.blank?
+
+      invoice.stripe_payment_intent == data_object.payment_intent
     end
 
     def is_checkout_status_complete?
@@ -65,5 +70,21 @@ class InvoicePayment::StripeCheckoutFulfillment < ApplicationService
       ).process
 
       payment_method&.billing_details&.name
+    rescue StandardError => error
+      Rails.logger.warn("Stripe cardholder name lookup failed for invoice #{invoice.id}: #{error.message}")
+      nil
+    end
+
+    def find_invoice
+      invoice_id = data_object&.metadata&.invoice_id
+      return Invoice.find_by(id: invoice_id) if invoice_id.present?
+
+      return nil if data_object.payment_intent.blank?
+
+      Invoice.where("payment_infos ->> 'stripe_payment_intent' = ?", data_object.payment_intent).first
+    end
+
+    def duplicate_payment?
+      invoice.paid?
     end
 end

--- a/app/services/invoice_payment/stripe_checkout_fulfillment.rb
+++ b/app/services/invoice_payment/stripe_checkout_fulfillment.rb
@@ -29,7 +29,7 @@ class InvoicePayment::StripeCheckoutFulfillment < ApplicationService
     def is_valid_event?
       return false unless is_checkout_status_complete? && is_payment_status_paid?
 
-      return true if invoice.stripe_payment_intent.blank? || data_object.payment_intent.blank?
+      return true if invoice.stripe_payment_intent.blank? && data_object.payment_intent.blank?
 
       invoice.stripe_payment_intent == data_object.payment_intent
     end

--- a/app/services/invoice_payment/stripe_payment_succeeded.rb
+++ b/app/services/invoice_payment/stripe_payment_succeeded.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class InvoicePayment::StripePaymentSucceeded < ApplicationService
+  attr_reader :event, :data_object
+  attr_accessor :invoice
+
+  def initialize(event)
+    @event = event
+    @data_object = event.data.object
+    @invoice = nil
+  end
+
+  def process
+    @invoice = Invoice.where("payment_infos ->> 'stripe_payment_intent' = ?", data_object.id).first
+    return false if invoice.blank?
+    return true if invoice.paid?
+
+    InvoicePayment::Settle.process(payment_params, invoice)
+  rescue StandardError => error
+    Rails.logger.error error.message
+    Rails.logger.error error.backtrace.join("\n")
+    nil
+  end
+
+  private
+
+    def payment_params
+      {
+        invoice_id: invoice.id,
+        transaction_date: DateTime.strptime(event.created.to_s, "%s").to_date,
+        transaction_type: "stripe",
+        amount: Money.from_cents(amount_total_cents, data_object.currency).amount,
+        note: "Stripe_Payment_Success"
+      }
+    end
+
+    def amount_total_cents
+      data_object.amount_received.presence || data_object.amount
+    end
+end

--- a/app/services/stripe/retrieve_payment_intent.rb
+++ b/app/services/stripe/retrieve_payment_intent.rb
@@ -19,7 +19,7 @@ class Stripe::RetrievePaymentIntent < ApplicationService
   private
 
     def retrieve_payment_intent
-      return nil if payment_intent.nil? && account_id.nil?
+      return nil if payment_intent.nil? || account_id.nil?
 
       Stripe::PaymentIntent.retrieve(
         payment_intent,

--- a/app/services/stripe/retrieve_payment_method.rb
+++ b/app/services/stripe/retrieve_payment_method.rb
@@ -19,7 +19,7 @@ class Stripe::RetrievePaymentMethod < ApplicationService
   private
 
     def retrieve_payment_method
-      return nil if payment_method.nil? && account_id.nil?
+      return nil if payment_method.nil? || account_id.nil?
 
       Stripe::PaymentMethod.retrieve(
         payment_method,

--- a/app/services/subscriptions/stripe_sync_service.rb
+++ b/app/services/subscriptions/stripe_sync_service.rb
@@ -62,7 +62,8 @@ module Subscriptions
           stripe_subscription_id: subscription_value(stripe_subscription, :id),
           subscription_status: subscription_value(stripe_subscription, :status),
           subscription_ends_at: timestamp_to_time(subscription_period_end),
-          subscription_interval: stripe_subscription_interval(stripe_subscription)
+          subscription_interval: stripe_subscription_interval(stripe_subscription),
+          cancel_at_period_end: subscription_boolean_value(stripe_subscription, :cancel_at_period_end)
         )
 
         if notify_plan_purchase && !was_paid && target_company.plan_tier == "paid"
@@ -100,6 +101,11 @@ module Subscriptions
 
       def subscription_value(stripe_subscription, key)
         value_from(stripe_subscription, key) || value_from(stripe_subscription, key.to_s)
+      end
+
+      def subscription_boolean_value(stripe_subscription, key)
+        value = ActiveModel::Type::Boolean.new.cast(subscription_value(stripe_subscription, key))
+        value.nil? ? false : value
       end
 
       def value_from(object, key)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,10 @@ en:
     tagline: Run your agency’s ops from one command center.
   application_controller:
     not_found: Route not found
+  errors:
+    stripe:
+      connect_not_enabled: Stripe Connect is not enabled for this Stripe account. Enable Connect in Stripe Dashboard and try again.
+      generic: "%{message}"
   avatar:
     destroy:
       success: Avatar deleted successfully

--- a/db/migrate/20260429130000_add_cancel_at_period_end_to_companies.rb
+++ b/db/migrate/20260429130000_add_cancel_at_period_end_to_companies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCancelAtPeriodEndToCompanies < ActiveRecord::Migration[8.0]
+  def change
+    add_column :companies, :cancel_at_period_end, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_113000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -240,6 +240,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_113000) do
     t.boolean "billing_exempt", default: false, null: false
     t.string "business_phone"
     t.boolean "calendar_enabled", default: true
+    t.boolean "cancel_at_period_end", default: false, null: false
     t.string "country", null: false
     t.datetime "created_at", null: false
     t.string "date_format"
@@ -569,8 +570,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_113000) do
     t.index ["period_date"], name: "index_metrics_on_period_date"
     t.index ["trackable_type", "trackable_id", "metric_type", "period", "period_date"], name: "index_metrics_on_trackable_and_type_and_period", unique: true
     t.index ["trackable_type", "trackable_id"], name: "index_metrics_on_trackable"
-    t.check_constraint "metric_type::text = ANY (ARRAY['hours_logged'::character varying, 'invoice_summary'::character varying, 'project_stats'::character varying, 'client_revenue'::character varying, 'team_utilization'::character varying, 'outstanding_amounts'::character varying, 'overdue_amounts'::character varying, 'timesheet_summary'::character varying]::text[])", name: "valid_metric_type"
-    t.check_constraint "period::text = ANY (ARRAY['hour'::character varying, 'day'::character varying, 'week'::character varying, 'month'::character varying, 'quarter'::character varying, 'year'::character varying, 'all_time'::character varying]::text[])", name: "valid_period"
+    t.check_constraint "metric_type::text = ANY (ARRAY['hours_logged'::character varying::text, 'invoice_summary'::character varying::text, 'project_stats'::character varying::text, 'client_revenue'::character varying::text, 'team_utilization'::character varying::text, 'outstanding_amounts'::character varying::text, 'overdue_amounts'::character varying::text, 'timesheet_summary'::character varying::text])", name: "valid_metric_type"
+    t.check_constraint "period::text = ANY (ARRAY['hour'::character varying::text, 'day'::character varying::text, 'week'::character varying::text, 'month'::character varying::text, 'quarter'::character varying::text, 'year'::character varying::text, 'all_time'::character varying::text])", name: "valid_period"
   end
 
   create_table "notification_preferences", force: :cascade do |t|
@@ -607,6 +608,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_113000) do
     t.decimal "amount", precision: 20, scale: 2, default: "0.0"
     t.decimal "base_currency_amount", precision: 20, scale: 2
     t.datetime "created_at", null: false
+    t.datetime "discarded_at"
     t.decimal "exchange_rate", precision: 18, scale: 10
     t.date "exchange_rate_date"
     t.bigint "invoice_id", null: false
@@ -617,6 +619,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_113000) do
     t.date "transaction_date", null: false
     t.integer "transaction_type", null: false
     t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_payments_on_discarded_at"
     t.index ["invoice_id"], name: "index_payments_on_invoice_id"
     t.index ["status"], name: "index_payments_on_status"
     t.index ["transaction_date"], name: "index_payments_on_transaction_date"

--- a/spec/requests/api/v1/payment_settings/connect_stripe_spec.rb
+++ b/spec/requests/api/v1/payment_settings/connect_stripe_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe "Api::V1::PaymentSettings#connect_stripe", type: :request do
       expect(json_response).to have_key("accountLink")
       expect(json_response["accountLink"]).to eq("https://connect.stripe.com/setup/s/something")
     end
+
+    it "returns a helpful error when Stripe Connect is not enabled" do
+      allow(Stripe::Account).to receive(:create).and_raise(
+        Stripe::InvalidRequestError.new(
+          "You can only create new accounts if you've signed up for Connect.",
+          "account"
+        )
+      )
+
+      send_request :post, api_v1_payments_settings_stripe_connect_path, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response["errors"]).to eq(
+        "Stripe Connect is not enabled for this Stripe account. Enable Connect in Stripe Dashboard and try again."
+      )
+    end
   end
 
   context "when user is an employee" do

--- a/spec/requests/webhooks/stripe_controller_spec.rb
+++ b/spec/requests/webhooks/stripe_controller_spec.rb
@@ -118,4 +118,27 @@ RSpec.describe "Stripe webhooks", type: :request do
     expect(response).to have_http_status(:ok)
     expect(InvoicePayment::StripeCheckoutFulfillment).to have_received(:process).with(event)
   end
+
+  it "settles invoice payment on payment_intent.succeeded" do
+    event = OpenStruct.new(
+      type: "payment_intent.succeeded",
+      data: OpenStruct.new(
+        object: OpenStruct.new(
+          id: "pi_123",
+          amount_received: 1000,
+          amount: 1000,
+          currency: "usd"
+        )
+      ),
+      created: Time.zone.now.to_i
+    )
+
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    allow(InvoicePayment::StripePaymentSucceeded).to receive(:process).and_return(true)
+
+    post "/webhooks/stripe/checkout/fulfillment", params: "{}", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(InvoicePayment::StripePaymentSucceeded).to have_received(:process).with(event)
+  end
 end

--- a/spec/requests/webhooks/stripe_controller_spec.rb
+++ b/spec/requests/webhooks/stripe_controller_spec.rb
@@ -141,4 +141,27 @@ RSpec.describe "Stripe webhooks", type: :request do
     expect(response).to have_http_status(:ok)
     expect(InvoicePayment::StripePaymentSucceeded).to have_received(:process).with(event)
   end
+
+  it "acknowledges valid payment_intent.succeeded events that do not settle an invoice" do
+    event = OpenStruct.new(
+      type: "payment_intent.succeeded",
+      data: OpenStruct.new(
+        object: OpenStruct.new(
+          id: "pi_without_invoice",
+          amount_received: 1000,
+          amount: 1000,
+          currency: "usd"
+        )
+      ),
+      created: Time.zone.now.to_i
+    )
+
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    allow(InvoicePayment::StripePaymentSucceeded).to receive(:process).and_return(false)
+
+    post "/webhooks/stripe/checkout/fulfillment", params: "{}", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(InvoicePayment::StripePaymentSucceeded).to have_received(:process).with(event)
+  end
 end

--- a/spec/services/invoice_payment/stripe_checkout_fulfillment_intent_validation_spec.rb
+++ b/spec/services/invoice_payment/stripe_checkout_fulfillment_intent_validation_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "hash_dot"
+
+RSpec.describe InvoicePayment::StripeCheckoutFulfillment do
+  let(:company) { create(:company, base_currency: "inr") }
+  let(:client) { create(:client_with_phone_number_without_country_code, company:) }
+
+  def event_for(invoice:, payment_intent:)
+    {
+      data: {
+        object: {
+          metadata: { invoice_id: invoice.id },
+          payment_intent:,
+          amount_total: Money.from_amount(invoice.amount, "inr").cents,
+          status: "complete",
+          payment_status: "paid",
+          currency: "inr"
+        }
+      },
+      created: Time.current.strftime("%s")
+    }.to_dot
+  end
+
+  it "rejects checkout fulfillment when only the invoice has a payment intent" do
+    invoice = create(
+      :invoice,
+      status: "sent",
+      company:,
+      client:,
+      amount: 11583.33,
+      amount_due: 11583.33,
+      amount_paid: 0,
+      payment_infos: { "stripe_payment_intent" => "pi_invoice_only" }
+    )
+
+    expect(described_class.new(event_for(invoice:, payment_intent: nil)).process).to be(false)
+    expect(Payment.last&.invoice_id).not_to eq(invoice.id)
+  end
+
+  it "rejects checkout fulfillment when only the stripe event has a payment intent" do
+    invoice = create(
+      :invoice,
+      status: "sent",
+      company:,
+      client:,
+      amount: 11583.33,
+      amount_due: 11583.33,
+      amount_paid: 0
+    )
+
+    expect(described_class.new(event_for(invoice:, payment_intent: "pi_event_only")).process).to be(false)
+    expect(Payment.last&.invoice_id).not_to eq(invoice.id)
+  end
+end


### PR DESCRIPTION
…g webhook noise

## Stripe Billing Test Matrix Status

### Scope

Status captured from the latest local Stripe integration verification session on `2026-04-29`.

### Prerequisites

- App running on `http://127.0.0.1:3000` ✅
- Stripe CLI forwarding to webhook endpoint ✅
- Required Stripe env vars configured ✅

### Use Case Status

1. Subscription checkout success (monthly)  
Status: ✅ Tested  
Evidence: `checkout.session.completed` and `customer.subscription.created` returned `200`; billing page showed `Current plan: Paid`.

2. Subscription checkout success (yearly)  
Status: ✅ Tested  
Evidence: Yearly checkout completed successfully and billing/cadence reflected yearly plan as expected.

3. Checkout cancel path  
Status: ✅ Tested  
Evidence: Cancel-at-period-end flow verified and immediate cancel-now flow from Stripe also verified.

4. Payment failure during checkout  
Status: ✅ Tested  
Evidence: Declined card scenario (`4000 0000 0000 0002`) shows Stripe error and blocks checkout success.

5. Billing portal open  
Status: ✅ Tested  
Evidence: Portal opened from Miru and cancellation workflow was performed from Stripe portal.

6. Cancel subscription from Stripe portal  
Status: ✅ Tested  
Evidence: `customer.subscription.updated` events received during period-end cancellation and `customer.subscription.deleted` returned `200` for immediate cancellation flow.
Additional verification:
- Period-end cancellation state was visible in Stripe Billing Portal (`Cancels <date>`).
- Miru now supports showing scheduled cancellation details (`cancel_at_period_end` + end date).

7. Reactivate / new subscription after cancellation  
Status: ✅ Tested  
Evidence: After cancellation flow, checkout was re-run and workspace returned to Paid.

8. Webhook signature validation negative test  
Status: ✅ Substantially tested  
Evidence: Signature/event handling failures were reproduced and fixed (`nil event` handling + webhook robustness).  
Notes: A clean scripted “old secret then new secret” runbook execution is still optional.

9. Missing price config negative test  
Status: ✅ Tested  
Evidence: With subscription price env vars removed, billing checkout returned app-level error: `Stripe subscription pricing is not configured`.

10. Invoice Stripe payment flow (non-subscription)  
Status: ✅ Tested  
Evidence:
- Invoice checkout completed with Stripe test card.
- Webhook `payment_intent.succeeded` processed successfully.
- Invoice state updated from `viewed` to paid flow after webhook sync fix.

### Summary

- Fully/substantially tested: **10/10**
- Pending: **0/10**

### Additional Fixes Validated In This Cycle

1. Webhook nil-event crash fix validated:
- `HandleStripeCheckoutEventService` no longer crashes when Stripe event construction fails.

2. Stripe payload compatibility fix validated:
- Subscription sync no longer assumes top-level `current_period_end` always exists.

3. Scheduled cancellation UX support validated:
- Added and verified `cancel_at_period_end` persistence/sync path.
- Billing UI now supports showing “scheduled to cancel” while access remains active until period end.

4. Pro tile status badge logic improved:
- Badge now shows `Current plan (Monthly/Yearly)` for paid workspaces instead of always static `Recommended`.

5. Additional negative scenario validated:
- Invalid Stripe price ID configuration returns Stripe error (`No such price: ...`) and blocks checkout.

### Residual Notes

1. In local logs, some non-critical Stripe events can still return `400` (for example, events outside Miru's handled event set).
2. The invoice payment success path is now reliably handled through `payment_intent.succeeded` webhook processing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled subscription cancellation support with end-of-period alerts
  * Webhook handling for Stripe payment_intent.succeeded events
  * Soft-delete support for payments

* **Bug Fixes**
  * Clearer Stripe Connect error messaging surfaced to the API
  * Stricter guards when retrieving Stripe payment intents/methods

* **Enhancements**
  * Billing UI shows current plan, cadence, and cancellation notice
  * API now exposes cancel_at_period_end
  * Added Stripe-related translation strings

* **Tests**
  * New specs for Connect error handling, webhooks, and fulfillment validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->