### PR TITLE
fix(settings): improve edit settings button contrast

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Details/Page.tsx
+++ b/app/javascript/src/components/Profile/Organization/Details/Page.tsx
@@ -193,7 +193,7 @@ const OrganizationSettingsPage: React.FC<OrganizationSettingsPageProps> = ({
         <div className="mb-6 flex justify-end">
           <Button
             onClick={handleEditClick}
-            className="bg-primary hover:bg-primary text-white font-geist-medium"
+            className="font-geist-medium"
             size="sm"
           >
             <PencilSimple className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- Fixes #2215
- Remove the Company Settings page-level primary button color override
- Let the shared `Button` default variant supply theme-aware `text-primary-foreground` and hover styles

## Verification
- `rtk mise exec -- timeout 30 bin/vite build`
- `rtk mise exec -- pnpm lint`
- `rtk git diff --check`
- Browser verified `/settings/organization` in dark mode on local port 3015. Edit Settings button computed contrast: 14.36:1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Edit Settings" button styling in the organization profile details page to use the Button component's default styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->