### PR TITLE
fix(invoices): clarify failed send feedback

### DIFF
--- a/app/javascript/src/components/Invoices/index.tsx
+++ b/app/javascript/src/components/Invoices/index.tsx
@@ -395,9 +395,17 @@ const InvoicesPage: React.FC<InvoicesPageProps> = ({
         navigate(`/invoices/${savedInvoice.id}/edit`);
       }
 
-      toast.error(
-        invoiceRequestErrorMessage(err, i18n.t("invoices.failedToSend"))
+      const errorMessage = invoiceRequestErrorMessage(
+        err,
+        i18n.t("invoices.failedToSend")
       );
+
+      toast.error(
+        savedInvoice
+          ? `Invoice was saved as a draft, but sending failed: ${errorMessage}`
+          : errorMessage
+      );
+      err.toastHandled = true;
       clearError();
     } finally {
       setIsLoading(false);

--- a/app/javascript/src/services/invoiceApi.ts
+++ b/app/javascript/src/services/invoiceApi.ts
@@ -287,9 +287,13 @@ class InvoiceApiService {
    * Create a new invoice
    */
   async createInvoice(invoiceData: InvoiceFormData): Promise<Invoice> {
-    const response = await axios.post(`/invoices`, {
-      invoice: this.formatInvoiceForApi(invoiceData),
-    });
+    const response = await axios.post(
+      `/invoices`,
+      {
+        invoice: this.formatInvoiceForApi(invoiceData),
+      },
+      { skipErrorToast: true }
+    );
 
     return this.transformApiInvoice(response.data.invoice || response.data);
   }
@@ -301,9 +305,13 @@ class InvoiceApiService {
     id: string,
     invoiceData: InvoiceFormData
   ): Promise<Invoice> {
-    const response = await axios.patch(`/invoices/${id}`, {
-      invoice: this.formatInvoiceForApi(invoiceData),
-    });
+    const response = await axios.patch(
+      `/invoices/${id}`,
+      {
+        invoice: this.formatInvoiceForApi(invoiceData),
+      },
+      { skipErrorToast: true }
+    );
 
     return this.transformApiInvoice(response.data.invoice || response.data);
   }
@@ -326,9 +334,13 @@ class InvoiceApiService {
       recipients: string[];
     }
   ): Promise<{ message: string }> {
-    const response = await axios.post(`/invoices/${id}/send_invoice`, {
-      invoice_email: emailData,
-    });
+    const response = await axios.post(
+      `/invoices/${id}/send_invoice`,
+      {
+        invoice_email: emailData,
+      },
+      { skipErrorToast: true }
+    );
 
     return response.data;
   }
@@ -341,9 +353,13 @@ class InvoiceApiService {
       recipients: string[];
     }
   ): Promise<{ message: string }> {
-    const response = await axios.post(`/invoices/${id}/send_reminder`, {
-      invoice_email: emailData,
-    });
+    const response = await axios.post(
+      `/invoices/${id}/send_reminder`,
+      {
+        invoice_email: emailData,
+      },
+      { skipErrorToast: true }
+    );
 
     return response.data;
   }

--- a/spec/system/invoices/create_spec.rb
+++ b/spec/system/invoices/create_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe "Invoice creation", type: :system, js: true do
 
       expect do
         click_button "Send Invoice"
-        expect(page).to have_text("Failed to generate PDF", wait: 10)
+        expect(page).to have_text(
+          "Invoice was saved as a draft, but sending failed: Failed to generate PDF",
+          wait: 10
+        )
       end.to change(Invoice, :count).by(1)
 
       invoice = Invoice.find_by!(invoice_number: "INV-SEND-FAIL-001")
@@ -73,7 +76,10 @@ RSpec.describe "Invoice creation", type: :system, js: true do
 
       expect do
         click_button "Send Invoice"
-        expect(page).to have_text("Failed to generate PDF", wait: 10)
+        expect(page).to have_text(
+          "Invoice was saved as a draft, but sending failed: Failed to generate PDF",
+          wait: 10
+        )
       end.not_to change(Invoice, :count)
 
       expect(page).to have_no_text("Invoice number has already been taken")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when invoice sending fails. Users now receive clearer feedback indicating whether an invoice was saved as a draft while explaining why sending failed, eliminating duplicate error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->