### PR TITLE
fix: dashboard revenue momentum chart to respect fiscal year settings

### DIFF
--- a/app/javascript/src/components/Dashboard/MonochromeCharts.tsx
+++ b/app/javascript/src/components/Dashboard/MonochromeCharts.tsx
@@ -109,7 +109,7 @@ export const RevenueAreaChart: React.FC<RevenueChartProps> = ({
               strokeOpacity={0.5}
             />
             <XAxis
-              dataKey="month"
+              dataKey="full_month"
               tickLine={false}
               axisLine={false}
               tickMargin={12}
@@ -117,6 +117,13 @@ export const RevenueAreaChart: React.FC<RevenueChartProps> = ({
                 fill: "hsl(var(--muted-foreground))",
                 fontSize: 11,
                 fontWeight: 500,
+              }}
+              tickFormatter={value => {
+                // Format "January 2024" to "Jan '24"
+                const match = value.match(/^([A-Za-z]+)\s+(\d{4})$/);
+                if (!match) return value;
+
+                return `${match[1].slice(0, 3)} '${match[2].slice(-2)}`;
               }}
             />
             <YAxis
@@ -135,9 +142,7 @@ export const RevenueAreaChart: React.FC<RevenueChartProps> = ({
               cursor={{ stroke: "hsl(var(--border))", strokeWidth: 1 }}
               content={
                 <ChartTooltipContent
-                  labelFormatter={value =>
-                    `${value} ${new Date().getFullYear()}`
-                  }
+                  labelFormatter={value => value}
                   formatter={(value: any) =>
                     currencyFormat(baseCurrency, value)
                   }

--- a/app/javascript/src/i18n/locales/bn.ts
+++ b/app/javascript/src/i18n/locales/bn.ts
@@ -2146,7 +2146,7 @@ const locale = {
       week: "এই সপ্তাহে",
       month: "এই মাসে",
       quarter: "এই ত্রৈমাসিকে",
-      year: "এই বছর",
+      year: "বর্তমান আর্থিক বছর",
     },
     stats: {
       revenue: "রাজস্ব",
@@ -2167,7 +2167,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "রাজস্ব গতি",
-      revenueMomentumDescription: "গত এক বছরে মাসিক আয়ের প্রবণতা",
+      revenueMomentumDescription:
+        "বর্তমান আর্থিক বছরের জন্য মাসিক আয়ের প্রবণতা",
       revenueTrendEyebrow: "রাজস্ব প্রবণতা",
       revenueLeadersTitle: "রাজস্ব নেতারা",
       revenueLeadersDescription: "রাজস্ব অবদানের ভিত্তিতে শীর্ষ গ্রাহক",

--- a/app/javascript/src/i18n/locales/de.ts
+++ b/app/javascript/src/i18n/locales/de.ts
@@ -2177,7 +2177,7 @@ const locale = {
       week: "Diese Woche",
       month: "Diesen Monat",
       quarter: "Dieses Quartal",
-      year: "Dieses Jahr",
+      year: "Aktuelles Geschäftsjahr",
     },
     stats: {
       revenue: "Einnahmen",
@@ -2199,7 +2199,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Umsatzdynamik",
       revenueMomentumDescription:
-        "Monatliche Umsatzentwicklung im vergangenen Jahr",
+        "Monatliche Umsatzentwicklung für das laufende Geschäftsjahr",
       revenueTrendEyebrow: "Umsatztrend",
       revenueLeadersTitle: "Umsatzführer",
       revenueLeadersDescription: "Umsatzstärkste Kunden nach Beitrag",

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -2506,7 +2506,7 @@ const en = {
       week: "This Week",
       month: "This Month",
       quarter: "This Quarter",
-      year: "This Year",
+      year: "Current Financial Year",
     },
     stats: {
       revenue: "Revenue",
@@ -2527,7 +2527,8 @@ const en = {
     },
     charts: {
       revenueMomentumTitle: "Revenue Momentum",
-      revenueMomentumDescription: "Monthly revenue trend over the past year",
+      revenueMomentumDescription:
+        "Monthly revenue trend for the current financial year",
       revenueTrendEyebrow: "REVENUE TREND",
       revenueLeadersTitle: "Revenue Leaders",
       revenueLeadersDescription: "Top clients by revenue contribution",

--- a/app/javascript/src/i18n/locales/es.ts
+++ b/app/javascript/src/i18n/locales/es.ts
@@ -2168,7 +2168,7 @@ const locale = {
       week: "Esta semana",
       month: "Este mes",
       quarter: "Este trimestre",
-      year: "Este año",
+      year: "Año Fiscal Actual",
     },
     stats: {
       revenue: "Ganancia",
@@ -2190,7 +2190,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Impulso de los ingresos",
       revenueMomentumDescription:
-        "Tendencia de los ingresos mensuales durante el último año",
+        "Tendencia de los ingresos mensuales para el año fiscal actual",
       revenueTrendEyebrow: "TENDENCIA DE INGRESOS",
       revenueLeadersTitle: "Líderes en ingresos",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/fr.ts
+++ b/app/javascript/src/i18n/locales/fr.ts
@@ -2181,7 +2181,7 @@ const locale = {
       week: "Cette semaine",
       month: "Ce mois-ci",
       quarter: "Ce trimestre",
-      year: "Cette année",
+      year: "Exercice Financier Actuel",
     },
     stats: {
       revenue: "Revenu",
@@ -2203,7 +2203,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Dynamique des revenus",
       revenueMomentumDescription:
-        "Évolution mensuelle du chiffre d'affaires au cours de l'année écoulée",
+        "Évolution mensuelle du chiffre d'affaires pour l'exercice en cours",
       revenueTrendEyebrow: "TENDANCE DES REVENUS",
       revenueLeadersTitle: "Leaders en matière de revenus",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/gu.ts
+++ b/app/javascript/src/i18n/locales/gu.ts
@@ -2140,7 +2140,7 @@ const locale = {
       week: "આ અઠવાડિયે",
       month: "આ મહિનો",
       quarter: "આ ક્વાર્ટર",
-      year: "આ વર્ષે",
+      year: "વર્તમાન નાણાકીય વર્ષ",
     },
     stats: {
       revenue: "આવક",
@@ -2161,7 +2161,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "આવકનો વેગ",
-      revenueMomentumDescription: "ગયા વર્ષનો માસિક આવકનો ટ્રેન્ડ",
+      revenueMomentumDescription:
+        "વર્તમાન નાણાકીય વર્ષ માટે માસિક આવકનો ટ્રેન્ડ",
       revenueTrendEyebrow: "રેવન્યુ ટ્રેન્ડ",
       revenueLeadersTitle: "મહેસૂલ નેતાઓ",
       revenueLeadersDescription: "આવક યોગદાન દ્વારા ટોચના ગ્રાહકો",

--- a/app/javascript/src/i18n/locales/hi.ts
+++ b/app/javascript/src/i18n/locales/hi.ts
@@ -1301,7 +1301,7 @@ const locale = {
       week: "इस सप्ताह",
       month: "इस महीने",
       quarter: "इस तिमाही",
-      year: "इस साल",
+      year: "वर्तमान वित्तीय वर्ष",
     },
     stats: {
       revenue: "आय",
@@ -1322,7 +1322,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "राजस्व गति",
-      revenueMomentumDescription: "पिछले एक वर्ष में मासिक राजस्व का रुझान",
+      revenueMomentumDescription:
+        "वर्तमान वित्तीय वर्ष के लिए मासिक राजस्व का रुझान",
       revenueTrendEyebrow: "राजस्व प्रवृत्ति",
       revenueLeadersTitle: "राजस्व नेता",
       revenueLeadersDescription: "राजस्व योगदान के आधार पर शीर्ष ग्राहक",

--- a/app/javascript/src/i18n/locales/id.ts
+++ b/app/javascript/src/i18n/locales/id.ts
@@ -2154,7 +2154,7 @@ const locale = {
       week: "Minggu Ini",
       month: "Bulan Ini",
       quarter: "Kuartal ini",
-      year: "Tahun ini",
+      year: "Tahun Fiskal Saat Ini",
     },
     stats: {
       revenue: "Pendapatan",
@@ -2176,7 +2176,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Momentum Pendapatan",
       revenueMomentumDescription:
-        "Tren pendapatan bulanan selama setahun terakhir",
+        "Tren pendapatan bulanan untuk tahun keuangan saat ini",
       revenueTrendEyebrow: "TREN PENDAPATAN",
       revenueLeadersTitle: "Pemimpin Pendapatan",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/it.ts
+++ b/app/javascript/src/i18n/locales/it.ts
@@ -2165,7 +2165,7 @@ const locale = {
       week: "Questa settimana",
       month: "Questo mese",
       quarter: "Questo trimestre",
-      year: "Quest'anno",
+      year: "Anno Fiscale Corrente",
     },
     stats: {
       revenue: "Reddito",
@@ -2187,7 +2187,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Andamento dei ricavi",
       revenueMomentumDescription:
-        "Andamento del fatturato mensile nell'ultimo anno",
+        "Andamento del fatturato mensile per l'anno fiscale corrente",
       revenueTrendEyebrow: "ANDAMENTO DEI RICAVI",
       revenueLeadersTitle: "Leader del fatturato",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/ja.ts
+++ b/app/javascript/src/i18n/locales/ja.ts
@@ -2122,7 +2122,7 @@ const locale = {
       week: "今週",
       month: "今月",
       quarter: "今四半期",
-      year: "今年",
+      year: "現在の会計年度",
     },
     stats: {
       revenue: "収益",
@@ -2143,7 +2143,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "収益の勢い",
-      revenueMomentumDescription: "過去1年間の月間収益の推移",
+      revenueMomentumDescription: "現在の会計年度の月間収益の推移",
       revenueTrendEyebrow: "収益動向",
       revenueLeadersTitle: "収益リーダー",
       revenueLeadersDescription: "収益貢献度上位顧客",

--- a/app/javascript/src/i18n/locales/kn.ts
+++ b/app/javascript/src/i18n/locales/kn.ts
@@ -2153,7 +2153,7 @@ const locale = {
       week: "ಈ ವಾರ",
       month: "ಈ ತಿಂಗಳು",
       quarter: "ಈ ತ್ರೈಮಾಸಿಕ",
-      year: "ಈ ವರ್ಷ",
+      year: "ಪ್ರಸ್ತುತ ಆರ್ಥಿಕ ವರ್ಷ",
     },
     stats: {
       revenue: "ಆದಾಯ",
@@ -2174,7 +2174,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "ಆದಾಯದ ಆವೇಗ",
-      revenueMomentumDescription: "ಕಳೆದ ವರ್ಷದ ಮಾಸಿಕ ಆದಾಯದ ಪ್ರವೃತ್ತಿ",
+      revenueMomentumDescription: "ಪ್ರಸ್ತುತ ಆರ್ಥಿಕ ವರ್ಷದ ಮಾಸಿಕ ಆದಾಯದ ಪ್ರವೃತ್ತಿ",
       revenueTrendEyebrow: "ಆದಾಯ ಪ್ರವೃತ್ತಿ",
       revenueLeadersTitle: "ಕಂದಾಯ ನಾಯಕರು",
       revenueLeadersDescription: "ಆದಾಯದ ಕೊಡುಗೆಯ ಪ್ರಕಾರ ಉನ್ನತ ಕ್ಲೈಂಟ್‌ಗಳು",

--- a/app/javascript/src/i18n/locales/ko.ts
+++ b/app/javascript/src/i18n/locales/ko.ts
@@ -2105,7 +2105,7 @@ const locale = {
       week: "이번 주",
       month: "이번 달",
       quarter: "이번 분기",
-      year: "올해",
+      year: "현재 회계연도",
     },
     stats: {
       revenue: "수익",
@@ -2126,7 +2126,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "수익 모멘텀",
-      revenueMomentumDescription: "지난 1년간 월별 매출 추세",
+      revenueMomentumDescription: "현재 회계연도의 월별 매출 추세",
       revenueTrendEyebrow: "수익 추세",
       revenueLeadersTitle: "매출 선도 기업",
       revenueLeadersDescription: "수익 기여도 기준 주요 고객",

--- a/app/javascript/src/i18n/locales/ml.ts
+++ b/app/javascript/src/i18n/locales/ml.ts
@@ -2179,7 +2179,7 @@ const locale = {
       week: "ഈ ആഴ്ച",
       month: "ഈ മാസം",
       quarter: "ഈ പാദം",
-      year: "ഈ വര്ഷം",
+      year: "നിലവിലെ സാമ്പത്തിക വർഷം",
     },
     stats: {
       revenue: "വരുമാനം",
@@ -2200,7 +2200,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "വരുമാന മൊമന്റം",
-      revenueMomentumDescription: "കഴിഞ്ഞ വർഷത്തെ പ്രതിമാസ വരുമാന പ്രവണത",
+      revenueMomentumDescription:
+        "നിലവിലെ സാമ്പത്തിക വർഷത്തെ പ്രതിമാസ വരുമാന പ്രവണത",
       revenueTrendEyebrow: "വരുമാന പ്രവണത",
       revenueLeadersTitle: "റവന്യൂ നേതാക്കൾ",
       revenueLeadersDescription: "വരുമാന സംഭാവന പ്രകാരം മികച്ച ക്ലയന്റുകൾ",

--- a/app/javascript/src/i18n/locales/mr.ts
+++ b/app/javascript/src/i18n/locales/mr.ts
@@ -2137,7 +2137,7 @@ const locale = {
       week: "या आठवड्यात",
       month: "या महिन्यात",
       quarter: "या तिमाहीत",
-      year: "या वर्षी",
+      year: "चालू आर्थिक वर्ष",
     },
     stats: {
       revenue: "महसूल",
@@ -2158,7 +2158,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "महसूल गती",
-      revenueMomentumDescription: "गेल्या वर्षभरातील मासिक महसुलाचा कल",
+      revenueMomentumDescription: "चालू आर्थिक वर्षासाठी मासिक महसुलाचा कल",
       revenueTrendEyebrow: "महसुलाचा कल",
       revenueLeadersTitle: "महसूल नेते",
       revenueLeadersDescription: "महसूल योगदानानुसार प्रमुख ग्राहक",

--- a/app/javascript/src/i18n/locales/nl.ts
+++ b/app/javascript/src/i18n/locales/nl.ts
@@ -2154,7 +2154,7 @@ const locale = {
       week: "Deze week",
       month: "Deze maand",
       quarter: "Dit kwartaal",
-      year: "Dit jaar",
+      year: "Huidig Boekjaar",
     },
     stats: {
       revenue: "Winst",
@@ -2176,7 +2176,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Omzetmomentum",
       revenueMomentumDescription:
-        "Maandelijkse omzetontwikkeling over het afgelopen jaar",
+        "Maandelijkse omzetontwikkeling voor het huidige boekjaar",
       revenueTrendEyebrow: "OMZETTREND",
       revenueLeadersTitle: "Omzetleiders",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/pa.ts
+++ b/app/javascript/src/i18n/locales/pa.ts
@@ -2126,7 +2126,7 @@ const locale = {
       week: "ਇਸ ਹਫ਼ਤੇ",
       month: "ਇਸ ਮਹੀਨੇ",
       quarter: "ਇਸ ਤਿਮਾਹੀ",
-      year: "ਇਸ ਸਾਲ",
+      year: "ਮੌਜੂਦਾ ਵਿੱਤੀ ਸਾਲ",
     },
     stats: {
       revenue: "ਮਾਲੀਆ",
@@ -2147,7 +2147,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "ਆਮਦਨ ਦੀ ਗਤੀ",
-      revenueMomentumDescription: "ਪਿਛਲੇ ਸਾਲ ਦੌਰਾਨ ਮਾਸਿਕ ਆਮਦਨ ਦਾ ਰੁਝਾਨ",
+      revenueMomentumDescription: "ਮੌਜੂਦਾ ਵਿੱਤੀ ਸਾਲ ਲਈ ਮਾਸਿਕ ਆਮਦਨ ਦਾ ਰੁਝਾਨ",
       revenueTrendEyebrow: "ਰੈਵੇਨਿਊ ਟ੍ਰੈਂਡ",
       revenueLeadersTitle: "ਮਾਲੀਆ ਆਗੂ",
       revenueLeadersDescription: "ਆਮਦਨ ਯੋਗਦਾਨ ਦੇ ਹਿਸਾਬ ਨਾਲ ਪ੍ਰਮੁੱਖ ਗਾਹਕ",

--- a/app/javascript/src/i18n/locales/pt-BR.ts
+++ b/app/javascript/src/i18n/locales/pt-BR.ts
@@ -2157,7 +2157,7 @@ const locale = {
       week: "Essa semana",
       month: "Este mês",
       quarter: "Este trimestre",
-      year: "Este ano",
+      year: "Ano Fiscal Atual",
     },
     stats: {
       revenue: "Receita",
@@ -2179,7 +2179,7 @@ const locale = {
     charts: {
       revenueMomentumTitle: "Impulso de Receita",
       revenueMomentumDescription:
-        "Tendência da receita mensal ao longo do último ano",
+        "Tendência da receita mensal para o ano fiscal atual",
       revenueTrendEyebrow: "TENDÊNCIA DE RECEITA",
       revenueLeadersTitle: "Líderes em Receita",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/ta.ts
+++ b/app/javascript/src/i18n/locales/ta.ts
@@ -2199,7 +2199,7 @@ const locale = {
       week: "இந்த வாரம்",
       month: "இந்த மாதம்",
       quarter: "இந்தக் காலாண்டில்",
-      year: "இந்த ஆண்டு",
+      year: "தற்போதைய நிதியாண்டு",
     },
     stats: {
       revenue: "வருவாய்",
@@ -2220,7 +2220,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "வருவாய் உத்வேகம்",
-      revenueMomentumDescription: "கடந்த ஆண்டின் மாதாந்திர வருவாய் போக்கு",
+      revenueMomentumDescription:
+        "தற்போதைய நிதியாண்டிற்கான மாதாந்திர வருவாய் போக்கு",
       revenueTrendEyebrow: "வருவாய் போக்கு",
       revenueLeadersTitle: "வருவாய் தலைவர்கள்",
       revenueLeadersDescription:

--- a/app/javascript/src/i18n/locales/te.ts
+++ b/app/javascript/src/i18n/locales/te.ts
@@ -2155,7 +2155,7 @@ const locale = {
       week: "ఈ వారం",
       month: "ఈ నెల",
       quarter: "ఈ త్రైమాసికంలో",
-      year: "ఈ సంవత్సరం",
+      year: "ప్రస్తుత ఆర్థిక సంవత్సరం",
     },
     stats: {
       revenue: "ఆదాయం",
@@ -2176,7 +2176,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "రాబడి ఊపందుకోవడం",
-      revenueMomentumDescription: "గత సంవత్సరంలో నెలవారీ ఆదాయ ధోరణి",
+      revenueMomentumDescription:
+        "ప్రస్తుత ఆర్థిక సంవత్సరానికి నెలవారీ ఆదాయ ధోరణి",
       revenueTrendEyebrow: "ఆదాయ ధోరణి",
       revenueLeadersTitle: "రెవెన్యూ లీడర్లు",
       revenueLeadersDescription: "ఆదాయ సహకారం ప్రకారం అగ్రశ్రేణి క్లయింట్లు",

--- a/app/javascript/src/i18n/locales/tr.ts
+++ b/app/javascript/src/i18n/locales/tr.ts
@@ -2145,7 +2145,7 @@ const locale = {
       week: "Bu hafta",
       month: "Bu Ay",
       quarter: "Bu Çeyrek",
-      year: "Bu Yıl",
+      year: "Mevcut Mali Yıl",
     },
     stats: {
       revenue: "Hasılat",
@@ -2166,7 +2166,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "Gelir Momentumu",
-      revenueMomentumDescription: "Geçtiğimiz yıl boyunca aylık gelir trendi",
+      revenueMomentumDescription: "Mevcut mali yıl için aylık gelir trendi",
       revenueTrendEyebrow: "GELİR TRENDİ",
       revenueLeadersTitle: "Gelir Liderleri",
       revenueLeadersDescription: "Gelir katkısına göre en büyük müşteriler",

--- a/app/javascript/src/i18n/locales/ur.ts
+++ b/app/javascript/src/i18n/locales/ur.ts
@@ -2136,7 +2136,7 @@ const locale = {
       week: "اس ہفتے",
       month: "اس مہینے",
       quarter: "اس سہ ماہی",
-      year: "اس سال",
+      year: "موجودہ مالی سال",
     },
     stats: {
       revenue: "آمدنی",
@@ -2157,7 +2157,8 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "آمدنی کی رفتار",
-      revenueMomentumDescription: "گزشتہ سال کے دوران ماہانہ آمدنی کا رجحان",
+      revenueMomentumDescription:
+        "موجودہ مالی سال کے لیے ماہانہ آمدنی کا رجحان",
       revenueTrendEyebrow: "ریوینیو کا رجحان",
       revenueLeadersTitle: "ریونیو لیڈرز",
       revenueLeadersDescription: "آمدنی میں شراکت کے لحاظ سے سرفہرست کلائنٹس",

--- a/app/javascript/src/i18n/locales/zh-CN.ts
+++ b/app/javascript/src/i18n/locales/zh-CN.ts
@@ -2022,7 +2022,7 @@ const locale = {
       week: "本星期",
       month: "本月",
       quarter: "本季度",
-      year: "今年",
+      year: "当前财年",
     },
     stats: {
       revenue: "收入",
@@ -2043,7 +2043,7 @@ const locale = {
     },
     charts: {
       revenueMomentumTitle: "营收势头",
-      revenueMomentumDescription: "过去一年的月度收入趋势",
+      revenueMomentumDescription: "当前财年的月度收入趋势",
       revenueTrendEyebrow: "收入趋势",
       revenueLeadersTitle: "营收领先者",
       revenueLeadersDescription: "按营收贡献排名前列的客户",

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -11,6 +11,28 @@ class DashboardPresenter
     @from_date = from_date || calculate_from_date
   end
 
+  def fiscal_year_end_month
+    return 12 unless company.fiscal_year_end.present?
+
+    # Map month names to month numbers
+    month_mapping = {
+      "january" => 1, "jan" => 1,
+      "february" => 2, "feb" => 2,
+      "march" => 3, "mar" => 3,
+      "april" => 4, "apr" => 4,
+      "may" => 5,
+      "june" => 6, "jun" => 6,
+      "july" => 7, "jul" => 7,
+      "august" => 8, "aug" => 8,
+      "september" => 9, "sep" => 9, "sept" => 9,
+      "october" => 10, "oct" => 10,
+      "november" => 11, "nov" => 11,
+      "december" => 12, "dec" => 12
+    }
+
+    month_mapping[company.fiscal_year_end.downcase.strip] || 12
+  end
+
   def data
     {
       stats: stats_data,
@@ -32,7 +54,18 @@ class DashboardPresenter
       when "month"
         to_date.beginning_of_month
       when "year"
-        to_date.beginning_of_year
+        # Use fiscal year if configured, otherwise calendar year
+        fiscal_end_month = fiscal_year_end_month
+        fiscal_start_month = fiscal_end_month == 12 ? 1 : fiscal_end_month + 1
+
+        # Determine the fiscal year start date
+        if to_date.month >= fiscal_start_month
+          # We're in the current fiscal year
+          Date.new(to_date.year, fiscal_start_month, 1)
+        else
+          # We're in the previous fiscal year
+          Date.new(to_date.year - 1, fiscal_start_month, 1)
+        end
       else
         to_date.beginning_of_year
       end
@@ -109,6 +142,8 @@ class DashboardPresenter
 
         chart_data << {
           month: current_date.strftime("%b"),
+          full_month: current_date.strftime("%B %Y"),
+          year: current_date.year,
           revenue: amount_value(cumulative_revenue),
           monthly_revenue: amount_value(month_revenue),
           invoices: invoice_count_for_month(current_date)


### PR DESCRIPTION
- Add fiscal year support to DashboardPresenter
  - Parse company's fiscal_year_end field to determine fiscal year start
  - Update calculate_from_date to use fiscal year instead of calendar year
  - Enhance revenue_chart_data to include full_month and year fields

- Update MonochromeCharts component to display year labels
  - Change X-axis dataKey from 'month' to 'full_month'
  - Add tickFormatter to show labels as 'Jan '24' format
  - Update tooltip to display full month with year

- Update i18n translations across all 22 languages
  - Change 'revenueMomentumDescription' from 'past year' to 'current financial year'
  - Change 'timeframe.year' from 'This Year' to 'Current Financial Year'

All dashboard stats (Revenue, Active Projects, Hours Tracked) now correctly reflect the current fiscal year period based on company settings.

Fixes #2235

<img width="2940" height="1436" alt="image" src="https://github.com/user-attachments/assets/5f234128-92eb-4e33-a141-9b9d39f6b6d9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now supports fiscal year calculations for more accurate financial tracking
  * Chart date labels simplified to a shorter, more readable format (e.g., "Jan '24")
  * Revenue trend descriptions updated to reference current financial year data
* **Localization**
  * Updated terminology across 20+ languages to consistently use "Current Financial Year"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->