### PR TITLE
fix: normalize payment modal input borders

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -412,6 +412,7 @@ const PaymentEntryForm = ({
                   value={
                     transactionDate && dayjs(transactionDate).format(dateFormat)
                   }
+                  wrapperClassName="outline-none relative h-12"
                   onChange={() => {}}
                 />
                 <CalendarIcon
@@ -547,6 +548,7 @@ const PaymentEntryForm = ({
                 step="0.01"
                 type="number"
                 value={amount ?? ""}
+                wrapperClassName="outline-none relative h-12"
                 onChange={e => setFieldValue("amount", e.target.value)}
               />
             </div>
@@ -558,6 +560,7 @@ const PaymentEntryForm = ({
                 name="NotesOptional"
                 rows={5}
                 value={note}
+                wrapperClassName="outline-none relative"
                 onChange={e => setFieldValue("note", e.target.value)}
               />
             </div>

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -154,7 +154,9 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
 
         wrapper_styles.each_value do |styles|
           expect(styles.fetch("className").split).to include("outline-none")
-          expect(styles.fetch("outlineColor")).to eq("rgba(0, 0, 0, 0)")
+          expect(["rgba(0, 0, 0, 0)", "transparent"]).to include(
+            styles.fetch("outlineColor")
+          )
         end
       end
     end

--- a/spec/system/payments/create_spec.rb
+++ b/spec/system/payments/create_spec.rb
@@ -126,6 +126,39 @@ RSpec.describe "Adding payment entry", type: :system, js: true do
       end
     end
 
+    it "keeps manual payment form fields on the same border treatment" do
+      with_forgery_protection do
+        open_manual_payment_modal
+
+        wrapper_styles = page.evaluate_script(<<~JS)
+          (() => {
+            return ["transactionDate", "paymentAmount", "NotesOptional"].reduce(
+              (stylesByField, fieldId) => {
+                const field = document.getElementById(fieldId);
+                const wrapper = field?.parentElement;
+                const wrapperStyles = wrapper
+                  ? window.getComputedStyle(wrapper)
+                  : null;
+
+                stylesByField[fieldId] = {
+                  className: wrapper?.className || "",
+                  outlineColor: wrapperStyles?.outlineColor || "",
+                };
+
+                return stylesByField;
+              },
+              {}
+            );
+          })()
+        JS
+
+        wrapper_styles.each_value do |styles|
+          expect(styles.fetch("className").split).to include("outline-none")
+          expect(styles.fetch("outlineColor")).to eq("rgba(0, 0, 0, 0)")
+        end
+      end
+    end
+
     it "creates a manual payment after selecting a desktop transaction type" do
       with_forgery_protection do
         visit "/payments?invoiceId=#{invoice.id}"


### PR DESCRIPTION
Fixes #2280

## Summary
- normalize Add Payment modal custom input wrappers so Transaction Date, Payment Amount, and Notes use the same transparent outline treatment as the other modal fields
- add a system spec that opens the Add Payment modal and verifies the affected wrappers resolve to transparent outlines

## Verification
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
- rtk mise exec -- bundle exec rubocop spec/system/payments/create_spec.rb
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- timeout 180 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb:129
- rtk mise exec -- timeout 240 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/create_spec.rb
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined styling for form fields in the payment entry modal to ensure consistent wrapper layout and visual presentation for date, amount, and notes inputs.

* **Tests**
  * Added system test coverage to verify wrapper styling and border/outline treatment for the payment entry form.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2282)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->