### PR TITLE
fix(profile): prevent reusing current password when updating password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
 
   # Attribute accessor
   attribute :locale, :string, default: "en-US"
-  attr_accessor :current_company, :role, :skip_password_validation
+  attr_accessor :current_company, :current_password, :role, :skip_password_validation
 
   # Validations
   after_initialize :set_default_social_accounts, if: :new_record?
@@ -110,6 +110,13 @@ class User < ApplicationRecord
 
     record = find_by(id: key)
     record if record && record.authenticatable_salt == salt
+  end
+
+  def update_with_password(params)
+    self.current_password = params[:current_password] || params["current_password"]
+    super
+  ensure
+    self.current_password = nil
   end
 
   # Callbacks

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,7 @@ class User < ApplicationRecord
   validate :date_of_birth_cannot_be_in_future
   validate :phone_length_within_limit
   validate :validate_avatar_constraints
+  validate :password_must_differ_from_current_password, if: :password_being_changed?
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -317,6 +318,16 @@ class User < ApplicationRecord
       return unless date_of_birth > Date.current
 
       errors.add(:date_of_birth, "cannot be in the future")
+    end
+
+    def password_being_changed?
+      password.present? && current_password.present?
+    end
+
+    def password_must_differ_from_current_password
+      return unless valid_password?(password)
+
+      errors.add(:password, :same_as_current_password)
     end
 
     def phone_length_within_limit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -325,7 +325,8 @@ class User < ApplicationRecord
     end
 
     def password_must_differ_from_current_password
-      return unless valid_password?(password)
+      return unless valid_password?(current_password)
+      return unless password == current_password
 
       errors.add(:password, :same_as_current_password)
     end

--- a/app/services/update_profile_settings_service.rb
+++ b/app/services/update_profile_settings_service.rb
@@ -40,7 +40,10 @@ class UpdateProfileSettingsService
   private
 
     def new_password_same_as_current_password?
-      user_params[:password].present? && current_user.valid_password?(user_params[:password])
+      user_params[:password].present? &&
+        user_params[:current_password].present? &&
+        current_user.valid_password?(user_params[:current_password]) &&
+        user_params[:password] == user_params[:current_password]
     end
 
     def success_payload(notice)

--- a/app/services/update_profile_settings_service.rb
+++ b/app/services/update_profile_settings_service.rb
@@ -25,6 +25,11 @@ class UpdateProfileSettingsService
   end
 
   def update_user_with_password
+    if new_password_same_as_current_password?
+      current_user.errors.add(:password, :same_as_current_password)
+      return { res: { errors: current_user.errors.full_messages }, status: :unprocessable_content }
+    end
+
     if current_user.update_with_password(user_params)
       { res: success_payload(I18n.t("password.update.success")), status: :ok }
     else
@@ -33,6 +38,10 @@ class UpdateProfileSettingsService
   end
 
   private
+
+    def new_password_same_as_current_password?
+      user_params[:password].present? && current_user.valid_password?(user_params[:password])
+    end
 
     def success_payload(notice)
       {

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -26,5 +26,6 @@ en-GB:
             password:
               blank: can't be blank
               too_short: must be at least %{count} characters long
+              same_as_current_password: must be different from current password
             password_confirmation:
               confirmation: doesn't match with new password

--- a/config/locales/activerecord.en-US.yml
+++ b/config/locales/activerecord.en-US.yml
@@ -26,5 +26,6 @@ en-US:
             password:
               blank: can't be blank
               too_short: must be at least %{count} characters long
+              same_as_current_password: must be different from current password
             password_confirmation:
               confirmation: doesn't match with new password

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -26,5 +26,6 @@ en:
             password:
               blank: can't be blank
               too_short: must be at least %{count} characters long
+              same_as_current_password: must be different from current password
             password_confirmation:
               confirmation: doesn't match with new password

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -32,7 +32,7 @@
 FactoryBot.define do
   factory :client do
     company
-    name { Faker::Name.unique.name[0..30] }
+    name { Faker::Name.unique.name[0...30] }
     email { Faker::Internet.unique.email }
     phone { Faker::PhoneNumber.phone_number_with_country_code.slice(0, 15) }
     currency { "USD" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -133,6 +133,32 @@ RSpec.describe User, type: :model do
       expect(user).not_to be_valid
       expect(user.errors[:phone]).to include("must contain at least 2 digits")
     end
+
+    describe "password reuse validation" do
+      let(:user) { create(:user, password: "testing12") }
+
+      it "does not allow updating the password to the current password" do
+        result = user.update_with_password(
+          current_password: "testing12",
+          password: "testing12",
+          password_confirmation: "testing12"
+        )
+
+        expect(result).to be(false)
+        expect(user.errors.details[:password]).to include(error: :same_as_current_password)
+      end
+
+      it "allows updating the password to a different password" do
+        result = user.update_with_password(
+          current_password: "testing12",
+          password: "newtesting12",
+          password_confirmation: "newtesting12"
+        )
+
+        expect(result).to be(true)
+        expect(user.reload.valid_password?("newtesting12")).to be(true)
+      end
+    end
   end
 
   describe "Callbacks" do

--- a/spec/requests/api/v1/profile/update_spec.rb
+++ b/spec/requests/api/v1/profile/update_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe "Api::V1::Profile#update", type: :request do
       expect(json_response["errors"]).to eq(["Password must be at least 8 characters long"])
     end
 
+    it "throws error when new password is same as current password" do
+      params = {
+        user: {
+          first_name: "Example", last_name: "User", current_password: "testing12", password: "testing12",
+          password_confirmation: "testing12"
+        }
+      }
+
+      send_request(:put, api_v1_profile_path, params:, headers: auth_headers(user))
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response["errors"]).to eq(["Password must be different from current password"])
+    end
+
     it "ignores unexpected social account keys" do
       params = {
         user: {

--- a/spec/requests/api/v1/profile/update_spec.rb
+++ b/spec/requests/api/v1/profile/update_spec.rb
@@ -136,6 +136,20 @@ RSpec.describe "Api::V1::Profile#update", type: :request do
       expect(json_response["errors"]).to eq(["Password must be different from current password"])
     end
 
+    it "throws current password error when current password is incorrect even if new password matches existing password" do
+      params = {
+        user: {
+          first_name: "Example", last_name: "User", current_password: "incorrect", password: "testing12",
+          password_confirmation: "testing12"
+        }
+      }
+
+      send_request(:put, api_v1_profile_path, params:, headers: auth_headers(user))
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response["errors"]).to eq(["Current password is invalid"])
+    end
+
     it "ignores unexpected social account keys" do
       params = {
         user: {


### PR DESCRIPTION
Fixes #2258 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password change validation now prevents users from setting a new password identical to their current password, with clear error messages to guide users through the update process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->