### PR TITLE
fix: manual payment entry fields

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -366,11 +366,13 @@ const PaymentEntryForm = ({
                       {transactionTypes.map(type => (
                         <li key={type.value}>
                           <button
+                            aria-selected={transactionType === type.value}
                             className={`flex w-full items-center rounded-sm px-3 py-2 text-left text-sm ${
                               transactionType === type.value
                                 ? "bg-muted font-medium text-foreground"
                                 : "text-foreground hover:bg-muted"
                             }`}
+                            role="option"
                             type="button"
                             onClick={() => {
                               setFieldValue("transactionType", type.value);

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -12,6 +12,7 @@ import { Form, Formik, FormikProps } from "formik";
 import { currencyFormat, useOutsideClick } from "helpers";
 import { mapPayment } from "mapper/mappedIndex";
 import { CalendarIcon } from "miruIcons";
+import { CaretDown } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import { i18n } from "../../../i18n";
 import {
@@ -51,10 +52,13 @@ const PaymentEntryForm = ({
 
   const [showDatePicker, setShowDatePicker] = useState<any>(false);
   const [showSelectMenu, setShowSelectMenu] = useState(false);
+  const [showDesktopTransactionTypes, setShowDesktopTransactionTypes] =
+    useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const wrapperSelectRef = useRef(null);
   const wrapperCalendartRef = useRef(null);
+  const wrapperDesktopTransactionTypeRef = useRef(null);
 
   const navigate = useNavigate();
   const selectedInvoiceFromUrl = invoiceId
@@ -80,6 +84,7 @@ const PaymentEntryForm = ({
     const close = e => {
       if (e.keyCode === 27) {
         setShowDatePicker({ visibility: false });
+        setShowDesktopTransactionTypes(false);
       }
     };
     window.addEventListener("keydown", close);
@@ -93,6 +98,10 @@ const PaymentEntryForm = ({
 
   useOutsideClick(wrapperCalendartRef, () => {
     setShowDatePicker({ visibility: false });
+  });
+
+  useOutsideClick(wrapperDesktopTransactionTypeRef, () => {
+    setShowDesktopTransactionTypes(false);
   });
 
   const handleAddPayment = async values => {
@@ -154,6 +163,10 @@ const PaymentEntryForm = ({
           showTransactionTypes,
           note,
         } = values;
+
+        const selectedTransactionType = transactionTypes.find(
+          type => type.value === transactionType
+        );
 
         const isPaymentBtnActive = () =>
           isAddPaymentBtnActive(
@@ -315,31 +328,61 @@ const PaymentEntryForm = ({
               onClick={() => setFieldValue("showTransactionTypes", true)}
             >
               {isDesktop ? (
-                <div className="field relative">
-                  <label className="absolute -top-1 left-0 z-1 ml-3 origin-0 bg-background px-1 text-xsm font-medium text-muted-foreground duration-300">
-                    {i18n.t("payments.transactionType")}
-                  </label>
-                  <Select
-                    value={transactionType || ""}
-                    onValueChange={value =>
-                      setFieldValue("transactionType", value)
+                <div
+                  className="field relative"
+                  ref={wrapperDesktopTransactionTypeRef}
+                >
+                  <button
+                    aria-label={i18n.t("payments.transactionType")}
+                    aria-expanded={showDesktopTransactionTypes}
+                    aria-haspopup="listbox"
+                    className="flex h-12 w-full items-center justify-between rounded-md border border-border bg-background px-4 text-left text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    type="button"
+                    onClick={() =>
+                      setShowDesktopTransactionTypes(previous => !previous)
                     }
                   >
-                    <SelectTrigger className="mt-1 bg-background text-foreground">
-                      <SelectValue
-                        placeholder={i18n.t(
-                          "payments.selectTransactionTypeBtn"
-                        )}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
+                    <span
+                      className={
+                        transactionType
+                          ? "text-foreground"
+                          : "text-muted-foreground"
+                      }
+                    >
+                      {selectedTransactionType?.label ||
+                        i18n.t("payments.selectTransactionTypeBtn")}
+                    </span>
+                    <CaretDown
+                      className={`h-4 w-4 text-muted-foreground transition-transform ${
+                        showDesktopTransactionTypes ? "rotate-180" : ""
+                      }`}
+                    />
+                  </button>
+                  {showDesktopTransactionTypes && (
+                    <ul
+                      className="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-border bg-background p-1 shadow-lg"
+                      role="listbox"
+                    >
                       {transactionTypes.map(type => (
-                        <SelectItem key={type.value} value={type.value}>
-                          {type.label}
-                        </SelectItem>
+                        <li key={type.value}>
+                          <button
+                            className={`flex w-full items-center rounded-sm px-3 py-2 text-left text-sm ${
+                              transactionType === type.value
+                                ? "bg-muted font-medium text-foreground"
+                                : "text-foreground hover:bg-muted"
+                            }`}
+                            type="button"
+                            onClick={() => {
+                              setFieldValue("transactionType", type.value);
+                              setShowDesktopTransactionTypes(false);
+                            }}
+                          >
+                            {type.label}
+                          </button>
+                        </li>
                       ))}
-                    </SelectContent>
-                  </Select>
+                    </ul>
+                  )}
                 </div>
               ) : (
                 <>
@@ -385,19 +428,16 @@ const PaymentEntryForm = ({
             </div>
             <div className="mt-4">
               <CustomInputText
-                disabled
                 id="paymentAmount"
                 inputBoxClassName="form__input block h-12 w-full appearance-none border-border bg-background p-4 text-base text-foreground focus-within:border-primary"
                 label={i18n.t("payments.paymentAmount")}
                 labelClassName="absolute top-0.5 left-1 h-6 z-1 origin-0 bg-background p-2 text-base font-medium duration-300 text-muted-foreground"
+                min="0"
                 name="paymentAmount"
-                type="text"
-                value={
-                  amount && baseCurrency
-                    ? currencyFormat(baseCurrency, amount)
-                    : ""
-                }
-                onChange={() => {}}
+                step="0.01"
+                type="number"
+                value={amount ?? ""}
+                onChange={e => setFieldValue("amount", e.target.value)}
               />
             </div>
             <div className="mt-4">

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
         # Wait for payments page to load
         expect(page).to have_content("Payments")
 
-        first(:button, "Add Manual Entry", minimum: 1).click
-        expect(page).to have_content("Add Manual Entry", wait: 10)
+        first(:button, "ADD MANUAL ENTRY", minimum: 1).click
+        expect(page).to have_content("Add Payment", wait: 10)
         expect(page).to have_selector("#invoice", wait: 10)
         expect(page).to have_selector("#transactionType", wait: 10)
       end
@@ -38,20 +38,23 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
       with_forgery_protection do
         visit "/payments?invoiceId=#{invoice.id}"
 
-        first(:button, "Add Manual Entry", minimum: 1).click
+        first(:button, "ADD MANUAL ENTRY", minimum: 1).click
         within("#transactionType") do
           find("button", text: "Select Transaction Type", match: :first, wait: 10).click
+          find("button", text: "Bank Transfer", wait: 10).click
         end
-        find("[role='option']", text: "Bank Transfer", wait: 10).click
+        expect(page).to have_field("paymentAmount", disabled: false)
+        fill_in "paymentAmount", with: "123.45"
 
         expect do
-          click_button "ADD PAYMENT"
+          click_button "Add Payment"
           expect(page).to have_content("Manual entry added successfully.", wait: 10)
         end.to change(Payment, :count).by(1)
 
         payment = Payment.order(:id).last
 
         expect(payment.invoice_id).to eq(invoice.id)
+        expect(payment.amount).to eq(BigDecimal("123.45"))
         expect(payment.transaction_type).to eq("bank_transfer")
       end
     end


### PR DESCRIPTION
## Summary
- Make the manual payment amount field editable and submit the entered decimal amount.
- Replace the broken desktop transaction type select with an aligned button/listbox dropdown.
- Add a browser-backed payment system regression for selecting a transaction type, editing amount, and persisting both values.

Fixes #2232

## Verification
- `rtk mise exec -- npx eslint app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx`
- `rtk mise exec -- npx prettier --check app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx`
- `rtk mise exec -- bundle exec rubocop spec/system/payments/create_spec.rb --format simple`
- `git diff --check`
- `rtk mise exec -- bundle exec rspec spec/system/payments/create_spec.rb`
- `rtk mise exec -- timeout 30 bin/vite build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transaction-type selector with enhanced desktop interaction
  * Payment amount field now accepts numeric input for clearer entry and validation

* **Bug Fixes**
  * Dropdown now reliably closes when clicking outside
  * Escape key handling extended to dismiss desktop transaction menu

* **Tests**
  * Updated system test flows and button label expectations for manual payments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->