### PR TITLE
fix: show empty invoice dropdown state

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -195,8 +195,6 @@ const PaymentEntryForm = ({
         };
 
         const handleInvoiceMenuKeyDown = event => {
-          if (!invoices.length) return;
-
           if (
             !showSelectMenu &&
             ["ArrowDown", "ArrowUp", "Enter", " "].includes(event.key)
@@ -209,6 +207,16 @@ const PaymentEntryForm = ({
           }
 
           if (!showSelectMenu) return;
+
+          if (!invoices.length) {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setShowSelectMenu(false);
+              focusInvoiceSelect();
+            }
+
+            return;
+          }
 
           switch (event.key) {
             case "ArrowDown":
@@ -311,58 +319,75 @@ const PaymentEntryForm = ({
                         onKeyDown={handleInvoiceMenuKeyDown}
                         role="listbox"
                       >
-                        {invoices.map((invoiceOption, index) => (
-                          <button
-                            aria-selected={
-                              invoice?.value === invoiceOption.value
-                            }
-                            className={`flex w-full cursor-pointer flex-col gap-2 p-2 text-left hover:bg-muted focus:outline-none sm:flex-row sm:items-center sm:justify-between sm:gap-0 ${
-                              focusedInvoiceIndex === index
-                                ? "bg-muted ring-1 ring-ring"
-                                : ""
-                            }`}
-                            id={`manual-payment-invoice-option-${invoiceOption.value}`}
-                            key={invoiceOption.value}
-                            role="option"
-                            tabIndex={-1}
-                            type="button"
-                            onClick={() => {
-                              selectInvoiceOption(invoiceOption);
-                            }}
-                            onMouseEnter={() => setFocusedInvoiceIndex(index)}
-                          >
-                            <span className="w-full py-2 pr-0 pl-0 sm:w-2/6 sm:py-3 sm:pr-2">
-                              <span className="block truncate text-sm font-medium leading-5 text-foreground">
-                                {invoiceOption.label}
+                        {invoices.length ? (
+                          invoices.map((invoiceOption, index) => (
+                            <button
+                              aria-selected={
+                                invoice?.value === invoiceOption.value
+                              }
+                              className={`flex w-full cursor-pointer flex-col gap-2 p-2 text-left hover:bg-muted focus:outline-none sm:flex-row sm:items-center sm:justify-between sm:gap-0 ${
+                                focusedInvoiceIndex === index
+                                  ? "bg-muted ring-1 ring-ring"
+                                  : ""
+                              }`}
+                              id={`manual-payment-invoice-option-${invoiceOption.value}`}
+                              key={invoiceOption.value}
+                              role="option"
+                              tabIndex={-1}
+                              type="button"
+                              onClick={() => {
+                                selectInvoiceOption(invoiceOption);
+                              }}
+                              onMouseEnter={() => setFocusedInvoiceIndex(index)}
+                            >
+                              <span className="w-full py-2 pr-0 pl-0 sm:w-2/6 sm:py-3 sm:pr-2">
+                                <span className="block truncate text-sm font-medium leading-5 text-foreground">
+                                  {invoiceOption.label}
+                                </span>
+                                <span className="block pt-1 text-sm font-normal leading-5 text-muted-foreground">
+                                  {invoiceOption.invoiceNumber}
+                                </span>
                               </span>
-                              <span className="block pt-1 text-sm font-normal leading-5 text-muted-foreground">
-                                {invoiceOption.invoiceNumber}
-                              </span>
-                            </span>
-                            <span className="w-full px-0 py-2 sm:w-2/6 sm:px-2 sm:py-3 sm:text-right">
-                              <span className="block text-base font-bold leading-5 text-foreground">
-                                {baseCurrency &&
-                                  currencyFormat(
-                                    baseCurrency,
-                                    invoiceOption.amount
+                              <span className="w-full px-0 py-2 sm:w-2/6 sm:px-2 sm:py-3 sm:text-right">
+                                <span className="block text-base font-bold leading-5 text-foreground">
+                                  {baseCurrency &&
+                                    currencyFormat(
+                                      baseCurrency,
+                                      invoiceOption.amount
+                                    )}
+                                </span>
+                                <span className="block pt-1 text-sm font-medium leading-5 text-muted-foreground">
+                                  {dayjs(invoiceOption.invoiceDate).format(
+                                    dateFormat
                                   )}
+                                </span>
                               </span>
-                              <span className="block pt-1 text-sm font-medium leading-5 text-muted-foreground">
-                                {dayjs(invoiceOption.invoiceDate).format(
-                                  dateFormat
-                                )}
+                              <span className="w-full py-1 pl-0 pr-0 text-sm font-semibold leading-4 tracking-wider sm:w-2/6 sm:py-3 sm:pl-2 sm:text-right">
+                                <Badge
+                                  className={`${getStatusCssClass(
+                                    invoiceOption.status
+                                  )} uppercase`}
+                                  text={invoiceOption.status}
+                                />
                               </span>
-                            </span>
-                            <span className="w-full py-1 pl-0 pr-0 text-sm font-semibold leading-4 tracking-wider sm:w-2/6 sm:py-3 sm:pl-2 sm:text-right">
-                              <Badge
-                                className={`${getStatusCssClass(
-                                  invoiceOption.status
-                                )} uppercase`}
-                                text={invoiceOption.status}
-                              />
-                            </span>
-                          </button>
-                        ))}
+                            </button>
+                          ))
+                        ) : (
+                          <div
+                            aria-disabled="true"
+                            className="flex min-h-24 flex-col justify-center px-4 py-3"
+                            role="option"
+                          >
+                            <p className="text-sm font-medium text-foreground">
+                              {i18n.t("payments.noInvoicesAvailable")}
+                            </p>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                              {i18n.t(
+                                "payments.createInvoiceFirstToAddPayment"
+                              )}
+                            </p>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -804,6 +804,8 @@ const en = {
     manualEntryAdded: "Manual entry added successfully.",
     failedToAddManualEntry: "Failed to add manual entry",
     searchByClientOrInvoice: "Search by client name or invoice ID",
+    noInvoicesAvailable: "No invoices available",
+    createInvoiceFirstToAddPayment: "Create an invoice first to add a payment",
     selectTransactionTypeBtn: "Select Transaction Type",
     noPaymentFound: "No payment found!",
   },

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -188,6 +188,23 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
       end
     end
 
+    context "when there are no invoices available" do
+      let!(:invoice) { nil }
+
+      it "shows an empty state in the manual payment invoice dropdown" do
+        with_forgery_protection do
+          open_manual_payment_modal
+
+          find("[data-testid='manual-payment-invoice-select']", wait: 10).click
+
+          within("[data-testid='manual-payment-invoice-options']") do
+            expect(page).to have_content("No invoices available", wait: 10)
+            expect(page).to have_content("Create an invoice first to add a payment")
+          end
+        end
+      end
+    end
+
     it "keeps selected payment values visible when the save fails" do
       with_forgery_protection do
         open_manual_payment_modal

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -201,6 +201,13 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
             expect(page).to have_content("No invoices available", wait: 10)
             expect(page).to have_content("Create an invoice first to add a payment")
           end
+
+          page.driver.browser.keyboard.type(:Escape)
+
+          expect(page).not_to have_css(
+            "[data-testid='manual-payment-invoice-options']",
+            wait: 10
+          )
         end
       end
     end


### PR DESCRIPTION
## Summary
- Show a clear empty state inside the Add Payment invoice dropdown when no invoices are available
- Keep keyboard activation useful for the empty dropdown and allow Escape to close it
- Add a system regression spec for the no-invoice manual payment flow

Fixes #2278

## Verification
- `rtk mise exec -- pnpm exec eslint app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx app/javascript/src/i18n/locales/en.ts`
- `rtk mise exec -- timeout 30 bin/vite build`
- `rtk mise exec -- timeout 180 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb:194`
- `rtk mise exec -- timeout 240 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb`
- `rtk mise exec -- bundle exec rubocop spec/system/payments/create_spec.rb`
- `rtk git diff --check`
- `script/enforce_council_gate.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment form now shows a clear “No invoices available” message with guidance to create an invoice first, and the invoice selector handles keyboard input (Escape closes the menu and returns focus) for improved accessibility.

* **Localization**
  * Added English copy for the empty-invoice messaging.

* **Tests**
  * Added system tests covering the empty-invoice workflow and keyboard behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2281)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->