### PR TITLE
fix: soften profile logout action

### DIFF
--- a/app/javascript/src/components/Profile/Personal/User/PersonalProfileSummary.tsx
+++ b/app/javascript/src/components/Profile/Personal/User/PersonalProfileSummary.tsx
@@ -203,9 +203,9 @@ const PersonalProfileSummary = ({
                 </CardHeader>
                 <CardContent>
                   <Button
-                    variant="destructive"
+                    variant="outline"
                     size="sm"
-                    className="w-full gap-2 font-geist-medium"
+                    className="w-full gap-2 border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive font-geist-medium"
                     data-testid="profile-settings-logout-button"
                     onClick={handleLogout}
                   >

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -57,6 +57,38 @@ RSpec.describe "Profile Settings", type: :system, js: true do
     end
   end
 
+  it "renders the profile logout action as a subtle destructive control" do
+    with_forgery_protection do
+      visit "/settings/profile"
+
+      logout_button_selector = "[data-testid='profile-settings-logout-button']"
+
+      expect(page).to have_css("#react-root", wait: 10)
+      expect(page).to have_css(logout_button_selector, wait: 10)
+
+      logout_button = find(logout_button_selector)
+      logout_classes = logout_button[:class]
+      logout_styles = page.evaluate_script(<<~JS)
+        (() => {
+          const button = document.querySelector("#{logout_button_selector}");
+          const styles = window.getComputedStyle(button);
+
+          return {
+            backgroundColor: styles.backgroundColor,
+            color: styles.color
+          };
+        })();
+      JS
+
+      expect(logout_classes).to include("border-destructive/30")
+      expect(logout_classes).to include("text-destructive")
+      expect(logout_classes).to include("hover:bg-destructive/10")
+      expect(logout_classes).not_to include("bg-red-500")
+      expect(logout_classes).not_to include("text-white")
+      expect(logout_styles["backgroundColor"]).not_to eq("rgb(239, 68, 68)")
+    end
+  end
+
   it "boots the app in the user's saved locale" do
     user.update!(locale: "hi")
 


### PR DESCRIPTION
Fixes #2279

## Summary
- renders the Profile Account logout action as an outline destructive-secondary button instead of a filled red CTA
- adds a system spec that guards against the filled red logout styling returning

## Verification
- rtk mise exec -- pnpm install --frozen-lockfile
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/Profile/Personal/User/PersonalProfileSummary.tsx
- rtk mise exec -- bundle exec rubocop spec/system/profile/settings_spec.rb
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- timeout 180 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/profile/settings_spec.rb:60 --format documentation
- rtk mise exec -- timeout 240 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/profile/settings_spec.rb --format documentation
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified logout button styling for a more subtle visual appearance.

* **Tests**
  * Added system test to verify logout button styling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2284)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->