### PR TITLE
fix(billing): add alert for client portal users in seat count

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -88,6 +88,7 @@ class Api::V1::SubscriptionsController < Api::V1::ApplicationController
         has_stripe_customer: current_company.stripe_customer_id.present?,
         team_member_limit: current_company.team_member_limit,
         used_team_seats: current_company.used_team_seats,
+        client_portal_users_count: current_company.client_portal_users_count,
         team_member_limit_reached: current_company.team_member_limit_reached?,
         trial_active: current_company.trial_active?,
         trial_available: current_company.trial_available?,

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -434,7 +434,6 @@ const Billing = () => {
                       "billingSettings.alerts.clientPortalUsersDescription",
                       {
                         count: summary.client_portal_users_count,
-                        total: summary.used_team_seats,
                       }
                     )}
                   </AlertDescription>

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -48,6 +48,7 @@ type BillingSummary = {
   has_stripe_customer: boolean;
   team_member_limit: number;
   used_team_seats: number;
+  client_portal_users_count: number;
   team_member_limit_reached: boolean;
   trial_active: boolean;
   trial_available: boolean;
@@ -422,6 +423,23 @@ const Billing = () => {
                   </p>
                 </div>
               </div>
+
+              {summary.client_portal_users_count > 0 && (
+                <Alert>
+                  <AlertTitle>
+                    {i18n.t("billingSettings.alerts.clientPortalUsersTitle")}
+                  </AlertTitle>
+                  <AlertDescription>
+                    {i18n.t(
+                      "billingSettings.alerts.clientPortalUsersDescription",
+                      {
+                        count: summary.client_portal_users_count,
+                        total: summary.used_team_seats,
+                      }
+                    )}
+                  </AlertDescription>
+                </Alert>
+              )}
 
               {summary.trial_active && summary.trial_ends_at && (
                 <Alert>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1872,6 +1872,9 @@ const en = {
       seatLimitReached: "Seat limit reached",
       seatLimitReachedDescription:
         "Upgrade in Stripe to add more than 3 members to this workspace.",
+      clientPortalUsersTitle: "Client portal users included in seat count",
+      clientPortalUsersDescription:
+        "Your seat count includes %{count} client portal user(s) who have login access. These users can view their invoices, projects, and time entries. Team members are managed on the Team page.",
     },
     errors: {
       unableToOpenStripeCheckout: "Unable to open Stripe checkout",

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -106,15 +106,7 @@ class Company < ApplicationRecord
   end
 
   def client_portal_users_count
-    user_ids_with_only_client_role = users.with_kept_employments
-      .joins(:roles)
-      .group("users.id, roles.resource_id, roles.resource_type")
-      .having("COUNT(roles.id) = 1 AND MAX(roles.name) = 'client' \
-              AND roles.resource_id = #{id} \
-              AND roles.resource_type = 'Company'")
-      .pluck("users.id")
-
-    user_ids_with_only_client_role.count
+    User.from(users_with_only_client_role_for_company.select("users.id"), :client_portal_users).count
   end
 
   def team_member_limit_reached?
@@ -222,18 +214,20 @@ class Company < ApplicationRecord
   end
 
   def employees_without_client_role
-    user_ids_with_only_client_role = users.with_kept_employments
-      .joins(:roles)
-      .group("users.id, roles.resource_id, roles.resource_type")
-      .having("COUNT(roles.id) = 1 AND MAX(roles.name) = 'client' \
-              AND roles.resource_id = #{id} \
-              AND roles.resource_type = 'Company'")
-      .pluck("users.id")
-
-    users.with_kept_employments.where.not(id: user_ids_with_only_client_role).distinct
+    users.with_kept_employments
+      .where.not(id: users_with_only_client_role_for_company.select("users.id"))
+      .distinct
   end
 
   private
+
+    def users_with_only_client_role_for_company
+      users.with_kept_employments
+        .joins(:roles)
+        .where(roles: { resource_id: id, resource_type: "Company" })
+        .group("users.id")
+        .having("COUNT(roles.id) = 1 AND MAX(roles.name) = ?", "client")
+    end
 
     def stripe_subscription_access?(status)
       %w[active trialing past_due].include?(status.to_s)

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -105,6 +105,18 @@ class Company < ApplicationRecord
     [used_team_seats, 1].max
   end
 
+  def client_portal_users_count
+    user_ids_with_only_client_role = users.with_kept_employments
+      .joins(:roles)
+      .group("users.id, roles.resource_id, roles.resource_type")
+      .having("COUNT(roles.id) = 1 AND MAX(roles.name) = 'client' \
+              AND roles.resource_id = #{id} \
+              AND roles.resource_type = 'Company'")
+      .pluck("users.id")
+
+    user_ids_with_only_client_role.count
+  end
+
   def team_member_limit_reached?
     return false if team_member_limit.infinite?
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -243,6 +243,42 @@ RSpec.describe Company, type: :model do
       end
     end
 
+    describe "#client_portal_users_count" do
+      let(:team_member) { create(:user, current_workspace_id: company.id) }
+      let(:client_portal_user) { create(:user, current_workspace_id: company.id) }
+      let(:mixed_role_user) { create(:user, current_workspace_id: company.id) }
+      let(:other_company_client) { create(:user, current_workspace_id: company.id) }
+      let(:discarded_client_user) { create(:user, current_workspace_id: company.id) }
+      let(:other_company) { create(:company) }
+
+      before do
+        create(:employment, company:, user: team_member)
+        team_member.add_role(:employee, company)
+
+        create(:employment, company:, user: client_portal_user)
+        client_portal_user.add_role(:client, company)
+
+        create(:employment, company:, user: mixed_role_user)
+        mixed_role_user.add_role(:client, company)
+        mixed_role_user.add_role(:employee, company)
+
+        create(:employment, company:, user: other_company_client)
+        other_company_client.add_role(:client, other_company)
+
+        create(:employment, company:, user: discarded_client_user, discarded_at: Time.current)
+        discarded_client_user.add_role(:client, company)
+      end
+
+      it "counts kept users whose only company role is client" do
+        expect(company.client_portal_users_count).to eq(1)
+      end
+
+      it "excludes only client portal users from employee lists" do
+        expect(company.employees_without_client_role).to include(team_member, mixed_role_user, other_company_client)
+        expect(company.employees_without_client_role).not_to include(client_portal_user, discarded_client_user)
+      end
+    end
+
     describe "#apply_stripe_subscription!" do
       it "marks the company as paid for active subscriptions" do
         company.apply_stripe_subscription!(

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(body["trial_active"]).to eq(false)
       expect(body["trial_available"]).to eq(true)
       expect(body["pro_access"]).to eq(false)
+      expect(body["client_portal_users_count"]).to eq(0)
+    end
+
+    it "returns client portal users included in the seat count" do
+      client_portal_user = create(:user, current_workspace_id: company.id)
+      create(:employment, company:, user: client_portal_user)
+      client_portal_user.add_role(:client, company)
+
+      get "/api/v1/subscription", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["used_team_seats"]).to eq(2)
+      expect(body["client_portal_users_count"]).to eq(1)
     end
 
     it "returns trial summary when the company is on a pro trial" do

--- a/spec/system/settings/billing_spec.rb
+++ b/spec/system/settings/billing_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe "Settings billing", type: :system, js: true do
     end
   end
 
+  it "explains client portal users included in seat usage" do
+    client_portal_user = create(:user, current_workspace_id: company.id)
+    create(:employment, company:, user: client_portal_user)
+    client_portal_user.add_role :client, company
+
+    with_forgery_protection do
+      visit "/settings/billing"
+
+      expect(page).to have_content("2/3 seats used", wait: 10)
+      expect(page).to have_content("Client portal users included in seat count", wait: 10)
+      expect(page).to have_content("Your seat count includes 1 client portal user(s) who have login access", wait: 10)
+    end
+  end
+
   it "shows localized billing copy in Hindi" do
     user.update!(locale: "hi")
 


### PR DESCRIPTION
Fixes #2269 

After Fixes

<img width="2940" height="1436" alt="image" src="https://github.com/user-attachments/assets/e2b31d06-99d1-4a5f-83b9-0124b388d832" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing summary now shows a count of client portal users.
  * Billing page displays an alert when client portal users are present, explaining they count toward team seats.

* **Documentation**
  * Added English translations for the client portal users messaging in billing.

* **Tests**
  * Added model, request, and system tests validating client portal user counts and billing page messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->