### PR TITLE
fix: prevent last workspace owner from deleting their own team member…

### DIFF
--- a/app/controllers/api/v1/team_controller.rb
+++ b/app/controllers/api/v1/team_controller.rb
@@ -44,12 +44,20 @@ class Api::V1::TeamController < Api::V1::ApplicationController
   end
 
   def destroy
-    authorize employment, policy_class: TeamPolicy
-    employment.user.remove_roles_for(current_company)
-    employment.discard!
+    removed_user = nil
+
+    current_company.with_lock do
+      target_employment = employment
+      target_employment.lock!
+      authorize target_employment, policy_class: TeamPolicy
+
+      removed_user = target_employment.user
+      removed_user.remove_roles_for(current_company)
+      target_employment.discard!
+    end
 
     render json: {
-      user: employment.user,
+      user: removed_user,
       notice: I18n.t("team.delete.success.message")
     }, status: 200
   end

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TeamPolicy < ApplicationPolicy
+  attr_reader :error_message_key
+
   def index?
     user_owner_role? || user_admin_role?
   end
@@ -23,6 +25,27 @@ class TeamPolicy < ApplicationPolicy
       return false
     end
 
+    return false if only_owner_removing_self?
+
     user_owner_role? || user_admin_role?
+  end
+
+  def only_owner_removing_self?
+    return false unless record.user_id == user.id
+    return false unless user.has_role?(:owner, record.company)
+
+    is_last_owner = owner_role_count_for_company <= 1
+    @error_message_key = :last_owner_self_removal if is_last_owner
+    is_last_owner
+  end
+
+  def owner_role_count_for_company
+    User
+      .joins(:roles, :employments)
+      .where(roles: { name: "owner", resource_type: "Company", resource_id: record.company_id })
+      .merge(User.kept)
+      .merge(Employment.kept.where(company_id: record.company_id))
+      .distinct
+      .count
   end
 end

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -636,6 +636,7 @@ en-US:
     team_policy:
       destroy?: You are not authorized to destroy team.
       edit?: You are not authorized to edit team.
+      last_owner_self_removal: You cannot remove yourself because you are the only workspace owner.
       update?: You are not authorized to update team.
   registration:
     confirm_password: confirm password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -640,6 +640,7 @@ en:
     team_policy:
       destroy?: You are not authorized to destroy team.
       edit?: You are not authorized to edit team.
+      last_owner_self_removal: You cannot remove yourself because you are the only workspace owner.
       update?: You are not authorized to update team.
   registration:
     confirm_password: confirm password

--- a/spec/requests/api/v1/team/destroy_spec.rb
+++ b/spec/requests/api/v1/team/destroy_spec.rb
@@ -142,6 +142,31 @@ RSpec.describe "Api::V1::Team#destroy", type: :request do
     end
   end
 
+  describe "when current user is owner" do
+    let(:owner_user) { create(:user, current_workspace_id: company.id) }
+
+    context "when owner tries to delete self and is the only owner" do
+      before do
+        create(:employment, company:, user: owner_user)
+        owner_user.add_role :owner, company
+        sign_in owner_user
+      end
+
+      it "returns forbidden response with a clear message" do
+        send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(owner_user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response["errors"]).to eq(I18n.t("pundit.team_policy.last_owner_self_removal"))
+      end
+
+      it "does not discard the owner employment" do
+        expect {
+          send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(owner_user)
+        }.not_to change(company.employments.kept, :count)
+      end
+    end
+  end
+
   context "when current user is an employee" do
     let(:employee_user) { create(:user, current_workspace_id: company.id) }
     let(:team_user) { create(:user, current_workspace_id: company.id) }

--- a/spec/requests/api/v1/team/destroy_spec.rb
+++ b/spec/requests/api/v1/team/destroy_spec.rb
@@ -165,6 +165,29 @@ RSpec.describe "Api::V1::Team#destroy", type: :request do
         }.not_to change(company.employments.kept, :count)
       end
     end
+
+    context "when owner tries to delete self and another owner exists" do
+      let(:another_owner) { create(:user, current_workspace_id: company.id) }
+
+      before do
+        create(:employment, company:, user: owner_user)
+        create(:employment, company:, user: another_owner)
+        owner_user.add_role :owner, company
+        another_owner.add_role :owner, company
+        sign_in owner_user
+      end
+
+      it "allows self removal" do
+        owner_employment = company.employments.kept.find_by!(user: owner_user)
+
+        expect {
+          send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(owner_user)
+        }.to change(company.employments.kept, :count).by(-1)
+
+        expect(response).to be_successful
+        expect(owner_employment.reload.discarded?).to be_truthy
+      end
+    end
   end
 
   context "when current user is an employee" do


### PR DESCRIPTION
…ship

Fixes #2262 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection to prevent the last workspace owner from removing themselves, ensuring your workspace always has at least one owner.

* **Tests**
  * Added test coverage for owner self-removal prevention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->