### PR TITLE
fix(time-tracking): guard copy shortcut against form submit

### DIFF
--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -658,6 +658,7 @@ const AddEntry: React.FC<Iprops> = ({
             <div className="flex flex-col gap-3 pt-4">
               {editEntryId === 0 ? (
                 <Button
+                  type="button"
                   size="lg"
                   disabled={handleDisableBtn()}
                   onClick={() => {
@@ -670,6 +671,7 @@ const AddEntry: React.FC<Iprops> = ({
                 </Button>
               ) : (
                 <Button
+                  type="button"
                   size="lg"
                   disabled={handleDisableBtn()}
                   onClick={() => {
@@ -681,6 +683,7 @@ const AddEntry: React.FC<Iprops> = ({
                 </Button>
               )}
               <Button
+                type="button"
                 variant="outline"
                 size="lg"
                 onClick={() => {

--- a/app/javascript/src/components/TimeTracking/EntryForm.tsx
+++ b/app/javascript/src/components/TimeTracking/EntryForm.tsx
@@ -366,6 +366,7 @@ const AddEntry: React.FC<Iprops> = ({
           </div>
           {isNewEntry && latestTrackedEntry && (
             <Button
+              type="button"
               variant="outline"
               size="sm"
               data-testid="duplicate-last-entry"

--- a/spec/system/time_tracking/add_entry_spec.rb
+++ b/spec/system/time_tracking/add_entry_spec.rb
@@ -558,6 +558,28 @@ RSpec.describe "Time Tracking - Add Entry", type: :system, js: true do
     )
   end
 
+  it "keeps add-entry actions from submitting the time tracking page" do
+    visit "/time-tracking"
+    expect(page).to have_css("#react-root", wait: 10)
+    switch_to("Week")
+
+    click_button "Add Entry"
+
+    expect(find_button("Save Entry", disabled: :all, wait: 10)["type"]).to eq(
+      "button"
+    )
+
+    cancel_button = find_button("Cancel", wait: 10)
+    expect(cancel_button["type"]).to eq("button")
+
+    cancel_button.click
+
+    expect(page).to have_current_path("/time-tracking", ignore_query: true)
+    expect(page).to have_button("Add Entry", wait: 10)
+    expect(page).to have_no_button("Save Entry")
+    expect(page).to have_no_text("The page you were looking for doesn't exist")
+  end
+
   it "prefills the form from a recent shortcut and duplicates the last entry into the selected day" do
     recent_note = "Recent shortcut work"
     create(

--- a/spec/system/time_tracking/add_entry_spec.rb
+++ b/spec/system/time_tracking/add_entry_spec.rb
@@ -379,11 +379,13 @@ RSpec.describe "Time Tracking - Add Entry", type: :system, js: true do
 
     visit "/time-tracking"
     expect(page).to have_css("#react-root", wait: 10)
-    expect(page).to have_button(pause_timer_label, wait: 10)
-    expect(page).to have_text(project.name, wait: 10)
+    within "[data-testid='inline-web-timer']" do
+      expect(page).to have_button(pause_timer_label, wait: 10)
+      expect(page).to have_text(project.name, wait: 10)
 
-    click_button pause_timer_label
-    expect(page).to have_button("Start", wait: 10)
+      click_button pause_timer_label
+    end
+    expect(page).to have_button("Resume", wait: 10)
   end
 
   it "keeps the selected day visible when switching between week and month views" do
@@ -582,8 +584,11 @@ RSpec.describe "Time Tracking - Add Entry", type: :system, js: true do
     expect(find("input[name='timeInput']", wait: 10).value).to eq("01:35")
     expect(find("textarea[name='notes']", wait: 10).value).to eq(recent_note)
 
+    duplicate_button = find("[data-testid='duplicate-last-entry']", wait: 10)
+    expect(duplicate_button["type"]).to eq("button")
+
     expect do
-      find("[data-testid='duplicate-last-entry']", wait: 10).click
+      duplicate_button.click
       expect(page).to have_button("Add Entry", wait: 10)
     end.to change {
       TimesheetEntry.where(
@@ -593,6 +598,8 @@ RSpec.describe "Time Tracking - Add Entry", type: :system, js: true do
         note: recent_note
       ).count
     }.by(1)
+    expect(page).to have_current_path("/time-tracking", ignore_query: true)
+    expect(page).to have_no_text("The page you were looking for doesn't exist")
   end
 
   it "copies last week's entries into the current week" do


### PR DESCRIPTION
## Summary
- Fixes #2176 follow-up by making the add-entry copy shortcut an explicit non-submit button.
- Strengthens the system spec to prove the copy shortcut stays on /time-tracking and does not hit the Rails 404 page.
- Stabilizes the adjacent floating timer spec by scoping the Pause click and matching the current Resume state.

## Verification
- rtk mise exec -- pnpm exec prettier --write app/javascript/src/components/TimeTracking/EntryForm.tsx
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/TimeTracking/EntryForm.tsx
- rtk mise exec -- bundle exec rubocop spec/system/time_tracking/add_entry_spec.rb --format simple
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/time_tracking/add_entry_spec.rb:558
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/time_tracking/add_entry_spec.rb:598
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/time_tracking/add_entry_spec.rb:367
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/time_tracking/add_entry_spec.rb
- rtk mise exec -- timeout 30 bin/vite build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended form submissions when using desktop action buttons (duplicate/copy, save, update, cancel), improving reliability of entry actions.
  * Ensured duplicating or copying recent entries keeps you on the time-tracking page and avoids navigation errors or missing-page messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->