### PR TITLE
fix(invoices): improve waive off button contrast

### DIFF
--- a/app/javascript/src/StyledComponents/Button.tsx
+++ b/app/javascript/src/StyledComponents/Button.tsx
@@ -5,9 +5,10 @@ import classnames from "classnames";
 const DEFAULT_STYLE = "rounded text-center p-2";
 
 const PRIMARY =
-  "bg-primary hover:bg-primary/90 text-white  border border-primary hover:border-primary";
+  "bg-primary hover:bg-primary/90 text-primary-foreground border border-primary hover:border-primary";
 
-const PRIMARY_DISABLED = "bg-secondary text-white border border-border";
+const PRIMARY_DISABLED =
+  "bg-secondary text-secondary-foreground border border-border";
 
 const SECONDARY =
   "bg-transparent hover:bg-secondary text-primary border border-primary";


### PR DESCRIPTION
## Summary
- Fixes #2216
- Use theme foreground tokens for legacy primary buttons instead of hardcoded white text
- Update disabled primary buttons to use the secondary foreground token

## Verification
- `rtk mise exec -- timeout 30 bin/vite build` exited 0; Vite reported cached build unchanged from the earlier successful build
- `rtk mise exec -- pnpm lint`
- `rtk git diff --check`
- Browser verified the invoice Waive Off modal locally on port 3016. Dark mode computed contrast for the Waive Off primary button: 14.36:1; default theme: 17.18:1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated primary button text colors to use theme-based color values instead of fixed styling, improving visual consistency across enabled and disabled button states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->