### PR TITLE
fix: use inline attachments for company logos in all email templates

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -70,11 +70,26 @@ class ApplicationMailer < ActionMailer::Base
       attachments.inline[filename] = { content: path.binread, mime_type: "image/png" }
     end
 
+    def attach_company_logo_inline(company)
+      return "" unless company&.logo&.attached?
+
+      # Attach logo inline for email display
+      logo_filename = "company_logo_#{company.id}.#{company.logo.filename.extension}"
+      unless attachments[logo_filename].present?
+        attachments.inline[logo_filename] = {
+          content: company.logo.download,
+          mime_type: company.logo.content_type
+        }
+      end
+
+      attachments[logo_filename].url
+    end
+
     def email_company_logo_url
       company_details = @company_details&.with_indifferent_access
       company = email_company_record
 
-      return logo_company_url(company) if company&.logo&.attached?
+      return attach_company_logo_inline(company) if company&.logo&.attached?
       return @company_logo if @company_logo.present?
 
       company_details[:logo] if company_details&.[](:logo).present?

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -73,7 +73,6 @@ class ApplicationMailer < ActionMailer::Base
     def attach_company_logo_inline(company)
       return "" unless company&.logo&.attached?
 
-      # Attach logo inline for email display
       logo_filename = "company_logo_#{company.id}.#{company.logo.filename.extension}"
       unless attachments[logo_filename].present?
         attachments.inline[logo_filename] = {
@@ -83,6 +82,12 @@ class ApplicationMailer < ActionMailer::Base
       end
 
       attachments[logo_filename].url
+    end
+
+    def attached_company_logo_url(company)
+      return "" unless company&.logo&.attached?
+
+      polymorphic_url(company.logo)
     end
 
     def email_company_logo_url

--- a/app/mailers/client_payment_mailer.rb
+++ b/app/mailers/client_payment_mailer.rb
@@ -23,9 +23,7 @@ class ClientPaymentMailer < ApplicationMailer
   private
 
     def company_logo
-      @invoice.company.logo.attached? ?
-        polymorphic_url(@invoice.company.logo) :
-        ""
+      attach_company_logo_inline(@invoice.company)
     end
 
     def format_date

--- a/app/mailers/client_payment_mailer.rb
+++ b/app/mailers/client_payment_mailer.rb
@@ -23,7 +23,7 @@ class ClientPaymentMailer < ApplicationMailer
   private
 
     def company_logo
-      attach_company_logo_inline(@invoice.company)
+      attached_company_logo_url(@invoice.company)
     end
 
     def format_date

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -59,7 +59,7 @@ class InvoiceMailer < ApplicationMailer
     end
 
     def company_logo
-      attach_company_logo_inline(@company)
+      attached_company_logo_url(@company)
     end
 
     def can_send_invoice?

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -59,9 +59,7 @@ class InvoiceMailer < ApplicationMailer
     end
 
     def company_logo
-      @company.logo.attached? ?
-        polymorphic_url(@company.logo) :
-        ""
+      attach_company_logo_inline(@company)
     end
 
     def can_send_invoice?

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -26,9 +26,7 @@ class PaymentMailer < ApplicationMailer
   private
 
     def company_logo
-      @invoice.company.logo.attached? ?
-        polymorphic_url(@invoice.company.logo) :
-        ""
+      attach_company_logo_inline(@invoice.company)
     end
 
     def recipients_with_role

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -26,7 +26,7 @@ class PaymentMailer < ApplicationMailer
   private
 
     def company_logo
-      attach_company_logo_inline(@invoice.company)
+      attached_company_logo_url(@invoice.company)
     end
 
     def recipients_with_role

--- a/app/mailers/send_payment_reminder_mailer.rb
+++ b/app/mailers/send_payment_reminder_mailer.rb
@@ -22,8 +22,6 @@ class SendPaymentReminderMailer < ApplicationMailer
   private
 
     def company_logo
-      @invoices.first.company.logo.attached? ?
-        polymorphic_url(@invoices.first.company.logo) :
-        ""
+      attach_company_logo_inline(@invoices.first.company)
     end
 end

--- a/app/mailers/send_payment_reminder_mailer.rb
+++ b/app/mailers/send_payment_reminder_mailer.rb
@@ -22,6 +22,6 @@ class SendPaymentReminderMailer < ApplicationMailer
   private
 
     def company_logo
-      attach_company_logo_inline(@invoices.first.company)
+      attached_company_logo_url(@invoices.first.company)
     end
 end

--- a/app/mailers/send_reminder_mailer.rb
+++ b/app/mailers/send_reminder_mailer.rb
@@ -23,8 +23,6 @@ class SendReminderMailer < ApplicationMailer
   private
 
     def company_logo
-      @invoice.company.logo.attached? ?
-        polymorphic_url(@invoice.company.logo) :
-        ""
+      attach_company_logo_inline(@invoice.company)
     end
 end

--- a/app/mailers/send_reminder_mailer.rb
+++ b/app/mailers/send_reminder_mailer.rb
@@ -23,6 +23,6 @@ class SendReminderMailer < ApplicationMailer
   private
 
     def company_logo
-      attach_company_logo_inline(@invoice.company)
+      attached_company_logo_url(@invoice.company)
     end
 end

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -27,8 +27,17 @@ RSpec.describe InvoiceMailer, type: :mailer do
       it "renders the organization logo instead of attaching Miru fallback logos" do
         body = mail.html_part.body.decoded
 
-        expect(body).to include("/companies/#{company.id}/logo")
+        # Company logo should be attached inline with cid: reference
         expect(body).to include('alt="Saeloun Logo Co"')
+        expect(body).to match(/src="cid:[^"]+/)
+
+        # Company logo should be in attachments with inline disposition
+        company_logo_attachment = mail.attachments.find { |a| a.filename&.start_with?("company_logo_#{company.id}") }
+        expect(company_logo_attachment).to be_present
+        expect(company_logo_attachment.content_type).to match(/image/)
+        expect(company_logo_attachment["content-disposition"].to_s).to include("inline")
+
+        # Miru fallback logos should not be attached
         expect(mail.attachments["MiruLogoDarkWithText.png"]).to be_nil
         expect(mail.attachments["MiruLogoLightWithText.png"]).to be_nil
       end

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -27,19 +27,31 @@ RSpec.describe InvoiceMailer, type: :mailer do
       it "renders the organization logo instead of attaching Miru fallback logos" do
         body = mail.html_part.body.decoded
 
-        # Company logo should be attached inline with cid: reference
         expect(body).to include('alt="Saeloun Logo Co"')
         expect(body).to match(/src="cid:[^"]+/)
 
-        # Company logo should be in attachments with inline disposition
         company_logo_attachment = mail.attachments.find { |a| a.filename&.start_with?("company_logo_#{company.id}") }
         expect(company_logo_attachment).to be_present
         expect(company_logo_attachment.content_type).to match(/image/)
         expect(company_logo_attachment["content-disposition"].to_s).to include("inline")
 
-        # Miru fallback logos should not be attached
         expect(mail.attachments["MiruLogoDarkWithText.png"]).to be_nil
         expect(mail.attachments["MiruLogoLightWithText.png"]).to be_nil
+      end
+
+      it "keeps the PDF logo URL separate from the inline email attachment URL" do
+        expect(InvoicePayment::PdfGeneration).to receive(:process) do |generated_invoice, logo_url, root_url|
+          expect(generated_invoice).to eq(invoice)
+          expect(logo_url).to include("test-image.png")
+          expect(logo_url).not_to start_with("cid:")
+          expect(root_url).to be_present
+
+          "%PDF-1.4 invoice"
+        end
+
+        body = mail.html_part.body.decoded
+
+        expect(body).to match(/src="cid:[^"]+/)
       end
     end
 

--- a/spec/mailers/send_reminder_mailer_spec.rb
+++ b/spec/mailers/send_reminder_mailer_spec.rb
@@ -23,5 +23,22 @@ RSpec.describe SendReminderMailer, type: :mailer do
       expect(body).to include("is still awaiting payment")
       expect(body).to include("Open invoice")
     end
+
+    context "when the company has a logo" do
+      let(:company) { create :company, :with_logo, name: "Saeloun Logo Co" }
+
+      it "uses a public logo URL for PDF generation and an inline logo in the email" do
+        expect(InvoicePayment::PdfGeneration).to receive(:process) do |generated_invoice, logo_url, root_url|
+          expect(generated_invoice).to eq(invoice)
+          expect(logo_url).to include("test-image.png")
+          expect(logo_url).not_to start_with("cid:")
+          expect(root_url).to be_present
+
+          "%PDF-1.4 reminder"
+        end
+
+        expect(body).to match(/src="cid:[^"]+/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #2260 

<img width="1388" height="715" alt="Screenshot 2026-05-11 at 3 44 39 PM" src="https://github.com/user-attachments/assets/cd8ddd01-eefd-4ebd-9454-ee3da631842f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Company logos are now embedded directly in emails as inline attachments for improved rendering across all email clients.

* **Improvements**
  * Standardized logo handling across all email templates for consistent appearance and behavior.

* **Tests**
  * Updated email tests to verify inline logo attachment behavior and logo URL handling in PDF generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->