### PR TITLE
Fix payment bulk selection actions

### DIFF
--- a/app/javascript/src/components/payments/PaymentsTable.tsx
+++ b/app/javascript/src/components/payments/PaymentsTable.tsx
@@ -35,6 +35,7 @@ import {
   ArrowDown,
   CaretUp,
   CaretDown,
+  Copy,
 } from "phosphor-react";
 import { currencyFormat } from "../../helpers/currency";
 import { useUserContext } from "../../context/UserContext";
@@ -187,6 +188,23 @@ const PaymentsTable: React.FC = () => {
       );
     } finally {
       setWithdrawingPaymentId(null);
+    }
+  };
+
+  const copySelectedTransactionIds = async (selectedPayments: Payment[]) => {
+    const transactionIds = selectedPayments
+      .map(payment => payment.transactionId)
+      .filter(Boolean);
+
+    try {
+      await navigator.clipboard.writeText(transactionIds.join("\n"));
+      toast.success(
+        i18n.t("payments.transactionIdsCopied", {
+          count: transactionIds.length,
+        })
+      );
+    } catch {
+      toast.error(i18n.t("payments.transactionIdsCopyFailed"));
     }
   };
 
@@ -639,6 +657,16 @@ const PaymentsTable: React.FC = () => {
               <DataTable
                 columns={columns}
                 data={visiblePayments}
+                renderSelectedRowsActions={({ selectedRows }) => (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => copySelectedTransactionIds(selectedRows)}
+                  >
+                    <Copy className="mr-2 h-4 w-4" />
+                    {i18n.t("payments.copyTransactionIds")}
+                  </Button>
+                )}
                 searchPlaceholder={i18n.t(
                   "payments.searchByInvoiceClientMethodOrNotes"
                 )}

--- a/app/javascript/src/components/ui/checkbox.tsx
+++ b/app/javascript/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-gray-300 bg-background ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-gray-50 data-[state=checked]:border-gray-900",
+      "peer h-4 w-4 shrink-0 rounded-[3px] border border-input bg-background text-primary-foreground shadow-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}

--- a/app/javascript/src/components/ui/data-table.tsx
+++ b/app/javascript/src/components/ui/data-table.tsx
@@ -32,8 +32,15 @@ import {
   CaretRight,
   CaretDoubleLeft,
   CaretDoubleRight,
+  X,
 } from "phosphor-react";
 import { i18n } from "../../i18n";
+
+interface DataTableSelectionActions<TData> {
+  selectedRows: TData[];
+  filteredRows: TData[];
+  clearSelection: () => void;
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -43,6 +50,9 @@ interface DataTableProps<TData, TValue> {
   showColumnVisibility?: boolean;
   showPagination?: boolean;
   onRowClick?: (row: TData) => void;
+  renderSelectedRowsActions?: (
+    actions: DataTableSelectionActions<TData>
+  ) => React.ReactNode;
 }
 
 export function DataTable<TData, TValue>({
@@ -53,6 +63,7 @@ export function DataTable<TData, TValue>({
   showColumnVisibility = false,
   showPagination = true,
   onRowClick,
+  renderSelectedRowsActions,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -86,6 +97,17 @@ export function DataTable<TData, TValue>({
       globalFilter,
     },
   });
+
+  const selectedRows = table
+    .getFilteredSelectedRowModel()
+    .rows.map(row => row.original);
+
+  const filteredRows = table
+    .getFilteredRowModel()
+    .rows.map(row => row.original);
+
+  const selectedRowCount = selectedRows.length;
+  const clearSelection = () => table.resetRowSelection();
 
   return (
     <div className="w-full">
@@ -121,6 +143,38 @@ export function DataTable<TData, TValue>({
           </DropdownMenu>
         )}
       </div>
+      {selectedRowCount > 0 && (
+        <div
+          className="mb-3 flex flex-col gap-3 rounded-md border border-border bg-muted/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+          data-testid="data-table-selection-toolbar"
+        >
+          <span
+            className="text-sm font-medium text-foreground"
+            data-testid="data-table-selection-count"
+          >
+            {i18n.t("dataTable.rowsSelected", {
+              selected: selectedRowCount,
+              total: filteredRows.length,
+            })}
+          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            {renderSelectedRowsActions?.({
+              selectedRows,
+              filteredRows,
+              clearSelection,
+            })}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearSelection}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="mr-2 h-4 w-4" />
+              {i18n.t("dataTable.clearSelection")}
+            </Button>
+          </div>
+        </div>
+      )}
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -161,6 +161,7 @@ const en = {
   dataTable: {
     noResults: "No results.",
     rowsSelected: "%{selected} of %{total} row(s) selected.",
+    clearSelection: "Clear selection",
     pageOf: "Page %{page} of %{total}",
   },
 
@@ -754,6 +755,9 @@ const en = {
     withdrawal: "Withdrawal",
     openMenu: "Open menu",
     copyTransactionId: "Copy transaction ID",
+    copyTransactionIds: "Copy transaction IDs",
+    transactionIdsCopied: "%{count} transaction ID(s) copied.",
+    transactionIdsCopyFailed: "Failed to copy transaction IDs.",
     viewInvoice: "View invoice",
     downloadReceipt: "Download receipt",
     withdrawToUpi: "Withdraw to UPI",

--- a/spec/system/payments/list_spec.rb
+++ b/spec/system/payments/list_spec.rb
@@ -132,6 +132,46 @@ RSpec.describe "Payments page", type: :system, js: true do
         end
       end
     end
+
+    it "shows bulk actions and readable dark-mode checkboxes after selecting payments" do
+      with_forgery_protection do
+        visit "/payments"
+        page.execute_script("localStorage.setItem('miru-theme', 'dark')")
+        page.execute_script("document.documentElement.classList.add('dark')")
+        visit "/payments"
+
+        expect(page).to have_content("INV-PAY-001", wait: 10)
+
+        select_all = find("[role='checkbox'][aria-label='Select all']", wait: 10)
+        checkbox_styles = page.evaluate_script(<<~JS)
+          (() => {
+            const checkbox = document.querySelector("[role='checkbox'][aria-label='Select all']");
+            const styles = window.getComputedStyle(checkbox);
+
+            return {
+              backgroundColor: styles.backgroundColor,
+              borderColor: styles.borderColor,
+              borderRadius: styles.borderRadius,
+              borderWidth: styles.borderWidth
+            };
+          })()
+        JS
+
+        expect(checkbox_styles["borderColor"]).not_to eq("rgba(0, 0, 0, 0)")
+        expect(checkbox_styles["borderWidth"]).to eq("1px")
+        expect(checkbox_styles["borderRadius"].to_f).to be <= 4
+
+        select_all.click
+
+        expect(page).to have_css("[data-testid='data-table-selection-toolbar']", wait: 10)
+        expect(page).to have_css("[data-testid='data-table-selection-count']", text: "3 of 3 row(s) selected.")
+        expect(page).to have_button("Copy transaction IDs")
+        expect(page).to have_button("Clear selection")
+
+        find("button", text: "Clear selection").click
+        expect(page).to have_no_css("[data-testid='data-table-selection-toolbar']")
+      end
+    end
   end
 
   context "when there are no payments" do


### PR DESCRIPTION
## Summary
- show a selected-row action toolbar for payments when rows are selected
- add a bulk copy transaction IDs action
- make shared checkbox styling readable and square in dark mode

Fixes #2283

## Verification
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/payments/PaymentsTable.tsx app/javascript/src/components/ui/checkbox.tsx app/javascript/src/components/ui/data-table.tsx
- rtk mise exec -- bundle exec rubocop spec/system/payments/list_spec.rb
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- timeout 180 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/list_spec.rb:136 --format documentation
- rtk mise exec -- timeout 240 env RAILS_ENV=test NODE_ENV=test SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/system/payments/list_spec.rb --format documentation
- rtk git diff --check
- rtk mise exec -- script/enforce_council_gate.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk copy functionality to copy transaction IDs from selected payment rows to your clipboard
  * Selection toolbar displays count of selected rows with a clear selection button

* **Style**
  * Updated checkbox styling for improved appearance

* **Tests**
  * Added system test for bulk transaction ID copy and selection features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2285)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->