### PR TITLE
fix: exclude discarded employments from dashboard team size count

### DIFF
--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -355,7 +355,7 @@ class DashboardPresenter
 
     def team_size
       return 1 if employee_scoped?
-      return company.users.count unless client_scoped?
+      return company.employments.kept.count unless client_scoped?
 
       scoped_projects.joins(:project_members).distinct.count("project_members.user_id")
     end

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -355,7 +355,7 @@ class DashboardPresenter
 
     def team_size
       return 1 if employee_scoped?
-      return company.employments.kept.count unless client_scoped?
+      return company.employments.kept.select(:user_id).distinct.count unless client_scoped?
 
       scoped_projects.joins(:project_members).distinct.count("project_members.user_id")
     end

--- a/spec/requests/api/v1/dashboard/index_spec.rb
+++ b/spec/requests/api/v1/dashboard/index_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe "Api::V1::Dashboard#index", type: :request do
     it "returns dashboard data" do
       expect(json_response).to be_a(Hash)
     end
+
+    it "counts distinct users with kept employments as team size" do
+      teammate = create(:user, current_workspace_id: company.id)
+      former_teammate = create(:user, current_workspace_id: company.id)
+
+      create(:employment, company:, user:)
+      create(:employment, company:, user: teammate)
+      discarded_employment = create(:employment, company:, user: former_teammate)
+      discarded_employment.discard!
+
+      send_request :get, api_v1_dashboard_index_path, headers: auth_headers(user)
+
+      expect(json_response.dig("stats", "team_size")).to eq(2)
+    end
   end
 
   context "when user is an employee" do


### PR DESCRIPTION
Fixes #2286 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard team-size calculation to count only active employments, ensuring the displayed team size reflects current members rather than a broader user count.
  * Team-size display now consistently represents actual team membership across user scopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->