### PR TITLE
chore: require gstack for AI-assisted work

### DIFF
--- a/.claude/hooks/check-gstack.sh
+++ b/.claude/hooks/check-gstack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Block skill usage when gstack is not installed globally.
+
+if [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
+  cat >&2 <<'MSG'
+BLOCKED: gstack is not installed globally.
+
+gstack is required for AI-assisted work in this repo.
+
+Install it:
+  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+  cd ~/.claude/skills/gstack && ./setup --team
+
+Then restart your AI coding tool.
+MSG
+  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/hooks/check-gstack.sh
+++ b/.claude/hooks/check-gstack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Block skill usage when gstack is not installed globally.
 
-if [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
+if [ -z "${HOME:-}" ] || [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
   cat >&2 <<'MSG'
 BLOCKED: gstack is not installed globally.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Keep this file short. Treat it as a router for repo-specific rules.
 - On SPA pages, prefer settled route checks over generic `networkidle` when background requests stay alive.
 - If a user reports a live production bug, reproduce it on the real domain when practical before declaring root cause.
 
+## gstack
+
+- gstack is required for AI-assisted work in this repo. If `~/.claude/skills/gstack/bin` is missing, stop and ask the user to install it with `git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup --team`.
+- Use gstack skills for QA, review, investigate, ship, land-and-deploy, canary, and browser workflows when they match the task.
+- Keep gstack as a global install. Do not vendor `.claude/skills/gstack/` or `.agents/skills/gstack/` into this repo.
+
 ## Local Development
 
 - Primary local app URL: `http://127.0.0.1:3000`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,27 @@ This file is retained for compatibility with tools that still look for `CLAUDE.m
 If `CLAUDE.md` and `AGENTS.md` ever differ, follow `AGENTS.md`.
 
 Before pushing a new commit, cancel stale in-progress GitHub Actions runs for the current branch so CI does not pile up redundant runs.
+
+## gstack (REQUIRED — global install)
+
+**Before doing ANY work, verify gstack is installed:**
+
+```bash
+test -d ~/.claude/skills/gstack/bin && echo "GSTACK_OK" || echo "GSTACK_MISSING"
+```
+
+If GSTACK_MISSING: STOP. Do not proceed. Tell the user:
+
+> gstack is required for all AI-assisted work in this repo.
+> Install it:
+> ```bash
+> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+> cd ~/.claude/skills/gstack && ./setup --team
+> ```
+> Then restart your AI coding tool.
+
+Do not skip skills, ignore gstack errors, or work around missing gstack.
+
+Using gstack skills: After install, skills like /qa, /ship, /review, /investigate,
+and /browse are available. Use /browse for all web browsing.
+Use ~/.claude/skills/gstack/... for gstack file paths (the global path).


### PR DESCRIPTION
## Summary
- require global gstack team-mode setup for AI-assisted work
- add Claude PreToolUse hook/settings to block missing gstack when skills are used
- add AGENTS/CLAUDE guidance so team members know how to install and use gstack

## Verification
- ran .claude/hooks/check-gstack.sh
- parsed .claude/settings.json as JSON
- ran git diff --check --cached before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration to register a pre-tool hook and a shell hook that validates a required external tool before use.
  * Pre-execution validation will block tool use when the required tool is missing and surface installation guidance.
* **Documentation**
  * Updated repository guidance with required tool installation steps, verification commands, and recommended usage across workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2254)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->