### PR TITLE
Fix time report filters

### DIFF
--- a/app/javascript/src/components/Reports/TimeEntryReport/index.tsx
+++ b/app/javascript/src/components/Reports/TimeEntryReport/index.tsx
@@ -295,6 +295,39 @@ const TimeEntryReport: React.FC = () => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
+  const buildTimeEntryReportParams = (
+    extraParams: Record<string, string | number> = {}
+  ) => {
+    const params = new URLSearchParams();
+
+    Object.entries(extraParams).forEach(([key, value]) => {
+      params.set(key, String(value));
+    });
+
+    params.set("group_by", groupBy);
+
+    if (dateRange?.from) {
+      params.set("date_range", "custom");
+      params.set("from", formatReportApiDate(dateRange.from) || "");
+      params.set(
+        "to",
+        formatReportApiDate(dateRange.to || dateRange.from) || ""
+      );
+    } else if (dateRangePreset) {
+      params.set("date_range", dateRangePreset);
+    }
+
+    selectedClients.forEach(clientId => {
+      params.append("client[]", String(clientId));
+    });
+
+    selectedTeamMembers.forEach(teamMemberId => {
+      params.append("team_member[]", String(teamMemberId));
+    });
+
+    return params;
+  };
+
   const {
     data,
     isLoading,
@@ -312,17 +345,8 @@ const TimeEntryReport: React.FC = () => {
     ],
     initialPageParam: 1,
     queryFn: async ({ pageParam = 1 }) => {
-      const params = new URLSearchParams({
+      const params = buildTimeEntryReportParams({
         page: String(pageParam),
-        group_by: groupBy,
-        ...(dateRange?.from && { from: formatReportApiDate(dateRange.from) }),
-        ...(dateRange?.to && { to: formatReportApiDate(dateRange.to) }),
-        ...(selectedClients.length > 0 && {
-          client: selectedClients.join(","),
-        }),
-        ...(selectedTeamMembers.length > 0 && {
-          team_member: selectedTeamMembers.join(","),
-        }),
       });
 
       const response = await axios.get(
@@ -495,17 +519,8 @@ const TimeEntryReport: React.FC = () => {
 
   const downloadMutation = useMutation({
     mutationFn: async (formatType: "csv" | "pdf") => {
-      const params = new URLSearchParams({
+      const params = buildTimeEntryReportParams({
         format: formatType,
-        group_by: groupBy,
-        ...(dateRange?.from && { from: formatReportApiDate(dateRange.from) }),
-        ...(dateRange?.to && { to: formatReportApiDate(dateRange.to) }),
-        ...(selectedClients.length > 0 && {
-          client: selectedClients.join(","),
-        }),
-        ...(selectedTeamMembers.length > 0 && {
-          team_member: selectedTeamMembers.join(","),
-        }),
       });
 
       const response = await axios.get(
@@ -686,7 +701,11 @@ const TimeEntryReport: React.FC = () => {
                     defaultMonth={dateRange?.from}
                     selected={dateRange}
                     onSelect={range => {
-                      setDateRange(range);
+                      setDateRange(
+                        range?.from && !range.to
+                          ? { from: range.from, to: range.from }
+                          : range
+                      );
                       setDateRangePreset("custom");
                     }}
                     numberOfMonths={2}

--- a/app/javascript/src/components/Reports/filterUtils.ts
+++ b/app/javascript/src/components/Reports/filterUtils.ts
@@ -1,7 +1,7 @@
 import { format, isValid, parseISO } from "date-fns";
 
 export const formatReportApiDate = (date?: Date) =>
-  date ? format(date, "dd/MM/yyyy") : undefined;
+  date ? format(date, "yyyy-MM-dd") : undefined;
 
 export const formatReportQueryDate = (date?: Date) =>
   date ? format(date, "yyyy-MM-dd") : undefined;

--- a/spec/requests/api/v1/reports/time_entries_controller_spec.rb
+++ b/spec/requests/api/v1/reports/time_entries_controller_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Api::V1::Reports::TimeEntriesController, type: :request do
 
       get api_v1_reports_time_entries_path, params: {
         date_range: "custom",
-        from: Date.current.strftime("%d/%m/%Y"),
-        to: Date.current.strftime("%d/%m/%Y")
+        from: Date.current.iso8601,
+        to: Date.current.iso8601
       }
 
       json = JSON.parse(response.body)
@@ -181,8 +181,8 @@ RSpec.describe Api::V1::Reports::TimeEntriesController, type: :request do
     it "applies filters to download" do
       get download_api_v1_reports_time_entries_path(format: :csv), params: {
         date_range: "custom",
-        from: Date.current.strftime("%d/%m/%Y"),
-        to: Date.current.strftime("%d/%m/%Y")
+        from: Date.current.iso8601,
+        to: Date.current.iso8601
       }
 
       expect(response).to have_http_status(:ok)

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -193,6 +193,45 @@ RSpec.describe "Reports", type: :system, js: true do
       end
     end
 
+    it "applies time entry date and client filters from the toolbar controls" do
+      included_client = create(:client, company:, name: "Toolbar Filter Alpha Client")
+      excluded_client = create(:client, company:, name: "Toolbar Filter Beta Client")
+      current_client = create(:client, company:, name: "Toolbar Filter Current Client")
+      included_project = create(:project, client: included_client, name: "Toolbar Alpha Project")
+      excluded_project = create(:project, client: excluded_client, name: "Toolbar Beta Project")
+      current_project = create(:project, client: current_client, name: "Toolbar Current Project")
+      last_month_date = 1.month.ago.beginning_of_month + 1.day
+      create(:project_member, user: admin, project: included_project)
+      create(:project_member, user: admin, project: excluded_project)
+      create(:project_member, user: admin, project: current_project)
+      create(:timesheet_entry, user: admin, project: included_project, duration: 240, work_date: last_month_date)
+      create(:timesheet_entry, user: admin, project: excluded_project, duration: 180, work_date: last_month_date)
+      create(:timesheet_entry, user: admin, project: current_project, duration: 120, work_date: Date.current)
+
+      with_forgery_protection do
+        visit "/reports/time-entry"
+
+        expect_reports_shell("Time Reports")
+        expect(page).to have_content("Toolbar Filter Current Client", wait: 10)
+
+        find("button", text: "This Month", match: :first).click
+        find("[role='option']", text: "Last Month", match: :first).click
+
+        expect(page).to have_content("Toolbar Filter Alpha Client", wait: 10)
+        expect(page).to have_content("Toolbar Filter Beta Client", wait: 10)
+        expect(page).to have_no_content("Toolbar Filter Current Client")
+
+        find("button", text: "Clients", match: :first).click
+        find("[role='menuitemcheckbox']", text: "Toolbar Filter Alpha Client", match: :first).click
+        page.send_keys(:escape)
+
+        expect(page).to have_content("Toolbar Filter Alpha Client", wait: 10)
+        expect(page).to have_no_content("Toolbar Filter Beta Client")
+        expect(page).to have_no_content("Toolbar Filter Current Client")
+        expect(page.current_url).to include("clients=#{included_client.id}")
+      end
+    end
+
     it "copies the time entry report permalink" do
       client = create(:client, company:, name: "Permalink Client")
       project = create(:project, client:, name: "Permalink Project")


### PR DESCRIPTION
## Summary
- Fix Time Reports API params generated by the toolbar filters.
- Send date filters as date_range=custom with ISO from/to values.
- Send client and team-member filters as Rails array params instead of comma strings.
- Add a browser-backed system regression for applying date and client filters from the UI.

## Verification
- rtk mise exec -- bundle exec rspec spec/requests/api/v1/reports/time_entries_controller_spec.rb
- rtk mise exec -- bundle exec rspec spec/services/date_range_service_spec.rb
- rtk mise exec -- bundle exec rspec spec/system/reports/index_spec.rb:196
- rtk mise exec -- bundle exec rspec spec/system/reports/index_spec.rb:177
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- npx prettier --check app/javascript/src/components/Reports/TimeEntryReport/index.tsx app/javascript/src/components/Reports/filterUtils.ts
- rtk mise exec -- bundle exec rubocop spec/system/reports/index_spec.rb spec/requests/api/v1/reports/time_entries_controller_spec.rb --format simple

Fixes #2233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the custom date range picker in time entry reports. When you select a start date without an end date, the component now automatically sets both the start and end date to the selected day.

* **Tests**
  * Added system tests to validate date range and client filtering functionality in time entry reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->