### PR TITLE
Fix API signup CSRF handling

### DIFF
--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
   respond_to :json
+  protect_from_forgery with: :null_session, only: :create
 
   def respond_with(user, _opts = {})
     if user.errors.present?

--- a/spec/requests/api/v1/users/registrations/create_spec.rb
+++ b/spec/requests/api/v1/users/registrations/create_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe "Api::V1::Users::Registrations#create", type: :request do
       expect(json_response["email"]).to eq(desktop_signup_json[:email])
       expect(User.find_by!(email: desktop_signup_json[:email]).locale).to eq("en-US")
     end
+
+    it "does not require a browser csrf token for JSON desktop signup" do
+      with_forgery_protection do
+        post api_v1_users_signup_path, params: {
+          user: desktop_signup_json.merge(email: generate(:user_email))
+        }, as: :json
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response["notice"]).to eq(I18n.t("devise.registrations.signed_up"))
+    end
   end
 
   context "when signs up with invalid info" do


### PR DESCRIPTION
## Summary
- allow JSON API registration requests to bypass browser CSRF verification
- add regression coverage with forgery protection enabled

## Verification
- rtk mise exec -- bundle exec rspec spec/requests/api/v1/users/registrations/create_spec.rb spec/models/user_spec.rb
- rtk mise exec -- bundle exec rubocop app/controllers/api/v1/users/registrations_controller.rb spec/requests/api/v1/users/registrations/create_spec.rb
- production smoke: POST https://app.miru.so/api/v1/users/signup returned 200 for a desktop-shaped payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON-based user registration now succeeds without requiring browser-specific authentication tokens, allowing non-browser clients to sign up seamlessly.

* **Tests**
  * Added test coverage to ensure JSON registration requests are accepted and behave correctly under forgery protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->