### PR TITLE
Fix empty time-tracking template while adding entry

### DIFF
--- a/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
+++ b/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
@@ -29,6 +29,7 @@ interface TimeEntriesDisplayProps {
   setSelectedFullDate: (value: string) => void;
   dayInfo?: any[];
   view?: string;
+  hideEmptyState?: boolean;
 }
 
 const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
@@ -47,6 +48,7 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   setSelectedFullDate,
   dayInfo = [],
   view = "week",
+  hideEmptyState = false,
 }) => {
   const [reviewMode, setReviewMode] = useState<"day" | "week">("day");
   const { companyRole, isDesktop } = useUserContext();
@@ -325,6 +327,10 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
         </div>
       </div>
     );
+  }
+
+  if (hideEmptyState) {
+    return null;
   }
 
   return (

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -1033,6 +1033,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
                 setSelectedFullDate={setSelectedFullDate}
                 dayInfo={dayInfo}
                 view={view}
+                hideEmptyState={newEntryView || newTimeoffEntryView}
               />
             </div>
           )}

--- a/spec/system/time_tracking/entries_spec.rb
+++ b/spec/system/time_tracking/entries_spec.rb
@@ -147,5 +147,23 @@ RSpec.describe "Time Tracking Entries", type: :system, js: true do
           .or have_content("Add Entry", wait: 10)
       end
     end
+
+    it "hides the empty state while adding an entry" do
+      with_forgery_protection do
+        visit "/time-tracking"
+
+        expect(page).to have_css("#react-root", wait: 10)
+        expect(page).to have_content("No time entries yet", wait: 10)
+
+        find("button", text: /Add Entry/, match: :first, wait: 10).click
+
+        expect(page).to have_button("Save Entry", disabled: true, wait: 10)
+        expect(page).to have_no_content("No time entries yet", wait: 10)
+        expect(page).to have_no_content(
+          'Click "Add Entry" to log your first time entry for this day',
+          wait: 10
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- hide the no-entries template while the add-entry/time-off form is open
- keep existing entry review rendering unchanged
- add a system regression spec for the empty-state to Add Entry flow

Fixes #2213.

## Verification
- rtk git diff --check origin/develop..HEAD
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- pnpm lint
- rtk mise exec -- bundle exec rspec spec/system/time_tracking/entries_spec.rb
- Playwright browser flow on /time-tracking: Add Entry opens the form and hides the empty state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * The empty state message automatically hides when you start creating a new time entry or managing time-off requests, providing a cleaner interface and smoother workflow experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->