### PR TITLE
fix: stabilize team delete confirmation modal

### DIFF
--- a/app/javascript/src/components/Team/TeamTable.tsx
+++ b/app/javascript/src/components/Team/TeamTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { ColumnDef } from "@tanstack/react-table";
@@ -88,6 +88,15 @@ interface RemovalImpact {
   hasRisk: boolean;
 }
 
+const formatDeleteImpactProjectNames = (projectNames: string[]) => {
+  if (!projectNames.length) return "";
+
+  const visibleProjectNames = projectNames.slice(0, 2).join(", ");
+  const truncatedSuffix = projectNames.length > 2 ? ", ..." : "";
+
+  return ` (${visibleProjectNames}${truncatedSuffix})`;
+};
+
 const fetchTeamMembers = async (): Promise<TeamData> => {
   const response = await teamApi.get("page=1&items=1000");
   const teamMembers = unmapList(response);
@@ -108,7 +117,7 @@ const TeamTable: React.FC = () => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
   const [deleteImpact, setDeleteImpact] = useState<RemovalImpact | null>(null);
-  const [loadingDeleteImpact, setLoadingDeleteImpact] = useState(false);
+  const deleteImpactRequestIdRef = useRef(0);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["team"],
@@ -212,18 +221,25 @@ const TeamTable: React.FC = () => {
   };
 
   const handleDelete = async (member: TeamMember) => {
+    const requestId = ++deleteImpactRequestIdRef.current;
+
     setSelectedMember(member);
     setDeleteImpact(null);
-    setShowDeleteDialog(true);
-    setLoadingDeleteImpact(true);
 
     try {
       const response = await teamApi.getRemovalImpact(member.id);
+      if (requestId !== deleteImpactRequestIdRef.current) return;
+
       setDeleteImpact(response.data?.removalImpact || null);
     } catch {
+      if (requestId !== deleteImpactRequestIdRef.current) return;
+
+      setDeleteImpact(null);
       toast.error(i18n.t("team.failedToLoadTeamMembers"));
     } finally {
-      setLoadingDeleteImpact(false);
+      if (requestId === deleteImpactRequestIdRef.current) {
+        setShowDeleteDialog(true);
+      }
     }
   };
 
@@ -700,48 +716,40 @@ const TeamTable: React.FC = () => {
             <DialogDescription>
               {i18n.t("team.deleteUserConfirm", { name: selectedMember?.name })}
             </DialogDescription>
-            {loadingDeleteImpact ? (
-              <p className="text-sm text-muted-foreground">
-                Checking active assignments and uninvoiced work...
-              </p>
-            ) : (
-              deleteImpact?.hasRisk && (
-                <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
-                  <p className="font-medium">
-                    Warning: This member has active work in this workspace.
-                  </p>
-                  <ul className="mt-2 list-disc space-y-1 pl-5">
-                    {deleteImpact.projectAssignmentsCount > 0 && (
-                      <li>
-                        Assigned to {deleteImpact.projectAssignmentsCount}{" "}
-                        {deleteImpact.projectAssignmentsCount === 1
-                          ? "project"
-                          : "projects"}
-                        {deleteImpact.projectNames.length > 0 &&
-                          ` (${deleteImpact.projectNames
-                            .slice(0, 2)
-                            .join(", ")}${
-                            deleteImpact.projectNames.length > 2 ? ", ..." : ""
-                          })`}
-                      </li>
-                    )}
-                    {deleteImpact.unbilledEntriesCount > 0 && (
-                      <li>
-                        {(
+            {deleteImpact?.hasRisk && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+                <p className="font-medium">
+                  {i18n.t("team.deleteImpact.warningTitle")}
+                </p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {deleteImpact.projectAssignmentsCount > 0 && (
+                    <li>
+                      {i18n.t("team.deleteImpact.assignedProjects", {
+                        count: deleteImpact.projectAssignmentsCount,
+                        projectNames: formatDeleteImpactProjectNames(
+                          deleteImpact.projectNames
+                        ),
+                      })}
+                    </li>
+                  )}
+                  {deleteImpact.unbilledEntriesCount > 0 && (
+                    <li>
+                      {i18n.t("team.deleteImpact.unbilledHours", {
+                        amount: Number(
+                          deleteImpact.uninvoicedAmount || 0
+                        ).toFixed(2),
+                        count: deleteImpact.unbilledEntriesCount,
+                        hours: (
                           Number(deleteImpact.unbilledMinutes || 0) / 60
-                        ).toFixed(1)}{" "}
-                        unbilled hours across{" "}
-                        {deleteImpact.unbilledEntriesCount} entries (estimated
-                        value: $
-                        {Number(deleteImpact.uninvoicedAmount || 0).toFixed(2)})
-                      </li>
-                    )}
-                    {deleteImpact.invoicedEntriesCount === 0 && (
-                      <li>No billed entries found for this member.</li>
-                    )}
-                  </ul>
-                </div>
-              )
+                        ).toFixed(1),
+                      })}
+                    </li>
+                  )}
+                  {deleteImpact.invoicedEntriesCount === 0 && (
+                    <li>{i18n.t("team.deleteImpact.noBilledEntries")}</li>
+                  )}
+                </ul>
+              </div>
             )}
           </DialogHeader>
           <DialogFooter>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -439,6 +439,19 @@ const en = {
     deleteInvite: "Delete Invite",
     deleteUserConfirm:
       "Are you sure you want to delete user %{name}? This action cannot be reversed.",
+    deleteImpact: {
+      warningTitle: "Warning: This member has active work in this workspace.",
+      assignedProjects: {
+        one: "Assigned to %{count} project%{projectNames}",
+        other: "Assigned to %{count} projects%{projectNames}",
+      },
+      unbilledHours: {
+        one: "%{hours} unbilled hours across %{count} entry (estimated value: $%{amount})",
+        other:
+          "%{hours} unbilled hours across %{count} entries (estimated value: $%{amount})",
+      },
+      noBilledEntries: "No billed entries found for this member.",
+    },
     admin: "Admin",
     employee: "Employee",
     bookkeeper: "Bookkeeper",

--- a/spec/system/teams/index_spec.rb
+++ b/spec/system/teams/index_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Team Member", type: :system, js: true do
 
           expect(page).to have_content(employee_user.email, wait: 10)
 
-          all("button", text: "Open menu").last.click
+          find("tr", text: employee_user.email, wait: 10).find("button", text: "Open menu").click
 
           find("[role='menuitem']", text: "Delete User", wait: 10).click
           within("[role='dialog']") do
@@ -126,6 +126,46 @@ RSpec.describe "Team Member", type: :system, js: true do
           end
 
           expect(page).to have_no_content(employee_user.email, wait: 10)
+        end
+      end
+
+      it "opens the delete confirmation with stable member copy" do
+        with_forgery_protection do
+          visit "/team"
+
+          expect(page).to have_content(employee_user.email, wait: 10)
+
+          page.execute_script(<<~JS)
+            window.__teamDeleteDialogTexts = [];
+            new MutationObserver(() => {
+              const dialog = document.querySelector("[role='dialog']");
+              if (dialog) window.__teamDeleteDialogTexts.push(dialog.innerText);
+            }).observe(document.body, {
+              childList: true,
+              characterData: true,
+              subtree: true
+            });
+          JS
+
+          find("tr", text: employee_user.email, wait: 10).find("button", text: "Open menu").click
+          find("[role='menuitem']", text: "Delete User", wait: 10).click
+
+          within("[role='dialog']") do
+            expect(page).to have_text(
+              "Are you sure you want to delete user #{employee_user.full_name}? This action cannot be reversed.",
+              wait: 10
+            )
+            expect(page).to have_no_text("Checking active assignments")
+            expect(page).to have_no_text("undefined")
+            expect(page).to have_no_text("%{name}")
+          end
+
+          observed_text = page.evaluate_script("window.__teamDeleteDialogTexts.join('\\n')")
+
+          expect(observed_text).to include(employee_user.full_name)
+          expect(observed_text).not_to include("Checking active assignments")
+          expect(observed_text).not_to include("undefined")
+          expect(observed_text).not_to include("%{name}")
         end
       end
     end


### PR DESCRIPTION
Fixes #2292.

Root cause: the Team delete dialog opened before the removal-impact request completed, so transient loading copy rendered briefly and then disappeared.

Verification:
- CI=1 rtk mise exec -- bundle exec rspec spec/system/teams/index_spec.rb:132
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/requests/api/v1/team/removal_impact_spec.rb spec/requests/api/v1/team/destroy_spec.rb
- rtk mise exec -- timeout 30 bin/vite build
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/Team/TeamTable.tsx
- Browser verified /team delete modal on local app: stable dialog copy, no transient loading text, no console errors, no failed requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delete confirmation now reliably shows complete, stable copy (no loading text or placeholders) and displays risk warnings only when applicable.
* **Localization**
  * Added/updated translations for the member-deletion warning, including project and unbilled-hours phrasing.
* **Refactor**
  * Simplified member-deletion workflow to improve stability and ensure the confirmation dialog reflects the latest removal-impact data.
* **Tests**
  * System test added to verify the delete dialog renders correct confirmation text and omits placeholder strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2293)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->