### PR TITLE
fix: improve invoice editor preview layout

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
@@ -27,7 +27,7 @@ import {
   FloppyDisk,
   PaperPlaneTilt,
   Eye,
-  EyeSlash,
+  PencilSimple,
 } from "phosphor-react";
 import InvoiceTable from "../common/InvoiceTable";
 import InvoicePreview from "../InvoicePreview";
@@ -102,7 +102,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
     return `${prefix}${paddedDigits}`;
   };
 
-  const [showPreview, setShowPreview] = useState(true);
+  const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [submitIntent, setSubmitIntent] = useState<"save" | "send" | null>(
     null
   );
@@ -454,18 +454,36 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
               </p>
             </div>
             <div className="flex flex-wrap gap-2 sm:gap-3">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowPreview(!showPreview)}
-                className="lg:hidden"
-              >
-                {showPreview ? (
-                  <EyeSlash className="h-4 w-4" />
-                ) : (
+              <div className="flex rounded-md border border-input bg-background p-0.5 min-[1800px]:hidden">
+                <Button
+                  aria-pressed={!isPreviewMode}
+                  className={cn(
+                    "h-8 gap-1.5 px-3",
+                    !isPreviewMode && "bg-accent text-accent-foreground"
+                  )}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setIsPreviewMode(false)}
+                >
+                  <PencilSimple className="h-4 w-4" />
+                  <span className="hidden sm:inline">{i18n.t("edit")}</span>
+                </Button>
+                <Button
+                  aria-pressed={isPreviewMode}
+                  className={cn(
+                    "h-8 gap-1.5 px-3",
+                    isPreviewMode && "bg-accent text-accent-foreground"
+                  )}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setIsPreviewMode(true)}
+                >
                   <Eye className="h-4 w-4" />
-                )}
-              </Button>
+                  <span className="hidden sm:inline">{i18n.t("preview")}</span>
+                </Button>
+              </div>
               <Button variant="outline" size="sm" onClick={onCancel}>
                 {i18n.t("cancel")}
               </Button>
@@ -529,13 +547,13 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
       </div>
 
       {/* Content */}
-      <div className="mx-auto max-w-[96rem]">
-        <div className="grid grid-cols-1 gap-8 p-4 sm:p-6 lg:grid-cols-12">
+      <div className="mx-auto max-w-[110rem]">
+        <div className="grid grid-cols-1 gap-8 p-4 sm:p-6 min-[1800px]:grid-cols-2">
           {/* Form Section */}
           <div
             className={cn(
               "min-w-0 space-y-6",
-              showPreview ? "lg:col-span-7" : "lg:col-span-12"
+              isPreviewMode && "hidden min-[1800px]:block"
             )}
           >
             {/* Basic Details */}
@@ -687,7 +705,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
                 </CardDescription>
               </CardHeader>
               <CardContent className="p-0">
-                <div className="px-6 py-4">
+                <div className="px-4 py-4 sm:px-6">
                   <InvoiceTable
                     clientCurrency={formData.currency}
                     dateFormat={company?.dateFormat || "MM/dd/yyyy"}
@@ -767,11 +785,14 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
           </div>
 
           {/* Preview Section */}
-          {showPreview && (
-            <div className="min-w-0 lg:col-span-5 lg:sticky lg:top-24 lg:h-fit">
-              <InvoicePreview invoice={previewInvoice} isEditing={true} />
-            </div>
-          )}
+          <div
+            className={cn(
+              "min-w-0 min-[1800px]:sticky min-[1800px]:top-24 min-[1800px]:h-fit",
+              !isPreviewMode && "hidden min-[1800px]:block"
+            )}
+          >
+            <InvoicePreview invoice={previewInvoice} isEditing={true} />
+          </div>
         </div>
       </div>
     </div>

--- a/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
@@ -454,8 +454,13 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
               </p>
             </div>
             <div className="flex flex-wrap gap-2 sm:gap-3">
-              <div className="flex rounded-md border border-input bg-background p-0.5 min-[1800px]:hidden">
+              <div
+                aria-label="Invoice editor view mode"
+                className="flex rounded-md border border-input bg-background p-0.5 min-[1800px]:hidden"
+                role="group"
+              >
                 <Button
+                  aria-label={i18n.t("edit")}
                   aria-pressed={!isPreviewMode}
                   className={cn(
                     "h-8 gap-1.5 px-3",
@@ -470,6 +475,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
                   <span className="hidden sm:inline">{i18n.t("edit")}</span>
                 </Button>
                 <Button
+                  aria-label={i18n.t("preview")}
                   aria-pressed={isPreviewMode}
                   className={cn(
                     "h-8 gap-1.5 px-3",

--- a/app/javascript/src/components/Invoices/InvoicePreview/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoicePreview/index.tsx
@@ -702,7 +702,7 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
               {invoice.discount > 0 && (
                 <div className="flex justify-between gap-4 py-2">
                   <span className="text-muted-foreground print:text-gray-600">
-                    Discount
+                    {i18n.t("invoices.discount")}
                   </span>
                   <span className="min-w-0 break-words text-right font-medium text-red-600">
                     -{currencyFormat(currency, invoice.discount)}
@@ -712,7 +712,7 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
               {invoice.tax > 0 && (
                 <div className="flex justify-between gap-4 py-2">
                   <span className="text-muted-foreground print:text-gray-600">
-                    Tax
+                    {i18n.t("invoices.tax")}
                   </span>
                   <span className="min-w-0 break-words text-right font-medium text-foreground print:text-gray-900">
                     {currencyFormat(currency, invoice.tax)}

--- a/app/javascript/src/components/Invoices/InvoicePreview/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoicePreview/index.tsx
@@ -567,7 +567,7 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
 
         {/* Line Items Table */}
         <div className="mb-8">
-          <div className="space-y-3 sm:hidden">
+          <div className="space-y-3 lg:hidden">
             {invoice.lineItems.map((item, index) => (
               <div
                 className="rounded-lg border border-border p-4"
@@ -622,8 +622,15 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
               </div>
             ))}
           </div>
-          <div className="hidden sm:block">
-            <table className="w-full">
+          <div className="hidden lg:block">
+            <table className="w-full table-fixed">
+              <colgroup>
+                <col className="w-[42%]" />
+                <col className="w-[16%]" />
+                <col className="w-[12%]" />
+                <col className="w-[15%]" />
+                <col className="w-[15%]" />
+              </colgroup>
               <thead>
                 <tr className="border-b-2 border-border print:border-gray-200">
                   <th className="px-2 py-3 text-left text-sm font-semibold text-foreground print:text-gray-700">
@@ -649,10 +656,10 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
                     key={item.id || index}
                     className="border-b border-border/70 print:border-gray-100"
                   >
-                    <td className="px-2 py-3 text-sm text-foreground print:text-gray-900">
-                      <div className="space-y-1">
+                    <td className="min-w-0 px-2 py-3 text-sm text-foreground print:text-gray-900">
+                      <div className="min-w-0 space-y-1">
                         {item.name && (
-                          <p className="font-medium">{item.name}</p>
+                          <p className="break-words font-medium">{item.name}</p>
                         )}
                         {item.description && (
                           <p className="whitespace-pre-wrap break-words text-muted-foreground print:text-gray-600">
@@ -661,16 +668,16 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
                         )}
                       </div>
                     </td>
-                    <td className="px-2 py-3 text-center text-sm text-muted-foreground print:text-gray-600">
+                    <td className="whitespace-nowrap px-2 py-3 text-center text-sm text-muted-foreground print:text-gray-600">
                       {item.date ? formatDate(item.date) : "-"}
                     </td>
-                    <td className="px-2 py-3 text-center text-sm text-foreground print:text-gray-900">
+                    <td className="whitespace-nowrap px-2 py-3 text-center text-sm text-foreground print:text-gray-900">
                       {formatQuantity(item.quantity)}
                     </td>
-                    <td className="px-2 py-3 text-right text-sm text-foreground print:text-gray-900">
+                    <td className="whitespace-nowrap px-2 py-3 text-right text-sm text-foreground print:text-gray-900">
                       {currencyFormat(currency, item.rate)}
                     </td>
-                    <td className="px-2 py-3 text-right text-sm font-medium text-foreground print:text-gray-900">
+                    <td className="whitespace-nowrap px-2 py-3 text-right text-sm font-medium text-foreground print:text-gray-900">
                       {formatLineAmount(item)}
                     </td>
                   </tr>
@@ -684,40 +691,40 @@ const InvoicePreview: React.FC<InvoicePreviewProps> = ({
         <div className="mb-8 flex justify-end">
           <div className="w-full sm:w-80">
             <div className="space-y-2 text-sm">
-              <div className="flex justify-between py-2">
+              <div className="flex justify-between gap-4 py-2">
                 <span className="text-muted-foreground print:text-gray-600">
                   {i18n.t("invoices.subtotal")}
                 </span>
-                <span className="font-medium text-foreground print:text-gray-900">
+                <span className="min-w-0 break-words text-right font-medium text-foreground print:text-gray-900">
                   {currencyFormat(currency, invoice.subtotal ?? invoice.amount)}
                 </span>
               </div>
               {invoice.discount > 0 && (
-                <div className="flex justify-between py-2">
+                <div className="flex justify-between gap-4 py-2">
                   <span className="text-muted-foreground print:text-gray-600">
                     Discount
                   </span>
-                  <span className="font-medium text-red-600">
+                  <span className="min-w-0 break-words text-right font-medium text-red-600">
                     -{currencyFormat(currency, invoice.discount)}
                   </span>
                 </div>
               )}
               {invoice.tax > 0 && (
-                <div className="flex justify-between py-2">
+                <div className="flex justify-between gap-4 py-2">
                   <span className="text-muted-foreground print:text-gray-600">
                     Tax
                   </span>
-                  <span className="font-medium text-foreground print:text-gray-900">
+                  <span className="min-w-0 break-words text-right font-medium text-foreground print:text-gray-900">
                     {currencyFormat(currency, invoice.tax)}
                   </span>
                 </div>
               )}
               <Separator className="my-2" />
-              <div className="flex justify-between py-2">
+              <div className="flex justify-between gap-4 py-2">
                 <span className="text-base font-semibold text-foreground print:text-gray-900">
                   {i18n.t("reports.totalDue")}
                 </span>
-                <span className="text-xl font-bold text-foreground print:text-gray-900">
+                <span className="min-w-0 break-words text-right text-xl font-bold text-foreground print:text-gray-900">
                   {currencyFormat(currency, invoice.amount)}
                 </span>
               </div>

--- a/app/javascript/src/components/Invoices/common/InvoiceTable/index.tsx
+++ b/app/javascript/src/components/Invoices/common/InvoiceTable/index.tsx
@@ -164,7 +164,7 @@ const InvoiceTable = ({
   return (
     <Fragment>
       <div className="w-full overflow-x-auto">
-        <table className="w-full table-fixed bg-card">
+        <table className="min-w-[760px] w-full table-fixed bg-card">
           <colgroup>
             <col className="w-[38%]" />
             <col className="w-[18%]" />

--- a/spec/support/invoice_editor_system_helpers.rb
+++ b/spec/support/invoice_editor_system_helpers.rb
@@ -4,7 +4,7 @@ module InvoiceEditorSystemHelpers
   def formatted_invoice_currency(amount, currency)
     case currency
     when "EUR"
-      "#{format('%.2f', amount).tr('.', ',')} €"
+      "€#{format('%.2f', amount)}"
     when "INR"
       "₹#{format('%.2f', amount)}"
     else
@@ -198,13 +198,35 @@ module InvoiceEditorSystemHelpers
     click_button "Save"
   end
 
+  def show_invoice_preview
+    return false if has_css?("[data-testid='invoice-preview']", wait: 1)
+
+    find("button", text: /preview/i, wait: 10).click
+    expect(page).to have_css("[data-testid='invoice-preview']", wait: 10)
+
+    true
+  end
+
+  def show_invoice_editor
+    return if has_button?("Save", wait: 1)
+
+    find("button", text: /edit/i, wait: 10).click
+    expect(page).to have_button("Save", wait: 10)
+  end
+
   def expect_invoice_preview_totals(currency:, subtotal:, total_due:, discount: nil, tax: nil)
-    expect(page).to have_text("Subtotal", wait: 10)
-    expect(page).to have_text(formatted_invoice_currency(subtotal, currency), wait: 10)
-    expect(page).to have_text("Total Due", wait: 10)
-    expect(page).to have_text(formatted_invoice_currency(total_due, currency), wait: 10)
-    expect(page).to have_text("-#{formatted_invoice_currency(discount, currency)}", wait: 10) if discount
-    expect(page).to have_text(formatted_invoice_currency(tax, currency), wait: 10) if tax
+    toggled_preview = show_invoice_preview
+
+    within "[data-testid='invoice-preview']" do
+      expect(page).to have_text("Subtotal", wait: 10)
+      expect(page).to have_text(formatted_invoice_currency(subtotal, currency), wait: 10)
+      expect(page).to have_text("Total Due", wait: 10)
+      expect(page).to have_text(formatted_invoice_currency(total_due, currency), wait: 10)
+      expect(page).to have_text("-#{formatted_invoice_currency(discount, currency)}", wait: 10) if discount
+      expect(page).to have_text(formatted_invoice_currency(tax, currency), wait: 10) if tax
+    end
+  ensure
+    show_invoice_editor if toggled_preview
   end
 end
 

--- a/spec/support/invoice_editor_system_helpers.rb
+++ b/spec/support/invoice_editor_system_helpers.rb
@@ -201,7 +201,7 @@ module InvoiceEditorSystemHelpers
   def show_invoice_preview
     return false if has_css?("[data-testid='invoice-preview']", wait: 1)
 
-    find("button", text: /preview/i, wait: 10).click
+    find("button", exact_text: "preview", wait: 10).click
     expect(page).to have_css("[data-testid='invoice-preview']", wait: 10)
 
     true
@@ -210,7 +210,7 @@ module InvoiceEditorSystemHelpers
   def show_invoice_editor
     return if has_button?("Save", wait: 1)
 
-    find("button", text: /edit/i, wait: 10).click
+    find("button", exact_text: "Edit", wait: 10).click
     expect(page).to have_button("Save", wait: 10)
   end
 

--- a/spec/system/invoices/create_spec.rb
+++ b/spec/system/invoices/create_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe "Invoice creation", type: :system, js: true do
         description: "Preview name check"
       )
 
+      show_invoice_preview
+
       within "[data-testid='invoice-preview']" do
         expect(page).to have_text("Manual preview item", wait: 10)
         expect(page).to have_text("Preview name check", wait: 10)
@@ -111,10 +113,14 @@ RSpec.describe "Invoice creation", type: :system, js: true do
     with_forgery_protection do
       visit_new_invoice_for(client)
 
-      expect(page).to have_text(company.name, wait: 10)
-      expect(page).to have_text("100 Market St", wait: 10)
-      expect(page).to have_text("TAX-123", wait: 10)
-      expect(page).not_to have_text("support@getmiru.com", wait: 1)
+      show_invoice_preview
+
+      within "[data-testid='invoice-preview']" do
+        expect(page).to have_text(company.name, wait: 10)
+        expect(page).to have_text("100 Market St", wait: 10)
+        expect(page).to have_text("TAX-123", wait: 10)
+        expect(page).not_to have_text("support@getmiru.com", wait: 1)
+      end
     end
   end
 


### PR DESCRIPTION
Need to get approval on https://github.com/saeloun/miru-web/issues/2227#issuecomment-4406093811 before merging this code

Fixes #2227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added explicit Edit and Preview buttons in the invoice editor header for clearer mode switching
  * Updated responsive layout: sticky preview panel on wide screens and streamlined spacing in edit/preview views
  * Improved invoice line-item table and desktop formatting for clearer alignment and readability
  * Refined totals section styling and typography for better presentation

* **Tests**
  * System tests updated to explicitly toggle and verify the invoice preview pane
<!-- end of auto-generated comment: release notes by coderabbit.ai -->