### PR TITLE
fix: repair manual payment flow

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -4,7 +4,6 @@ import { payment } from "apis/api";
 import CustomDatePicker from "common/CustomDatePicker";
 import { CustomInputText } from "common/CustomInputText";
 import CustomReactSelect from "common/CustomReactSelect";
-import { CustomValueContainer } from "common/CustomReactSelectStyle";
 import { CustomTextareaAutosize } from "common/CustomTextareaAutosize";
 import { useUserContext } from "context/UserContext";
 import dayjs from "dayjs";
@@ -15,13 +14,6 @@ import { CalendarIcon } from "miruIcons";
 import { CaretDown } from "phosphor-react";
 import { useNavigate } from "react-router-dom";
 import { i18n } from "../../../i18n";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../../ui/select";
 import { Badge, MobileMoreOptions, Toastr } from "StyledComponents";
 import getStatusCssClass from "utils/getBadgeStatus";
 
@@ -66,6 +58,7 @@ const PaymentEntryForm = ({
         invoice => invoice.value === Number(invoiceId)
       ) || null
     : null;
+  const invoices = invoiceList?.invoiceList || [];
 
   const initialValues = {
     ...paymentEntryInitialValues,
@@ -109,8 +102,10 @@ const PaymentEntryForm = ({
     if (
       !isAddPaymentBtnActive(invoice, transactionDate, transactionType, amount)
     ) {
-      return;
+      return false;
     }
+
+    setIsLoading(true);
 
     try {
       const sanitized = mapPayment({
@@ -122,15 +117,19 @@ const PaymentEntryForm = ({
       });
       await payment.create(sanitized);
       Toastr.success(i18n.t("payments.manualEntryAdded"));
-      setIsLoading(false);
       fetchPaymentList();
       fetchInvoiceList();
       setShowManualEntryModal(false);
       if (invoiceId) {
         navigate(`/invoices/${invoiceId}`);
       }
+
+      return true;
     } catch {
       Toastr.error(i18n.t("payments.failedToAddManualEntry"));
+
+      return false;
+    } finally {
       setIsLoading(false);
     }
   };
@@ -144,8 +143,8 @@ const PaymentEntryForm = ({
       enableReinitialize
       initialValues={initialValues}
       onSubmit={async (values, { resetForm }) => {
-        await handleAddPayment(values);
-        resetForm();
+        const saved = await handleAddPayment(values);
+        if (saved) resetForm();
       }}
     >
       {(props: FormikProps<PaymentEntryFormValues>) => {
@@ -181,105 +180,98 @@ const PaymentEntryForm = ({
             <div className="relative mt-4">
               <div className="field">
                 <div className="mt-1" id="invoice" ref={wrapperSelectRef}>
-                  <div
-                    className="relative mt-3"
-                    id="invoicesList"
-                    onClick={handleShowSelectMenu}
-                  >
-                    <CustomReactSelect
-                      ignoreDisabledFontColor
-                      isDisabled
-                      isSearchable
-                      classNamePrefix="border-0 font-medium text-foreground"
-                      defaultValue={invoice}
-                      id="invoice"
-                      label={i18n.t("payments.invoice")}
-                      name="invoiceSearch"
-                      options={invoiceList.invoiceList}
-                      value={invoice}
-                      components={{
-                        ValueContainer: CustomValueContainer,
-                        IndicatorSeparator: () => null,
-                      }}
-                      handleOnChange={val => {
-                        setShowSelectMenu(!showSelectMenu);
-                        setFieldValue("invoice", val);
-                        setFieldValue("amount", val?.amount ?? "");
-                      }}
-                    />
+                  <div className="relative mt-3" id="invoicesList">
+                    <label
+                      className="absolute top-0.5 left-1 z-1 h-6 origin-0 bg-background p-2 text-base font-medium text-muted-foreground duration-300"
+                      htmlFor="manual-payment-invoice-select"
+                    >
+                      {i18n.t("payments.invoice")}
+                    </label>
+                    <button
+                      aria-expanded={showSelectMenu}
+                      aria-haspopup="listbox"
+                      className="flex min-h-14 w-full items-center justify-between rounded-md border border-border bg-background px-4 pt-6 pb-2 text-left text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      data-testid="manual-payment-invoice-select"
+                      id="manual-payment-invoice-select"
+                      type="button"
+                      onClick={handleShowSelectMenu}
+                    >
+                      {invoice ? (
+                        <span>
+                          <span className="block font-medium">
+                            {invoice.label}
+                          </span>
+                          <span className="block text-muted-foreground">
+                            {invoice.invoiceNumber}
+                          </span>
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">
+                          {i18n.t("payments.searchByClientOrInvoice")}
+                        </span>
+                      )}
+                      <CaretDown
+                        className={`h-4 w-4 text-muted-foreground transition-transform ${
+                          showSelectMenu ? "rotate-180" : ""
+                        }`}
+                      />
+                    </button>
                     {showSelectMenu && (
                       <div
-                        className="absolute right-0 top-0 z-15 min-h-24 w-full flex-col items-end rounded-md border border-border bg-background p-2 shadow-c1 group-hover:flex"
-                        id="transactionDate"
-                        onClick={e => e.stopPropagation()}
+                        className="absolute right-0 top-full z-50 mt-1 max-h-80 min-h-24 w-full overflow-y-auto rounded-md border border-border bg-background shadow-lg"
+                        data-testid="manual-payment-invoice-options"
+                        role="listbox"
                       >
-                        <Select
-                          defaultOpen
-                          value={invoice?.value?.toString() || ""}
-                          onValueChange={value => {
-                            const selectedInvoice =
-                              invoiceList.invoiceList.find(
-                                inv => inv.value.toString() === value
+                        {invoices.map(invoiceOption => (
+                          <button
+                            aria-selected={
+                              invoice?.value === invoiceOption.value
+                            }
+                            className="flex w-full cursor-pointer flex-col gap-2 p-2 text-left hover:bg-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0"
+                            key={invoiceOption.value}
+                            role="option"
+                            type="button"
+                            onClick={() => {
+                              setShowSelectMenu(false);
+                              setFieldValue("invoice", invoiceOption);
+                              setFieldValue(
+                                "amount",
+                                invoiceOption.amount ?? ""
                               );
-                            setShowSelectMenu(!showSelectMenu);
-                            setFieldValue("invoice", selectedInvoice);
-                            setFieldValue(
-                              "amount",
-                              selectedInvoice?.amount ?? ""
-                            );
-                          }}
-                        >
-                          <SelectTrigger className="m-0 mt-2 w-full border-0 font-medium text-foreground">
-                            <SelectValue
-                              placeholder={i18n.t(
-                                "payments.searchByClientOrInvoice"
-                              )}
-                            />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {invoiceList.invoiceList.map(invoiceOption => (
-                              <SelectItem
-                                key={invoiceOption.value}
-                                value={invoiceOption.value.toString()}
-                              >
-                                <div className="flex w-full cursor-pointer flex-col gap-2 p-2 sm:flex-row sm:items-center sm:justify-between sm:gap-0">
-                                  <div className="w-full py-2 pr-0 pl-0 text-left sm:w-2/6 sm:py-3 sm:pr-2">
-                                    <div className="truncate text-sm font-medium leading-5 text-foreground">
-                                      {invoiceOption.label}
-                                    </div>
-                                    <div className="pt-1 text-sm font-normal leading-5 text-muted-foreground">
-                                      {invoiceOption.invoiceNumber}
-                                    </div>
-                                  </div>
-                                  <div className="w-full px-0 py-2 text-left sm:w-2/6 sm:px-2 sm:py-3 sm:text-right">
-                                    <div className="text-base font-bold leading-5 text-foreground">
-                                      {baseCurrency &&
-                                        currencyFormat(
-                                          baseCurrency,
-                                          invoiceOption.amount
-                                        )}
-                                    </div>
-                                    <div className="pt-1 text-sm font-medium leading-5 text-muted-foreground">
-                                      {dayjs(invoiceOption.invoiceDate).format(
-                                        dateFormat
-                                      )}
-                                    </div>
-                                  </div>
-                                  <div className="w-full py-1 pl-0 pr-0 text-left text-sm font-semibold leading-4 tracking-wider sm:w-2/6 sm:py-3 sm:pl-2 sm:text-right">
-                                    <span className="rounded-lg">
-                                      <Badge
-                                        className={`${getStatusCssClass(
-                                          invoiceOption.status
-                                        )} uppercase`}
-                                        text={invoiceOption.status}
-                                      />
-                                    </span>
-                                  </div>
-                                </div>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                            }}
+                          >
+                            <span className="w-full py-2 pr-0 pl-0 sm:w-2/6 sm:py-3 sm:pr-2">
+                              <span className="block truncate text-sm font-medium leading-5 text-foreground">
+                                {invoiceOption.label}
+                              </span>
+                              <span className="block pt-1 text-sm font-normal leading-5 text-muted-foreground">
+                                {invoiceOption.invoiceNumber}
+                              </span>
+                            </span>
+                            <span className="w-full px-0 py-2 sm:w-2/6 sm:px-2 sm:py-3 sm:text-right">
+                              <span className="block text-base font-bold leading-5 text-foreground">
+                                {baseCurrency &&
+                                  currencyFormat(
+                                    baseCurrency,
+                                    invoiceOption.amount
+                                  )}
+                              </span>
+                              <span className="block pt-1 text-sm font-medium leading-5 text-muted-foreground">
+                                {dayjs(invoiceOption.invoiceDate).format(
+                                  dateFormat
+                                )}
+                              </span>
+                            </span>
+                            <span className="w-full py-1 pl-0 pr-0 text-sm font-semibold leading-4 tracking-wider sm:w-2/6 sm:py-3 sm:pl-2 sm:text-right">
+                              <Badge
+                                className={`${getStatusCssClass(
+                                  invoiceOption.status
+                                )} uppercase`}
+                                text={invoiceOption.status}
+                              />
+                            </span>
+                          </button>
+                        ))}
                       </div>
                     )}
                   </div>
@@ -455,12 +447,12 @@ const PaymentEntryForm = ({
             </div>
             <div className="actions mx-auto mt-4 mb-4 w-full">
               <button
-                disabled={isLoading}
+                disabled={!isPaymentBtnActive() || isLoading}
                 type="submit"
                 className={
                   isPaymentBtnActive() && !isLoading
                     ? "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-primary py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-primary-foreground shadow-sm hover:bg-primary/90"
-                    : "focus:outline-none flex h-10 w-full cursor-pointer items-center justify-center rounded border border-transparent bg-secondary py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-primary-foreground shadow-sm"
+                    : "focus:outline-none flex h-10 w-full cursor-not-allowed items-center justify-center rounded border border-transparent bg-secondary py-1 px-4 font-sans text-base font-medium uppercase tracking-widest text-secondary-foreground opacity-80 shadow-sm"
                 }
               >
                 {i18n.t("payments.addPayment")}

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -324,7 +324,7 @@ const PaymentEntryForm = ({
                             id={`manual-payment-invoice-option-${invoiceOption.value}`}
                             key={invoiceOption.value}
                             role="option"
-                            tabIndex={focusedInvoiceIndex === index ? 0 : -1}
+                            tabIndex={-1}
                             type="button"
                             onClick={() => {
                               selectInvoiceOption(invoiceOption);

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -44,6 +44,7 @@ const PaymentEntryForm = ({
 
   const [showDatePicker, setShowDatePicker] = useState<any>(false);
   const [showSelectMenu, setShowSelectMenu] = useState(false);
+  const [focusedInvoiceIndex, setFocusedInvoiceIndex] = useState(0);
   const [showDesktopTransactionTypes, setShowDesktopTransactionTypes] =
     useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -77,6 +78,7 @@ const PaymentEntryForm = ({
     const close = e => {
       if (e.keyCode === 27) {
         setShowDatePicker({ visibility: false });
+        setShowSelectMenu(false);
         setShowDesktopTransactionTypes(false);
       }
     };
@@ -134,10 +136,6 @@ const PaymentEntryForm = ({
     }
   };
 
-  const handleShowSelectMenu = () => {
-    setShowSelectMenu(!showSelectMenu);
-  };
-
   return (
     <Formik
       enableReinitialize
@@ -167,6 +165,76 @@ const PaymentEntryForm = ({
           type => type.value === transactionType
         );
 
+        const selectedInvoiceIndex = invoices.findIndex(
+          invoiceOption => invoiceOption.value === invoice?.value
+        );
+
+        const initialFocusedInvoiceIndex =
+          selectedInvoiceIndex >= 0 ? selectedInvoiceIndex : 0;
+
+        const selectInvoiceOption = invoiceOption => {
+          setShowSelectMenu(false);
+          setFieldValue("invoice", invoiceOption);
+          setFieldValue("amount", invoiceOption.amount ?? "");
+        };
+
+        const toggleInvoiceMenu = () => {
+          setFocusedInvoiceIndex(initialFocusedInvoiceIndex);
+          setShowSelectMenu(previous => !previous);
+        };
+
+        const handleInvoiceMenuKeyDown = event => {
+          if (!invoices.length) return;
+
+          if (
+            !showSelectMenu &&
+            ["ArrowDown", "ArrowUp", "Enter", " "].includes(event.key)
+          ) {
+            event.preventDefault();
+            setFocusedInvoiceIndex(initialFocusedInvoiceIndex);
+            setShowSelectMenu(true);
+
+            return;
+          }
+
+          if (!showSelectMenu) return;
+
+          switch (event.key) {
+            case "ArrowDown":
+              event.preventDefault();
+              setFocusedInvoiceIndex(
+                currentIndex => (currentIndex + 1) % invoices.length
+              );
+              break;
+            case "ArrowUp":
+              event.preventDefault();
+              setFocusedInvoiceIndex(
+                currentIndex =>
+                  (currentIndex - 1 + invoices.length) % invoices.length
+              );
+              break;
+            case "Home":
+              event.preventDefault();
+              setFocusedInvoiceIndex(0);
+              break;
+            case "End":
+              event.preventDefault();
+              setFocusedInvoiceIndex(invoices.length - 1);
+              break;
+            case "Enter":
+            case " ":
+              event.preventDefault();
+              selectInvoiceOption(invoices[focusedInvoiceIndex] || invoices[0]);
+              break;
+            case "Escape":
+              event.preventDefault();
+              setShowSelectMenu(false);
+              break;
+            default:
+              break;
+          }
+        };
+
         const isPaymentBtnActive = () =>
           isAddPaymentBtnActive(
             invoice,
@@ -188,13 +256,20 @@ const PaymentEntryForm = ({
                       {i18n.t("payments.invoice")}
                     </label>
                     <button
+                      aria-activedescendant={
+                        showSelectMenu && invoices[focusedInvoiceIndex]
+                          ? `manual-payment-invoice-option-${invoices[focusedInvoiceIndex].value}`
+                          : undefined
+                      }
+                      aria-controls="manual-payment-invoice-options"
                       aria-expanded={showSelectMenu}
                       aria-haspopup="listbox"
                       className="flex min-h-14 w-full items-center justify-between rounded-md border border-border bg-background px-4 pt-6 pb-2 text-left text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                       data-testid="manual-payment-invoice-select"
                       id="manual-payment-invoice-select"
                       type="button"
-                      onClick={handleShowSelectMenu}
+                      onClick={toggleInvoiceMenu}
+                      onKeyDown={handleInvoiceMenuKeyDown}
                     >
                       {invoice ? (
                         <span>
@@ -220,25 +295,29 @@ const PaymentEntryForm = ({
                       <div
                         className="absolute right-0 top-full z-50 mt-1 max-h-80 min-h-24 w-full overflow-y-auto rounded-md border border-border bg-background shadow-lg"
                         data-testid="manual-payment-invoice-options"
+                        id="manual-payment-invoice-options"
+                        onKeyDown={handleInvoiceMenuKeyDown}
                         role="listbox"
                       >
-                        {invoices.map(invoiceOption => (
+                        {invoices.map((invoiceOption, index) => (
                           <button
                             aria-selected={
                               invoice?.value === invoiceOption.value
                             }
-                            className="flex w-full cursor-pointer flex-col gap-2 p-2 text-left hover:bg-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0"
+                            className={`flex w-full cursor-pointer flex-col gap-2 p-2 text-left hover:bg-muted focus:outline-none sm:flex-row sm:items-center sm:justify-between sm:gap-0 ${
+                              focusedInvoiceIndex === index
+                                ? "bg-muted ring-1 ring-ring"
+                                : ""
+                            }`}
+                            id={`manual-payment-invoice-option-${invoiceOption.value}`}
                             key={invoiceOption.value}
                             role="option"
+                            tabIndex={focusedInvoiceIndex === index ? 0 : -1}
                             type="button"
                             onClick={() => {
-                              setShowSelectMenu(false);
-                              setFieldValue("invoice", invoiceOption);
-                              setFieldValue(
-                                "amount",
-                                invoiceOption.amount ?? ""
-                              );
+                              selectInvoiceOption(invoiceOption);
                             }}
+                            onMouseEnter={() => setFocusedInvoiceIndex(index)}
                           >
                             <span className="w-full py-2 pr-0 pl-0 sm:w-2/6 sm:py-3 sm:pr-2">
                               <span className="block truncate text-sm font-medium leading-5 text-foreground">

--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -172,8 +172,15 @@ const PaymentEntryForm = ({
         const initialFocusedInvoiceIndex =
           selectedInvoiceIndex >= 0 ? selectedInvoiceIndex : 0;
 
+        const focusInvoiceSelect = () => {
+          window.requestAnimationFrame(() => {
+            document.getElementById("manual-payment-invoice-select")?.focus();
+          });
+        };
+
         const selectInvoiceOption = invoiceOption => {
           setShowSelectMenu(false);
+          focusInvoiceSelect();
           setFieldValue("invoice", invoiceOption);
           setFieldValue("amount", invoiceOption.amount ?? "");
         };
@@ -181,6 +188,10 @@ const PaymentEntryForm = ({
         const toggleInvoiceMenu = () => {
           setFocusedInvoiceIndex(initialFocusedInvoiceIndex);
           setShowSelectMenu(previous => !previous);
+        };
+
+        const handleInvoiceSelectPointerDown = () => {
+          toggleInvoiceMenu();
         };
 
         const handleInvoiceMenuKeyDown = event => {
@@ -229,6 +240,7 @@ const PaymentEntryForm = ({
             case "Escape":
               event.preventDefault();
               setShowSelectMenu(false);
+              focusInvoiceSelect();
               break;
             default:
               break;
@@ -268,8 +280,8 @@ const PaymentEntryForm = ({
                       data-testid="manual-payment-invoice-select"
                       id="manual-payment-invoice-select"
                       type="button"
-                      onClick={toggleInvoiceMenu}
                       onKeyDown={handleInvoiceMenuKeyDown}
+                      onPointerDown={handleInvoiceSelectPointerDown}
                     >
                       {invoice ? (
                         <span>

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -6,7 +6,44 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
   let(:company) { create(:company) }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let(:client) { create(:client, company:, name: "bob") }
-  let!(:invoice) { create(:invoice, client:, company:, status: "sent") }
+  let!(:invoice) do
+    create(:invoice,
+      client:,
+      company:,
+      status: "sent",
+      invoice_number: "INV-MANUAL-001",
+      amount: 500.00,
+      amount_due: 500.00,
+      outstanding_amount: 500.00)
+  end
+
+  def open_manual_payment_modal
+    visit "/payments"
+
+    expect(page).to have_content("Payments", wait: 10)
+    first(:button, "ADD MANUAL ENTRY", minimum: 1).click
+    expect(page).to have_content("Add Payment", wait: 10)
+  end
+
+  def select_manual_payment_invoice(invoice)
+    find("[data-testid='manual-payment-invoice-select']", wait: 10).click
+    within("[data-testid='manual-payment-invoice-options']") do
+      find("[role='option']", text: invoice.invoice_number, wait: 10).click
+    end
+
+    expect(page).to have_css(
+      "[data-testid='manual-payment-invoice-select']",
+      text: invoice.invoice_number,
+      wait: 10
+    )
+  end
+
+  def select_desktop_transaction_type(type)
+    within("#transactionType") do
+      find("button", text: "Select Transaction Type", match: :first, wait: 10).click
+      find("button", text: type, wait: 10).click
+    end
+  end
 
   context "when user is an admin" do
     before do
@@ -17,20 +54,12 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
 
     it "opens the manual payment modal" do
       with_forgery_protection do
-        visit "/payments"
+        open_manual_payment_modal
 
-        # Wait for the page to load and click on Payments in sidebar if needed
-        if page.has_content?("Time Tracking")
-          click_link "Payments"
-        end
-
-        # Wait for payments page to load
-        expect(page).to have_content("Payments")
-
-        first(:button, "ADD MANUAL ENTRY", minimum: 1).click
         expect(page).to have_content("Add Payment", wait: 10)
         expect(page).to have_selector("#invoice", wait: 10)
         expect(page).to have_selector("#transactionType", wait: 10)
+        expect(page).to have_button("Add Payment", disabled: true, wait: 10)
       end
     end
 
@@ -39,10 +68,7 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
         visit "/payments?invoiceId=#{invoice.id}"
 
         first(:button, "ADD MANUAL ENTRY", minimum: 1).click
-        within("#transactionType") do
-          find("button", text: "Select Transaction Type", match: :first, wait: 10).click
-          find("button", text: "Bank Transfer", wait: 10).click
-        end
+        select_desktop_transaction_type("Bank Transfer")
         expect(page).to have_field("paymentAmount", disabled: false)
         fill_in "paymentAmount", with: "123.45"
 
@@ -56,6 +82,52 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
         expect(payment.invoice_id).to eq(invoice.id)
         expect(payment.amount).to eq(BigDecimal("123.45"))
         expect(payment.transaction_type).to eq("bank_transfer")
+      end
+    end
+
+    it "creates a manual payment after selecting an invoice from the modal" do
+      with_forgery_protection do
+        open_manual_payment_modal
+        select_manual_payment_invoice(invoice)
+        select_desktop_transaction_type("Bank Transfer")
+        fill_in "paymentAmount", with: "123.45"
+
+        expect(page).to have_button("Add Payment", disabled: false, wait: 10)
+
+        expect do
+          click_button "Add Payment"
+          expect(page).to have_content("Manual entry added successfully.", wait: 10)
+        end.to change(Payment, :count).by(1)
+
+        payment = Payment.order(:id).last
+
+        expect(payment.invoice_id).to eq(invoice.id)
+        expect(payment.amount).to eq(BigDecimal("123.45"))
+        expect(payment.transaction_type).to eq("bank_transfer")
+      end
+    end
+
+    it "keeps selected payment values visible when the save fails" do
+      with_forgery_protection do
+        open_manual_payment_modal
+        select_manual_payment_invoice(invoice)
+        select_desktop_transaction_type("Bank Transfer")
+        fill_in "paymentAmount", with: "0"
+
+        expect do
+          click_button "Add Payment"
+          expect(page).to have_content("Failed to add manual entry", wait: 10)
+        end.not_to change(Payment, :count)
+
+        expect(page).to have_css(
+          "[data-testid='manual-payment-invoice-select']",
+          text: invoice.invoice_number,
+          wait: 10
+        )
+        within("#transactionType") do
+          expect(page).to have_button("Bank Transfer", wait: 10)
+        end
+        expect(page).to have_field("paymentAmount", with: "0", wait: 10)
       end
     end
   end

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -48,7 +48,46 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
     expect(page).to have_css("[data-testid='manual-payment-invoice-options']", wait: 10)
     expect(page).to have_css("[role='option']", text: invoice.invoice_number, wait: 10)
 
-    page.driver.browser.keyboard.type(:down)
+    target_option_id = page.evaluate_script(<<~JS)
+      (() => {
+        const targetInvoiceNumber = #{invoice.invoice_number.to_json};
+        const options = Array.from(
+          document.querySelectorAll(
+            '[data-testid="manual-payment-invoice-options"] [role="option"]'
+          )
+        );
+        const targetOption = options.find(option =>
+          option.textContent.includes(targetInvoiceNumber)
+        );
+
+        return targetOption ? targetOption.id : null;
+      })()
+    JS
+    expect(target_option_id).to be_present
+
+    target_option_index = page.evaluate_script(<<~JS)
+      (() => {
+        return Array.from(
+          document.querySelectorAll(
+            '[data-testid="manual-payment-invoice-options"] [role="option"]'
+          )
+        ).findIndex(option => option.id === #{target_option_id.to_json});
+      })()
+    JS
+    expect(target_option_index).to be >= 0
+
+    if target_option_index.zero?
+      page.driver.browser.keyboard.type(:down)
+      page.driver.browser.keyboard.type(:up)
+    else
+      target_option_index.times { page.driver.browser.keyboard.type(:down) }
+    end
+
+    expect(page).to have_css(
+      "[data-testid='manual-payment-invoice-select'][aria-activedescendant='#{target_option_id}']",
+      wait: 10
+    )
+
     page.driver.browser.keyboard.type(:Enter)
 
     expect(page).to have_css(

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -51,13 +51,16 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
     target_option_id = page.evaluate_script(<<~JS)
       (() => {
         const targetInvoiceNumber = #{invoice.invoice_number.to_json};
+        const normalize = text => text.replace(/\\s+/g, " ").trim();
         const options = Array.from(
           document.querySelectorAll(
             '[data-testid="manual-payment-invoice-options"] [role="option"]'
           )
         );
         const targetOption = options.find(option =>
-          option.textContent.includes(targetInvoiceNumber)
+          Array.from(option.querySelectorAll("span")).some(
+            span => normalize(span.textContent) === targetInvoiceNumber
+          )
         );
 
         return targetOption ? targetOption.id : null;

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
     )
   end
 
+  def select_manual_payment_invoice_with_keyboard(invoice)
+    invoice_select = find("[data-testid='manual-payment-invoice-select']", wait: 10)
+
+    invoice_select.click
+    invoice_select.send_keys(:down, :enter)
+
+    expect(page).to have_css(
+      "[data-testid='manual-payment-invoice-select']",
+      text: invoice.invoice_number,
+      wait: 10
+    )
+  end
+
   def select_desktop_transaction_type(type)
     within("#transactionType") do
       find("button", text: "Select Transaction Type", match: :first, wait: 10).click
@@ -104,6 +117,15 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
         expect(payment.invoice_id).to eq(invoice.id)
         expect(payment.amount).to eq(BigDecimal("123.45"))
         expect(payment.transaction_type).to eq("bank_transfer")
+      end
+    end
+
+    it "selects an invoice from the modal with keyboard navigation" do
+      with_forgery_protection do
+        open_manual_payment_modal
+        select_manual_payment_invoice_with_keyboard(invoice)
+
+        expect(page).to have_field("paymentAmount", disabled: false, wait: 10)
       end
     end
 

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -39,16 +39,24 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
   end
 
   def select_manual_payment_invoice_with_keyboard(invoice)
-    invoice_select = find("[data-testid='manual-payment-invoice-select']", wait: 10)
+    find("[data-testid='manual-payment-invoice-select']", wait: 10)
 
-    invoice_select.click
-    invoice_select.send_keys(:down, :enter)
+    page.execute_script("document.getElementById('manual-payment-invoice-select').focus()")
+    expect(page).to have_css("[data-testid='manual-payment-invoice-select']:focus", wait: 10)
+
+    page.driver.browser.keyboard.type(:Enter)
+    expect(page).to have_css("[data-testid='manual-payment-invoice-options']", wait: 10)
+    expect(page).to have_css("[role='option']", text: invoice.invoice_number, wait: 10)
+
+    page.driver.browser.keyboard.type(:down)
+    page.driver.browser.keyboard.type(:Enter)
 
     expect(page).to have_css(
       "[data-testid='manual-payment-invoice-select']",
       text: invoice.invoice_number,
       wait: 10
     )
+    expect(page).to have_css("[data-testid='manual-payment-invoice-select']:focus", wait: 10)
   end
 
   def select_desktop_transaction_type(type)
@@ -122,8 +130,17 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
 
     it "selects an invoice from the modal with keyboard navigation" do
       with_forgery_protection do
+        keyboard_invoice = create(:invoice,
+          client:,
+          company:,
+          status: "sent",
+          invoice_number: "INV-MANUAL-002",
+          amount: 275.00,
+          amount_due: 275.00,
+          outstanding_amount: 275.00)
+
         open_manual_payment_modal
-        select_manual_payment_invoice_with_keyboard(invoice)
+        select_manual_payment_invoice_with_keyboard(keyboard_invoice)
 
         expect(page).to have_field("paymentAmount", disabled: false, wait: 10)
       end


### PR DESCRIPTION
## Summary
- replace the broken invoice selector in Add Payment Manually with a direct accessible listbox
- add keyboard navigation for the invoice listbox after CodeRabbit feedback
- keep selected payment values when the API rejects the save
- disable and restyle the Add Payment CTA until required fields are present
- add system specs for invoice selection success, keyboard selection, failed-save retention, and CTA disabled state

Fixes #2239

## Verification
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
- rtk mise exec -- bundle exec rubocop spec/system/payments/create_spec.rb --format simple
- rtk mise exec -- timeout 120 env RAILS_ENV=test ./node_modules/.bin/vite build --mode test
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb:101 spec/system/payments/create_spec.rb:123 spec/system/payments/create_spec.rb:132
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb
- rtk mise exec -- timeout 30 bin/vite build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment entry preserves selected invoice, transaction type, and amount when submission fails; submit button disables while inactive or loading.

* **Improvements**
  * Form only resets after a successful payment; loading state managed around submission and modal closes on success. Conditional navigation to invoice details when launched with an invoice ID.
  * Invoice selector replaced with an accessible, keyboard-navigable control.

* **Tests**
  * System tests updated for modal flow, keyboard invoice selection, success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->