### PR TITLE
fix(payments): resolve Razorpay payment link amount error and add cov…

### DIFF
--- a/app/services/invoice_payment/razorpay_payment_link_webhook_fulfillment.rb
+++ b/app/services/invoice_payment/razorpay_payment_link_webhook_fulfillment.rb
@@ -48,12 +48,22 @@ class InvoicePayment::RazorpayPaymentLinkWebhookFulfillment
     def invoice
       @_invoice ||= begin
         invoice_id = payment_link_notes["miru_invoice_id"].presence || reference_invoice_id
-        Invoice.kept.find_by(id: invoice_id)
+        if invoice_id.present?
+          Invoice.kept.find_by(id: invoice_id)
+        else
+          invoice_from_payment_link_id
+        end
       end
     end
 
     def reference_invoice_id
       payment_link["reference_id"].to_s.delete_prefix("miru-inv-")
+    end
+
+    def invoice_from_payment_link_id
+      return if payment_link_id.blank?
+
+      Invoice.kept.find_by("payment_infos ->> 'razorpay_payment_link_id' = ?", payment_link_id)
     end
 
     def provider

--- a/app/services/payment_providers/razorpay_client.rb
+++ b/app/services/payment_providers/razorpay_client.rb
@@ -14,7 +14,10 @@ module PaymentProviders
     end
 
     def create_payment_link(payload)
-      with_sdk { normalize_response(Razorpay::PaymentLink.create(payload)) }
+      with_sdk(headers: { "Content-Type" => "application/json" }) do
+        request = Razorpay::Request.new("payment_links")
+        normalize_response(request.request(:post, "/v1/payment_links", JSON.generate(payload)))
+      end
     end
 
     def fetch_payment_link(payment_link_id)
@@ -70,6 +73,7 @@ module PaymentProviders
       end
 
       def normalize_response(response)
+        return response.parsed_response if response.respond_to?(:parsed_response)
         return response.attributes if response.respond_to?(:attributes)
 
         response

--- a/app/services/payment_providers/razorpay_payment_link_service.rb
+++ b/app/services/payment_providers/razorpay_payment_link_service.rb
@@ -75,7 +75,10 @@ module PaymentProviders
           notify: { sms: false, email: false },
           callback_url:,
           callback_method: "get"
-        }
+        }.tap do |payload|
+          route_options = route_transfer_options
+          payload[:options] = route_options if route_options.present?
+        end
       end
 
       def create_payment_link_with_fallback
@@ -90,7 +93,8 @@ module PaymentProviders
       end
 
       def amount_whole_number_error?(error)
-        error.message.to_s.downcase.include?("amount, should be a whole number")
+        message = error.message.to_s
+        message.match?(/\bamount\b.*\b(whole|whole\s*number)\b/i)
       end
 
       def customer_payload

--- a/app/services/payment_providers/razorpay_payment_link_service.rb
+++ b/app/services/payment_providers/razorpay_payment_link_service.rb
@@ -13,7 +13,7 @@ module PaymentProviders
     def process
       return existing_payment_link if existing_payment_link?
 
-      response = client.create_payment_link(payment_link_payload)
+      response = create_payment_link_with_fallback
       invoice.update!(
         razorpay_payment_link_id: response.fetch("id"),
         razorpay_payment_link_url: response.fetch("short_url"),
@@ -63,6 +63,34 @@ module PaymentProviders
           route_options = route_transfer_options
           payload[:options] = route_options if route_options.present?
         end
+      end
+
+      def minimal_payment_link_payload
+        {
+          amount: amount_subunits,
+          currency: invoice.currency,
+          accept_partial: false,
+          description: "Invoice #{invoice.invoice_number} from #{invoice.company.name}",
+          customer: customer_payload,
+          notify: { sms: false, email: false },
+          callback_url:,
+          callback_method: "get"
+        }
+      end
+
+      def create_payment_link_with_fallback
+        client.create_payment_link(payment_link_payload)
+      rescue PaymentProviders::RazorpayClient::Error => error
+        raise error unless amount_whole_number_error?(error)
+
+        Rails.logger.warn(
+          "Retrying Razorpay payment link creation with minimal payload for invoice #{invoice.id}: #{error.message}"
+        )
+        client.create_payment_link(minimal_payment_link_payload)
+      end
+
+      def amount_whole_number_error?(error)
+        error.message.to_s.downcase.include?("amount, should be a whole number")
       end
 
       def customer_payload

--- a/spec/services/invoice_payment/razorpay_payment_link_webhook_fulfillment_spec.rb
+++ b/spec/services/invoice_payment/razorpay_payment_link_webhook_fulfillment_spec.rb
@@ -166,6 +166,19 @@ RSpec.describe InvoicePayment::RazorpayPaymentLinkWebhookFulfillment do
     expect(invoice.razorpay_payment_link_status).to eq("paid")
   end
 
+  it "finds the invoice by stored payment link id when fallback payload metadata is missing" do
+    fallback_payload = JSON.parse(payload)
+    fallback_payload["payload"]["payment_link"]["entity"].delete("notes")
+    fallback_payload["payload"]["payment_link"]["entity"].delete("reference_id")
+    fallback_payload = fallback_payload.to_json
+
+    result = described_class.new(payload: fallback_payload, signature: sign(fallback_payload)).process
+
+    expect(result).to be(true)
+    expect(invoice.reload).to be_paid
+    expect(invoice.razorpay_payment_link_status).to eq("paid")
+  end
+
   it "rejects paid events without a matching invoice" do
     missing_invoice_payload = JSON.parse(payload)
     missing_invoice_payload["payload"]["payment_link"]["entity"]["notes"]["miru_invoice_id"] = "99999999"

--- a/spec/services/payment_providers/razorpay_client_spec.rb
+++ b/spec/services/payment_providers/razorpay_client_spec.rb
@@ -19,11 +19,15 @@ RSpec.describe PaymentProviders::RazorpayClient do
   let(:client) { described_class.new(provider:) }
 
   describe "#create_payment_link" do
-    it "uses the official Razorpay Payment Link SDK resource" do
+    it "creates payment links through the SDK request layer with JSON payloads" do
       payload = { amount: 1000, currency: "INR" }
-      response = instance_double(Razorpay::Entity, attributes: { "id" => "plink_test_123" })
+      request = instance_double(Razorpay::Request)
+      response = instance_double(HTTParty::Response, parsed_response: { "id" => "plink_test_123" })
 
-      expect(Razorpay::PaymentLink).to receive(:create).with(payload).and_return(response)
+      expect(Razorpay::Request).to receive(:new).with("payment_links").and_return(request)
+      expect(request).to receive(:request)
+        .with(:post, "/v1/payment_links", payload.to_json)
+        .and_return(response)
 
       expect(client.create_payment_link(payload)).to eq("id" => "plink_test_123")
     end

--- a/spec/services/payment_providers/razorpay_payment_link_service_spec.rb
+++ b/spec/services/payment_providers/razorpay_payment_link_service_spec.rb
@@ -80,7 +80,8 @@ RSpec.describe PaymentProviders::RazorpayPaymentLinkService do
 
         expect(payload[:reference_id]).to be_nil
         expect(payload[:notes]).to be_nil
-        expect(payload[:options]).to be_nil
+        expect(payload.dig(:options, :order, :transfers, 0, :account)).to eq("acc_test_123")
+        expect(payload.dig(:options, :order, :transfers, 0, :amount)).to eq(114_000)
         expect(payload[:amount]).to eq(120_000)
         expect(payload[:callback_method]).to eq("get")
         { "id" => "plink_test_retry", "short_url" => "https://rzp.io/rzp/retry", "status" => "created" }
@@ -96,6 +97,21 @@ RSpec.describe PaymentProviders::RazorpayPaymentLinkService do
       expect(invoice.reload.razorpay_payment_link_id).to eq("plink_test_retry")
       expect(invoice.razorpay_payment_link_url).to eq("https://rzp.io/rzp/retry")
       expect(invoice.razorpay_payment_link_status).to eq("created")
+    end
+
+    it "re-raises non amount-format Razorpay errors without retrying" do
+      expect(client_double).to receive(:create_payment_link).once.and_raise(
+        PaymentProviders::RazorpayClient::Error,
+        "request timeout from Razorpay"
+      )
+
+      expect do
+        described_class.new(
+          invoice:,
+          provider:,
+          callback_url: "https://app.test/invoices/#{invoice.id}/payments/razorpay_success"
+        ).process
+      end.to raise_error(PaymentProviders::RazorpayClient::Error, "request timeout from Razorpay")
     end
 
     it "reuses an active existing payment link and refreshes the stored status" do

--- a/spec/services/payment_providers/razorpay_payment_link_service_spec.rb
+++ b/spec/services/payment_providers/razorpay_payment_link_service_spec.rb
@@ -68,6 +68,36 @@ RSpec.describe PaymentProviders::RazorpayPaymentLinkService do
       expect(invoice.razorpay_payment_link_status).to eq("created")
     end
 
+    it "retries with a minimal payload when Razorpay rejects amount format unexpectedly" do
+      attempts = 0
+      expect(client_double).to receive(:create_payment_link).twice do |payload|
+        attempts += 1
+        if attempts == 1
+          expect(payload[:reference_id]).to eq("miru-inv-#{invoice.id}")
+          raise PaymentProviders::RazorpayClient::Error,
+            "amount, should be a whole number for e.g. 2234 to create a payment link for 22.34 INR"
+        end
+
+        expect(payload[:reference_id]).to be_nil
+        expect(payload[:notes]).to be_nil
+        expect(payload[:options]).to be_nil
+        expect(payload[:amount]).to eq(120_000)
+        expect(payload[:callback_method]).to eq("get")
+        { "id" => "plink_test_retry", "short_url" => "https://rzp.io/rzp/retry", "status" => "created" }
+      end
+
+      payment_url = described_class.new(
+        invoice:,
+        provider:,
+        callback_url: "https://app.test/invoices/#{invoice.id}/payments/razorpay_success"
+      ).process
+
+      expect(payment_url).to eq("https://rzp.io/rzp/retry")
+      expect(invoice.reload.razorpay_payment_link_id).to eq("plink_test_retry")
+      expect(invoice.razorpay_payment_link_url).to eq("https://rzp.io/rzp/retry")
+      expect(invoice.razorpay_payment_link_status).to eq("created")
+    end
+
     it "reuses an active existing payment link and refreshes the stored status" do
       invoice.update!(
         razorpay_payment_link_id: "plink_test_123",

--- a/spec/system/invoices/razorpay_payment_flow_spec.rb
+++ b/spec/system/invoices/razorpay_payment_flow_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "rails_helper"
+
+RSpec.describe "Invoice Razorpay payment flow", type: :system, js: true do
+  let(:company) { create(:india_company, base_currency: "INR") }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:client) { create(:client, company:, currency: "INR", name: "Razorpay Client") }
+  let(:invoice) do
+    create(
+      :invoice,
+      company:,
+      client:,
+      currency: "INR",
+      status: :sent,
+      invoice_number: "INV-RZP-E2E-001",
+      amount: 1000.00,
+      amount_due: 1000.00,
+      amount_paid: 0.00,
+      outstanding_amount: 1000.00,
+      payment_infos: {
+        "razorpay_payment_link_id" => "plink_test_123",
+        "razorpay_payment_link_url" => "https://rzp.io/rzp/test"
+      }
+    )
+  end
+  let!(:provider) do
+    create(
+      :payments_provider,
+      company:,
+      name: PaymentsProvider::RAZORPAY_PROVIDER,
+      enabled: true,
+      connected: true,
+      settings: {
+        key_id: "rzp_test_123",
+        key_secret: "secret",
+        webhook_secret: "webhook_secret",
+        enabled_on_invoices: true
+      }
+    )
+  end
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :admin, company
+    sign_in(user)
+    allow(PaymentMailer).to receive_message_chain(:with, :payment, :deliver_later)
+    allow_any_instance_of(Invoice).to receive(:send_to_client_email)
+  end
+
+  it "marks sent invoice paid via Razorpay webhook and shows the payment in UI" do
+    with_forgery_protection do
+      visit "/invoices/#{invoice.id}"
+      expect(page).to have_css("#react-root", wait: 10)
+      expect(page).to have_content("INV-RZP-E2E-001", wait: 10)
+      expect(page).to have_content("Sent", wait: 10)
+
+      payload = razorpay_paid_payload(invoice:)
+      signature = OpenSSL::HMAC.hexdigest("SHA256", "webhook_secret", payload)
+
+      result = InvoicePayment::RazorpayPaymentLinkWebhookFulfillment
+        .new(payload:, signature:)
+        .process
+
+      expect(result).to be(true)
+
+      visit "/invoices/#{invoice.id}"
+      expect(page).to have_content("INV-RZP-E2E-001", wait: 10)
+      expect(page).to have_content("Paid", wait: 10)
+
+      visit "/payments"
+      expect(page).to have_css("#react-root", wait: 10)
+      expect(page).to have_content("INV-RZP-E2E-001", wait: 10)
+      expect(page).to have_content("Razorpay", wait: 10)
+      expect(page).to have_content("1,000", wait: 10)
+    end
+  end
+
+  def razorpay_paid_payload(invoice:)
+    {
+      event: "payment_link.paid",
+      created_at: Time.zone.local(2026, 4, 29, 12, 0, 0).to_i,
+      payload: {
+        payment_link: {
+          entity: {
+            id: "plink_test_123",
+            amount_paid: 100_000,
+            updated_at: Time.zone.local(2026, 4, 29, 12, 0, 0).to_i,
+            reference_id: "miru-inv-#{invoice.id}",
+            notes: {
+              miru_invoice_id: invoice.id.to_s,
+              company_id: company.id.to_s
+            },
+            customer: {
+              name: "Razorpay Client"
+            }
+          }
+        },
+        payment: {
+          entity: {
+            id: "pay_test_123"
+          }
+        }
+      }
+    }.to_json
+  end
+end

--- a/spec/system/payments/payment_method_status_combinations_spec.rb
+++ b/spec/system/payments/payment_method_status_combinations_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Payment method and status combinations", type: :system, js: true do
+  let(:company) { create(:company, base_currency: "USD") }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:client) { create(:client, company:, name: "Test Client") }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :admin, company
+    sign_in(user)
+  end
+
+  describe "payment method and status badge differentiation" do
+    let!(:invoice) do
+      create(:invoice,
+        company:, client:, status: :sent,
+        invoice_number: "INV-TEST-001",
+        amount: 1000.00, amount_due: 1000.00,
+        outstanding_amount: 1000.00)
+    end
+
+    context "visual differentiation verification" do
+      let!(:payments_with_different_combinations) do
+        [
+          create(:payment, invoice:, amount: 100, status: :paid, transaction_type: :visa, note: "Visa paid"),
+          create(:payment, invoice:, amount: 200, status: :failed, transaction_type: :visa, note: "Visa failed"),
+          create(:payment, invoice:, amount: 300, status: :paid, transaction_type: :bank_transfer, note: "Bank paid"),
+          create(:payment, invoice:, amount: 400, status: :partially_paid, transaction_type: :stripe, note: "Stripe partial"),
+          create(:payment, invoice:, amount: 500, status: :cancelled, transaction_type: :cash, note: "Cash cancelled")
+        ]
+      end
+
+      it "displays all payment combinations with visually distinct badges" do
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Wait for all payments to load
+          expect(page).to have_content("Test Client", wait: 10)
+
+          # Collect all badge elements and their classes
+          payment_method_badges = page.all("[data-testid='payment-method-badge']")
+          status_badges = page.all("[data-testid='status-badge']")
+
+          expect(payment_method_badges.count).to be >= 5
+          expect(status_badges.count).to be >= 5
+
+          # Verify that we have different color schemes
+          payment_method_color_classes = payment_method_badges.pluck(:class).uniq
+          status_color_classes = status_badges.pluck(:class).uniq
+
+          # Should have multiple distinct color schemes for payment methods
+          expect(payment_method_color_classes.count).to be >= 3
+
+          # Should have multiple distinct color schemes for statuses
+          expect(status_color_classes.count).to be >= 3
+
+          # Payment method and status badges should not share the same color schemes
+          overlapping_classes = payment_method_color_classes & status_color_classes
+          expect(overlapping_classes).to be_empty
+        end
+      end
+
+      it "shows specific color coding for different statuses" do
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Wait for payments to load
+          expect(page).to have_content("Test Client", wait: 10)
+
+          # Check for specific status color coding
+          status_badges = page.all("[data-testid='status-badge']")
+
+          # Find badges with different statuses and verify they have different colors
+          paid_badges = status_badges.select { |badge| badge.text.downcase.include?("paid") && !badge.text.downcase.include?("partially") }
+          failed_badges = status_badges.select { |badge| badge.text.downcase.include?("failed") }
+          partial_badges = status_badges.select { |badge| badge.text.downcase.include?("partially") }
+          cancelled_badges = status_badges.select { |badge| badge.text.downcase.include?("cancelled") }
+
+          if paid_badges.any?
+            expect(paid_badges.first[:class]).to include("green")
+          end
+
+          if failed_badges.any?
+            expect(failed_badges.first[:class]).to include("red")
+          end
+
+          if partial_badges.any?
+            expect(partial_badges.first[:class]).to include("yellow")
+          end
+
+          if cancelled_badges.any?
+            expect(cancelled_badges.first[:class]).to include("gray")
+          end
+        end
+      end
+
+      it "shows specific color coding for different payment methods" do
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Wait for payments to load
+          expect(page).to have_content("Test Client", wait: 10)
+
+          # Check for specific payment method color coding
+          payment_method_badges = page.all("[data-testid='payment-method-badge']")
+
+          # Find badges with different payment methods and verify they have different colors
+          card_badges = payment_method_badges.select { |badge| badge.text.downcase.include?("visa") }
+          bank_badges = payment_method_badges.select { |badge| badge.text.downcase.include?("bank") }
+          stripe_badges = payment_method_badges.select { |badge| badge.text.downcase.include?("stripe") }
+          cash_badges = payment_method_badges.select { |badge| badge.text.downcase.include?("cash") }
+
+          if card_badges.any?
+            expect(card_badges.first[:class]).to include("emerald")
+          end
+
+          if bank_badges.any?
+            expect(bank_badges.first[:class]).to include("cyan")
+          end
+
+          if stripe_badges.any?
+            expect(stripe_badges.first[:class]).to include("indigo")
+          end
+
+          if cash_badges.any?
+            expect(cash_badges.first[:class]).to include("orange")
+          end
+        end
+      end
+    end
+
+    context "accessibility and usability" do
+      let!(:test_payment) do
+        create(:payment,
+          invoice:,
+          amount: 1000.00,
+          status: :paid,
+          transaction_type: :credit_card,
+          note: "Accessibility test payment")
+      end
+
+      it "ensures badges are accessible and readable" do
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Check that badges have proper contrast and are readable
+          payment_method_badge = page.find("[data-testid='payment-method-badge']",
+            match: :first, wait: 5)
+          status_badge = page.find("[data-testid='status-badge']",
+            match: :first, wait: 5)
+
+          # Badges should be visible and have text content
+          expect(payment_method_badge).to be_visible
+          expect(status_badge).to be_visible
+          expect(payment_method_badge.text).not_to be_empty
+          expect(status_badge.text).not_to be_empty
+
+          # Badges should have proper ARIA attributes or semantic meaning
+          expect(payment_method_badge.tag_name.downcase).to be_in(%w[span div badge])
+          expect(status_badge.tag_name.downcase).to be_in(%w[span div badge])
+        end
+      end
+    end
+  end
+
+  describe "edge cases and data validation" do
+    let!(:invoice) do
+      create(:invoice,
+        company:, client:, status: :sent,
+        invoice_number: "INV-EDGE-001",
+        amount: 1000.00)
+    end
+
+    context "with various payment methods" do
+      it "handles all payment methods gracefully" do
+        # Create payments with different transaction types
+        payment_methods = [:visa, :mastercard, :bank_transfer, :stripe, :cash, :cheque]
+        payment_methods.map.with_index do |method, index|
+          create(:payment,
+            invoice:,
+            amount: (index + 1) * 100.00,
+            status: :paid,
+            transaction_type: method,
+            note: "#{method.to_s.humanize} payment test")
+        end
+
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Should display all payments with their respective badges
+          payment_methods.each do |method|
+            expect(page).to have_content("#{method.to_s.humanize} payment test", wait: 10)
+          end
+
+          # Should have payment method badges for all payments
+          payment_method_badges = page.all("[data-testid='payment-method-badge']")
+          expect(payment_method_badges.count).to be >= payment_methods.count
+        end
+      end
+    end
+
+    context "with various statuses" do
+      it "handles all statuses gracefully" do
+        # Create payments with different statuses
+        statuses = [:paid, :partially_paid, :failed, :cancelled]
+        statuses.map.with_index do |status, index|
+          create(:payment,
+            invoice:,
+            amount: (index + 1) * 100.00,
+            status:,
+            transaction_type: :visa,
+            note: "#{status.to_s.humanize} status test")
+        end
+
+        with_forgery_protection do
+          visit "/payments"
+
+          expect(page).to have_current_path("/payments", wait: 10)
+          expect(page).to have_css("#react-root", wait: 10)
+
+          # Should display all payments with their respective badges
+          statuses.each do |status|
+            expect(page).to have_content("#{status.to_s.humanize} status test", wait: 10)
+          end
+
+          # Should have status badges for all payments
+          status_badges = page.all("[data-testid='status-badge']")
+          expect(status_badges.count).to be >= statuses.count
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…erage notes

## Razorpay Payment Test Matrix Status

### Scope

Status captured from the current local Razorpay integration verification cycle on `2026-04-30`.

### Prerequisites

- App running on `http://127.0.0.1:3000` ✅
- ngrok tunnel active and reachable ✅
- Razorpay provider configured for Company `1` (Key ID + Key Secret) ✅
- Razorpay provider enabled for invoices ✅
- Webhook secret configured in Miru and Razorpay Dashboard ✅
- Payment Links webhook configured:
  - `https://antibody-payroll-morbidity.ngrok-free.dev/webhooks/razorpay/payment_links` ✅
- Payment Link events selected:
  - `payment_link.paid` ✅
  - `payment_link.partially_paid` ✅
  - `payment_link.cancelled` ✅
  - `payment_link.expired` ✅
- Optional RazorpayX payouts webhook configured:
  - `https://antibody-payroll-morbidity.ngrok-free.dev/webhooks/razorpay/payouts` ⏳

### Use Case Status

1. Razorpay settings save and validation
Status: ✅ Tested
Evidence: Company `1` provider validated with enabled/connected true, invoice enablement true, and secrets configured.

2. Invoice payment link generation for INR invoice
Status: ✅ Tested
Evidence: Payment link creation for `INV-082-001` succeeded and redirected to Razorpay short URL (`rzp.io`).

3. Full payment success (`payment_link.paid`)
Status: ✅ Tested
Evidence: Test-mode payment completed from checkout; invoice marked paid in Miru (team verification completed in-session).

4. Partial payment success (`payment_link.partially_paid`)
Status: ⚪ Not Applicable (current product scope)
Evidence: Current payment-link creation sets `accept_partial: false`, so partial collection cannot be triggered via supported UI flow.

5. Payment cancellation (`payment_link.cancelled`)
Status: ✅ Tested (checkout cancel behavior) / ⚪ Optional (link-level webhook event)
Evidence:
- Checkout dismiss/cancel path tested: invoice remains unpaid and retry path is available.
- Link-level `payment_link.cancelled` webhook event requires dashboard/API cancellation of the Payment Link and is tracked as optional for current invoice collection scope.

6. Payment expiry (`payment_link.expired`)
Status: ✅ Tested
Evidence: Razorpay emitted `payment_link.expired` for link `plink_SjfYl5hiV1vtMu` on invoice `INV-RZP-EXP-1777544488` (`id=245`); ngrok webhook delivery returned `200 OK`; invoice remained `sent` (unpaid).

7. Payments page entry creation after success
Status: ✅ Tested
Evidence: Razorpay flow system/browser spec verifies payment visibility on `/payments` after settlement.

8. Webhook signature validation negative test
Status: ✅ Tested
Evidence: During webhook-secret mismatch, `payment_link.paid` delivery returned `401 Unauthorized`; Miru correctly rejected the payload (invalid signature path).

9. Webhook duplicate delivery idempotency
Status: ✅ Tested
Evidence: Replayed existing `payment_link.paid` event (invoice `INV-RZP-EXP-1777544489`, `miru_invoice_id=246`) returned `200 OK`; idempotent handling validated with no duplicate settlement.

10. Public invoice success view behavior
Status: ✅ Tested
Evidence: Request spec coverage exists for Razorpay success response payload and success notice behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment link creation reliability with an automatic retry for certain validation errors.
  * Fixed webhook handling so invoices are correctly resolved even when fallback metadata is missing.

* **User-facing**
  * Payment list now shows Razorpay links/entries with provider name and formatted amount.
  * Invoice pages reliably transition from "Sent" to "Paid" after Razorpay webhook processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2217 