### PR TITLE
feat: aggregate invoice time entries by project

### DIFF
--- a/app/javascript/src/components/Invoices/MultipleEntriesModal/Filters/index.tsx
+++ b/app/javascript/src/components/Invoices/MultipleEntriesModal/Filters/index.tsx
@@ -37,7 +37,8 @@ const Filters = ({
   const isResetActive =
     filters.teamMembers.length > 0 ||
     filters.dateRange.label !== "All" ||
-    filters.searchTerm !== "";
+    filters.searchTerm !== "" ||
+    filters.groupByProject;
 
   useEffect(() => {
     const { value, from, to } = filterParams.dateRange;
@@ -224,6 +225,17 @@ const Filters = ({
           setFilters={setFilters}
           teamMembers={teamMembers}
         />
+        <label className="ml-2 flex items-center gap-2 text-sm font-medium text-foreground">
+          <input
+            checked={filters.groupByProject}
+            className="h-4 w-4 accent-primary"
+            type="checkbox"
+            onChange={e =>
+              setFilters({ ...filters, groupByProject: e.target.checked })
+            }
+          />
+          {i18n.t("invoices.groupByProject")}
+        </label>
         <div className="ml-2 w-1/2 lg:w-auto">
           <Select
             name="dateRange"

--- a/app/javascript/src/components/Invoices/MultipleEntriesModal/TimeEntrySelectionTable.tsx
+++ b/app/javascript/src/components/Invoices/MultipleEntriesModal/TimeEntrySelectionTable.tsx
@@ -30,6 +30,17 @@ const TimeEntrySelectionTable = ({
   dateFormat,
 }) => {
   const { isDesktop } = useUserContext();
+  const selectionId = item => item.selection_id || item.timesheet_entry_id;
+  const formattedDate = item => {
+    if (item.date_range) {
+      return item.date_range
+        .split(" - ")
+        .map(date => dayjs(date).format(dateFormat))
+        .join(" - ");
+    }
+
+    return dayjs(item.date).format(dateFormat);
+  };
 
   return (
     <table className="table__width mt-0 lg:mt-4">
@@ -48,9 +59,12 @@ const TimeEntrySelectionTable = ({
               </div>
             </th>
             <th className="table__header w-1/5 p-3 text-left">
+              {i18n.t("project")}
+            </th>
+            <th className="table__header w-1/5 p-3 text-left">
               {i18n.t("invoices.nameHeader")}
             </th>
-            <th className="table__header w-3/5 p-3 text-left">
+            <th className="table__header w-2/5 p-3 text-left">
               {i18n.t("invoices.descriptionHeader")}
             </th>
             <th className="table__header p-3 text-right">
@@ -87,7 +101,7 @@ const TimeEntrySelectionTable = ({
       <tbody>
         {lineItems.map((item, index) => {
           const hoursLogged = minToHHMM(item.quantity);
-          const date = dayjs(item.date).format(dateFormat);
+          const date = formattedDate(item);
 
           return isDesktop ? (
             <tr key={index}>
@@ -97,17 +111,18 @@ const TimeEntrySelectionTable = ({
                     checked={item.checked}
                     className="custom__checkbox absolute h-8 w-8 opacity-0"
                     type="checkbox"
-                    onChange={() =>
-                      handleItemSelection(item.timesheet_entry_id)
-                    }
+                    onChange={() => handleItemSelection(selectionId(item))}
                   />
                   <CheckboxIcon />
                 </div>
               </td>
               <td className="table__data w-1/5 text-left text-left text-sm font-medium text-foreground">
+                {item.project_name}
+              </td>
+              <td className="table__data w-1/5 text-left text-left text-sm font-medium text-foreground">
                 {item.first_name} {item.last_name}
               </td>
-              <td className="table__data w-3/5 whitespace-normal text-left text-xs font-medium text-muted-foreground">
+              <td className="table__data w-2/5 whitespace-normal text-left text-xs font-medium text-muted-foreground">
                 {item.description}
               </td>
               <td className="table__data text-right text-xs font-medium text-foreground">
@@ -126,15 +141,18 @@ const TimeEntrySelectionTable = ({
                       checked={item.checked}
                       className="custom__checkbox absolute h-4 w-4 opacity-0"
                       type="checkbox"
-                      onChange={() =>
-                        handleItemSelection(item.timesheet_entry_id)
-                      }
+                      onChange={() => handleItemSelection(selectionId(item))}
                     />
                     <CheckboxIcon />
                   </div>
                 </td>
                 <td className="w-1/2 pt-3 text-left text-left text-sm font-medium text-foreground">
-                  {item.first_name} {item.last_name}
+                  {item.project_name}
+                  {item.first_name || item.last_name ? (
+                    <span className="block text-xs text-muted-foreground">
+                      {item.first_name} {item.last_name}
+                    </span>
+                  ) : null}
                 </td>
                 <td className="pt-3 text-right text-xs font-medium text-foreground">
                   {date} • {hoursLogged}

--- a/app/javascript/src/components/Invoices/MultipleEntriesModal/index.tsx
+++ b/app/javascript/src/components/Invoices/MultipleEntriesModal/index.tsx
@@ -9,6 +9,13 @@ import TimeEntrySelectionTable from "./TimeEntrySelectionTable";
 import { fetchMultipleNewLineItems } from "../common/utils";
 import { i18n } from "../../../i18n";
 
+const selectedEntryIds = entry =>
+  entry.linked_timesheet_entry_ids?.length
+    ? entry.linked_timesheet_entry_ids
+    : [entry.timesheet_entry_id].filter(Boolean);
+
+const selectionId = item => item.selection_id || item.timesheet_entry_id;
+
 const MultipleEntriesModal = ({
   selectedClient,
   selectedOption,
@@ -21,6 +28,7 @@ const MultipleEntriesModal = ({
     teamMembers: [],
     dateRange: { label: "All", value: "all", from: "", to: "" },
     searchTerm: "",
+    groupByProject: false,
   };
 
   const [lineItems, setLineItems] = useState<any>([]);
@@ -34,10 +42,10 @@ const MultipleEntriesModal = ({
 
   const handleItemSelection = id => {
     const checkboxes = lineItems.map(item => {
-      if (item.timesheet_entry_id === id) {
+      if (selectionId(item) === id) {
         if (item.checked) {
           const selectedItem = selectedLineItems.filter(
-            lineItem => lineItem.timesheet_entry_id !== item.timesheet_entry_id
+            lineItem => selectionId(lineItem) !== selectionId(item)
           );
           setSelectedLineItems(selectedItem);
           setAllCheckboxSelected(false);
@@ -63,7 +71,7 @@ const MultipleEntriesModal = ({
       checked: e.target.checked,
     }));
     if (e.target.checked) {
-      setSelectedLineItems(lineItems);
+      setSelectedLineItems(checkedLineItems);
     } else {
       setSelectedLineItems([]);
     }
@@ -102,7 +110,9 @@ const MultipleEntriesModal = ({
 
     selectedOption.forEach(entry => {
       if (!entry._destroy) {
-        filterQueryParams += `&selected_entries[]=${entry.timesheet_entry_id}`;
+        selectedEntryIds(entry).forEach(id => {
+          filterQueryParams += `&selected_entries[]=${id}`;
+        });
       }
     });
 
@@ -122,6 +132,10 @@ const MultipleEntriesModal = ({
       filterQueryParams += `&date_range=${value}`;
       filterQueryParams += `&from=${from}`;
       filterQueryParams += `&to=${to}`;
+    }
+
+    if (filterParams.groupByProject) {
+      filterQueryParams += "&group_by_project=true";
     }
 
     return `${filterQueryParams}`;

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
@@ -21,7 +21,8 @@ const LineItemEditorRow = ({
   dateFormat,
 }) => {
   const strName = getLineItemDisplayName(item);
-  const rowKey = item.id || item.timesheet_entry_id || strName;
+  const rowKey =
+    item.id || item.selection_id || item.timesheet_entry_id || strName;
   const [name, setName] = useState<string>(strName);
   const [lineItemDate, setLineItemDate] = useState<Date>(
     dayjs(item.date).isValid() ? dayjs(item.date).toDate() : new Date()
@@ -53,8 +54,15 @@ const LineItemEditorRow = ({
         item.timesheet_entry_id !== undefined &&
         item.timesheet_entry_id !== null;
 
+      const itemHasSelectionId =
+        item.selection_id !== undefined && item.selection_id !== null;
+
       if (itemHasId) {
         return option.id === item.id;
+      }
+
+      if (itemHasSelectionId) {
+        return option.selection_id === item.selection_id;
       }
 
       if (itemHasTimesheetEntryId) {

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/index.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/index.tsx
@@ -10,6 +10,8 @@ const NewLineItemRow = ({
   removeElement = false,
   dateFormat,
 }) => {
+  const selectionId = item => item.selection_id || item.timesheet_entry_id;
+
   const handleDelete = item => {
     const deleteItem = {
       ...item,
@@ -19,6 +21,7 @@ const NewLineItemRow = ({
     const selectedOptionArr = selectedOption.map(option => {
       if (
         (item.id && option.id === item.id) ||
+        (selectionId(item) && selectionId(option) === selectionId(item)) ||
         (option.timesheet_entry_id &&
           option.timesheet_entry_id === item.timesheet_entry_id)
       ) {

--- a/app/javascript/src/components/Invoices/common/NewLineItemTable/index.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemTable/index.tsx
@@ -62,7 +62,10 @@ const NewLineItemTable = ({
               >
                 <div className="flex w-full lg:hidden">
                   <span className="w-1/2 text-left text-sm font-medium text-foreground">
-                    {item.first_name} {item.last_name}
+                    {item.project_name}
+                    <span className="block text-xs text-muted-foreground">
+                      {item.first_name} {item.last_name}
+                    </span>
                   </span>
                   <span className="w-1/2 text-right text-xs font-medium text-foreground">
                     {date} • {hoursLogged}
@@ -72,7 +75,10 @@ const NewLineItemTable = ({
                   {item.description}
                 </span>
                 <span className="hidden w-1/5 text-left text-sm font-medium text-foreground lg:inline">
-                  {item.first_name} {item.last_name}
+                  {item.project_name}
+                  <span className="block text-xs text-muted-foreground">
+                    {item.first_name} {item.last_name}
+                  </span>
                 </span>
                 <span className="hidden w-3/5 whitespace-normal text-left text-xs font-medium text-muted-foreground lg:inline">
                   {item.description}

--- a/app/javascript/src/components/Invoices/common/utils.js
+++ b/app/javascript/src/components/Invoices/common/utils.js
@@ -4,9 +4,12 @@ import { lineTotalCalc } from "helpers";
 import { Toastr } from "StyledComponents";
 
 const selectedEntryIds = entry =>
-  entry.linked_timesheet_entry_ids?.length
-    ? entry.linked_timesheet_entry_ids
-    : [entry.timesheet_entry_id].filter(Boolean);
+  [
+    ...new Set([
+      entry.timesheet_entry_id,
+      ...(entry.linked_timesheet_entry_ids || []),
+    ]),
+  ].filter(Boolean);
 
 const selectionId = item => item.selection_id || item.timesheet_entry_id;
 

--- a/app/javascript/src/components/Invoices/common/utils.js
+++ b/app/javascript/src/components/Invoices/common/utils.js
@@ -3,6 +3,13 @@ import { invoiceLineItemsApi, invoicesApi } from "apis/api";
 import { lineTotalCalc } from "helpers";
 import { Toastr } from "StyledComponents";
 
+const selectedEntryIds = entry =>
+  entry.linked_timesheet_entry_ids?.length
+    ? entry.linked_timesheet_entry_ids
+    : [entry.timesheet_entry_id].filter(Boolean);
+
+const selectionId = item => item.selection_id || item.timesheet_entry_id;
+
 export const generateInvoiceLineItems = (
   selectedLineItems,
   manualEntryArr,
@@ -24,6 +31,7 @@ export const generateInvoiceLineItems = (
         timesheet_entry_id: item.time_sheet_entry
           ? item.time_sheet_entry
           : item.timesheet_entry_id,
+        linked_timesheet_entry_ids: item.linked_timesheet_entry_ids || [],
         _destroy: !!item._destroy,
       };
     })
@@ -59,7 +67,9 @@ export const fetchNewLineItems = async (
     let selectedEntriesString = "";
     selectedEntries.forEach(entry => {
       if (!entry._destroy) {
-        selectedEntriesString += `&selected_entries[]=${entry.timesheet_entry_id}`;
+        selectedEntryIds(entry).forEach(id => {
+          selectedEntriesString += `&selected_entries[]=${id}`;
+        });
       }
     });
     const queryParams = `client_id=${selectedClient.id}${selectedEntriesString}`;
@@ -83,13 +93,12 @@ export const fetchMultipleNewLineItems = async (
 ) => {
   const res = await invoiceLineItemsApi.getLineItems(handleFilterParams());
   const itemSelected = id =>
-    selectedLineItems.filter(
-      selectedItem => id == selectedItem.timesheet_entry_id
-    ).length;
+    selectedLineItems.filter(selectedItem => id == selectionId(selectedItem))
+      .length;
 
   const items = res.data.new_line_item_entries.map(item => ({
     ...item,
-    checked: itemSelected(item.timesheet_entry_id),
+    checked: itemSelected(selectionId(item)),
     lineTotal: lineTotalCalc(item.quantity, item.rate),
   }));
 

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -542,6 +542,7 @@ const en = {
     rate: "Rate",
     quantity: "Quantity",
     selectTimeEntries: "Select Time Entries",
+    groupByProject: "Group by project",
     entriesSelected: "%{count} entries selected",
     resetSelectedEntries: "Reset Selected Entries",
     addEntries: "ADD ENTRIES",

--- a/app/javascript/src/services/invoiceApi.ts
+++ b/app/javascript/src/services/invoiceApi.ts
@@ -15,6 +15,7 @@ export interface InvoiceItem {
   date?: string;
   work_date?: string;
   timesheet_entry_id?: string;
+  linked_timesheet_entry_ids?: Array<string | number>;
   lineTotal?: number;
   _destroy?: boolean;
 }
@@ -447,6 +448,7 @@ class InvoiceApiService {
           invoiceData.dateFormat
         ),
         timesheet_entry_id: item.timesheet_entry_id,
+        linked_timesheet_entry_ids: item.linked_timesheet_entry_ids || [],
         quantity: item.quantity || 0,
         rate: item.rate || 0,
         amount:
@@ -546,6 +548,8 @@ class InvoiceApiService {
         date: item.date || item.work_date,
         work_date: item.work_date || item.date,
         timesheet_entry_id: item.timesheet_entry_id || item.timesheetEntryId,
+        linked_timesheet_entry_ids:
+          item.linked_timesheet_entry_ids || item.linkedTimesheetEntryIds || [],
         amount:
           item.amount === null ||
           item.amount === undefined ||

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -113,8 +113,7 @@ class Invoice < ApplicationRecord
   end
 
   def update_timesheet_entry_status!
-    timesheet_entry_ids = invoice_line_items.pluck(:timesheet_entry_id)
-    TimesheetEntry.kept.where(id: timesheet_entry_ids).update!(bill_status: :billed)
+    TimesheetEntry.kept.where(id: invoice_timesheet_entry_ids).update!(bill_status: :billed)
   end
 
   def create_checkout_session!(success_url:, cancel_url:)
@@ -188,13 +187,21 @@ class Invoice < ApplicationRecord
     end
 
     def lock_timesheet_entries
-      timesheet_entry_ids = invoice_line_items.pluck(:timesheet_entry_id)
-      TimesheetEntry.in_workspace(company).where(id: timesheet_entry_ids).update!(locked: true)
+      TimesheetEntry.in_workspace(company).where(id: invoice_timesheet_entry_ids).update!(locked: true)
     end
 
     def unlock_timesheet_entries
-      timesheet_entry_ids = invoice_line_items.pluck(:timesheet_entry_id)
-      TimesheetEntry.in_workspace(company).where(id: timesheet_entry_ids).update!(locked: false)
+      TimesheetEntry.in_workspace(company).where(id: invoice_timesheet_entry_ids).update!(locked: false)
+    end
+
+    def invoice_timesheet_entry_ids
+      direct_ids = invoice_line_items.pluck(:timesheet_entry_id)
+      linked_ids = InvoiceLineItemTimeEntry
+        .joins(:invoice_line_item)
+        .where(invoice_line_items: { invoice_id: id })
+        .pluck(:timesheet_entry_id)
+
+      (direct_ids + linked_ids).compact.uniq
     end
 
     def same_currency?

--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -3,9 +3,11 @@
 class InvoiceLineItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :timesheet_entry, optional: true
+  has_many :invoice_line_item_time_entries, dependent: :destroy
+  has_many :linked_timesheet_entries, through: :invoice_line_item_time_entries, source: :timesheet_entry
 
   before_update :capture_previous_invoice_id, if: :will_save_change_to_invoice_id?
-  before_destroy :unlock_timesheet_entry
+  before_destroy :unlock_timesheet_entries
   after_save :sync_invoice_totals
   after_destroy :sync_invoice_totals
 
@@ -13,6 +15,7 @@ class InvoiceLineItem < ApplicationRecord
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
   validates :quantity, numericality: { greater_than_or_equal_to: 0 }
   validate :timesheet_entry_belongs_to_invoice_company
+  validate :linked_timesheet_entries_belong_to_invoice_company
 
   def self.total_cost_of_all_line_items
     (self.sum("quantity * rate") / 60.0).round(3)
@@ -57,10 +60,23 @@ class InvoiceLineItem < ApplicationRecord
       errors.add(:timesheet_entry, "must belong to the same company")
     end
 
-    def unlock_timesheet_entry
-      if invoice.draft? && timesheet_entry.present?
-        timesheet_entry.update!(locked: false)
-      end
+    def linked_timesheet_entries_belong_to_invoice_company
+      return if invoice.blank? || linked_timesheet_entries.blank?
+
+      invalid_entry = linked_timesheet_entries.find { |entry| entry.company&.id != invoice.company_id }
+      return unless invalid_entry
+
+      errors.add(:linked_timesheet_entries, "must belong to the same company")
+    end
+
+    def unlock_timesheet_entries
+      return unless invoice.draft?
+
+      TimesheetEntry.where(id: associated_timesheet_entry_ids).update!(locked: false)
+    end
+
+    def associated_timesheet_entry_ids
+      ([timesheet_entry_id] + linked_timesheet_entry_ids).compact.uniq
     end
 
     def capture_previous_invoice_id

--- a/app/models/invoice_line_item_time_entry.rb
+++ b/app/models/invoice_line_item_time_entry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class InvoiceLineItemTimeEntry < ApplicationRecord
+  belongs_to :invoice_line_item
+  belongs_to :timesheet_entry
+
+  validates :timesheet_entry_id, uniqueness: { scope: :invoice_line_item_id }
+  validate :timesheet_entry_belongs_to_invoice_company
+
+  private
+
+    def timesheet_entry_belongs_to_invoice_company
+      return if invoice_line_item&.invoice.blank? || timesheet_entry.blank?
+      return if timesheet_entry.company&.id == invoice_line_item.invoice.company_id
+
+      errors.add(:timesheet_entry, "must belong to the same company")
+    end
+end

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -51,7 +51,8 @@ class InvoicePolicy < ApplicationPolicy
       invoice_line_items_attributes: [
         :id, :name, :description,
         :date, :timesheet_entry_id,
-        :rate, :quantity, :_destroy
+        :rate, :quantity, :_destroy,
+        linked_timesheet_entry_ids: []
       ]
     ]
   end

--- a/app/services/generate_invoice/new_line_items_service.rb
+++ b/app/services/generate_invoice/new_line_items_service.rb
@@ -33,10 +33,17 @@ module GenerateInvoice
       # merging selected_entries from params with ids already present in other invoice line items
       def filtered_ids
         discarded_invoice_ids = Invoice.kept.pluck(:id)
-        @filtered_ids ||= params[:selected_entries].to_a | InvoiceLineItem.joins(:timesheet_entry)
+        direct_entry_ids = InvoiceLineItem.joins(:timesheet_entry)
           .where(invoice_id: discarded_invoice_ids)
           .where(timesheet_entries: { bill_status: "unbilled", discarded_at: nil })
           .pluck(:timesheet_entry_id)
+        linked_entry_ids = InvoiceLineItemTimeEntry
+          .joins(:timesheet_entry, :invoice_line_item)
+          .where(invoice_line_items: { invoice_id: discarded_invoice_ids })
+          .where(timesheet_entries: { bill_status: "unbilled", discarded_at: nil })
+          .pluck(:timesheet_entry_id)
+
+        @filtered_ids ||= params[:selected_entries].to_a | direct_entry_ids | linked_entry_ids
       end
 
       def where_clause
@@ -83,19 +90,63 @@ module GenerateInvoice
       def format_timesheet_entries(timesheet_entries)
         user_project_rates = ProjectMembersPresenter.new(projects).project_to_member_hourly_rate
 
+        return format_project_aggregates(timesheet_entries, user_project_rates) if group_by_project?
+
         timesheet_entries.map do |timesheet_entry|
+          rate = user_project_rates[timesheet_entry.project_id][timesheet_entry.user_id]
+
           {
+            selection_id: "timesheet-entry-#{timesheet_entry.id}",
             timesheet_entry_id: timesheet_entry.id,
+            linked_timesheet_entry_ids: [],
             user_id: timesheet_entry.user_id,
             project_id: timesheet_entry.project_id,
+            project_name: timesheet_entry.project.name,
             first_name: timesheet_entry.user.first_name,
             last_name: timesheet_entry.user.last_name,
             description: timesheet_entry.note,
             date: timesheet_entry.work_date,
             quantity: timesheet_entry.duration,
-            rate: user_project_rates[timesheet_entry.project_id][timesheet_entry.user_id]
+            rate:
           }
         end
+      end
+
+      def group_by_project?
+        ActiveModel::Type::Boolean.new.cast(params[:group_by_project])
+      end
+
+      def format_project_aggregates(timesheet_entries, user_project_rates)
+        timesheet_entries
+          .group_by { |entry| [entry.project_id, entry.user_id, user_project_rates[entry.project_id][entry.user_id]] }
+          .map do |(project_id, user_id, rate), entries|
+            first_entry = entries.first
+            work_dates = entries.map(&:work_date)
+
+            {
+              selection_id: "project-aggregate-#{project_id}-#{user_id}-#{formatted_rate(rate)}",
+              timesheet_entry_id: nil,
+              linked_timesheet_entry_ids: entries.map(&:id),
+              user_id:,
+              project_id:,
+              project_name: first_entry.project.name,
+              first_name: nil,
+              last_name: nil,
+              name: first_entry.project.name,
+              description: "#{first_entry.user.full_name} - #{entries.size} entries",
+              date: work_dates.min,
+              date_range: [work_dates.min, work_dates.max].uniq.join(" - "),
+              quantity: entries.sum(&:duration),
+              rate:,
+              entry_count: entries.size
+            }
+          end
+      end
+
+      def formatted_rate(rate)
+        return rate.to_s("F") if rate.is_a?(BigDecimal)
+
+        rate.to_s
       end
   end
 end

--- a/app/views/api/v1/invoices/_invoice.json.jbuilder
+++ b/app/views/api/v1/invoices/_invoice.json.jbuilder
@@ -25,6 +25,8 @@ json.invoice_line_items invoice.invoice_line_items do |invoice_line_item|
   json.date invoice_line_item.date
   json.rate invoice_line_item.rate
   json.quantity invoice_line_item.quantity
+  json.timesheet_entry_id invoice_line_item.timesheet_entry_id
+  json.linked_timesheet_entry_ids invoice_line_item.linked_timesheet_entry_ids
 end
 json.client do
   json.partial! "internal_api/v1/partial/client", locals: { client: }

--- a/app/views/api/v1/invoices/line_items/index.json.jbuilder
+++ b/app/views/api/v1/invoices/line_items/index.json.jbuilder
@@ -8,15 +8,21 @@ json.filter_options do
 end
 
 json.new_line_item_entries new_line_item_entries do |entry|
+  json.selection_id entry[:selection_id]
   json.timesheet_entry_id entry[:timesheet_entry_id]
+  json.linked_timesheet_entry_ids entry[:linked_timesheet_entry_ids]
   json.user_id entry[:user_id]
   json.project_id entry[:project_id]
+  json.project_name entry[:project_name]
   json.first_name entry[:first_name]
   json.last_name entry[:last_name]
+  json.name entry[:name]
   json.description entry[:description]
   json.date entry[:date]
+  json.date_range entry[:date_range]
   json.quantity entry[:quantity]
   json.rate entry[:rate]
+  json.entry_count entry[:entry_count]
 end
 
 json.total_new_line_items total_new_line_items

--- a/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
+++ b/app/views/internal_api/v1/generate_invoice/index.json.jbuilder
@@ -11,7 +11,9 @@ end
 # new line items data according to filters and search term
 json.new_line_item_entries new_line_item_entries do |line_item|
   json.extract! line_item,
-    :timesheet_entry_id, :user_id, :project_id, :first_name, :last_name, :description, :date, :quantity, :rate
+    :selection_id, :timesheet_entry_id, :linked_timesheet_entry_ids, :user_id, :project_id,
+    :project_name, :first_name, :last_name, :name, :description, :date, :date_range,
+    :quantity, :rate, :entry_count
 end
 
 # sends total number of new line item entry count

--- a/app/views/internal_api/v1/partial/_invoice_line_item.json.jbuilder
+++ b/app/views/internal_api/v1/partial/_invoice_line_item.json.jbuilder
@@ -7,3 +7,4 @@ json.date invoice_line_item.date
 json.rate invoice_line_item.rate
 json.quantity invoice_line_item.quantity
 json.timesheet_entry_id invoice_line_item.timesheet_entry_id
+json.linked_timesheet_entry_ids invoice_line_item.linked_timesheet_entry_ids

--- a/db/migrate/20260514130000_create_invoice_line_item_time_entries.rb
+++ b/db/migrate/20260514130000_create_invoice_line_item_time_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateInvoiceLineItemTimeEntries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :invoice_line_item_time_entries do |t|
+      t.references :invoice_line_item, null: false, foreign_key: true, index: { name: "idx_line_item_time_entries_on_invoice_line_item_id" }
+      t.references :timesheet_entry, null: false, foreign_key: true, index: { name: "idx_line_item_time_entries_on_timesheet_entry_id" }
+
+      t.timestamps
+    end
+
+    add_index :invoice_line_item_time_entries,
+      [:invoice_line_item_id, :timesheet_entry_id],
+      unique: true,
+      name: "idx_line_item_time_entries_unique_pair"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_123500) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_14_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -491,6 +491,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_123500) do
     t.index ["role"], name: "index_invitations_on_role"
     t.index ["sender_id"], name: "index_invitations_on_sender_id"
     t.index ["token"], name: "index_invitations_on_token", unique: true
+  end
+
+  create_table "invoice_line_item_time_entries", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "invoice_line_item_id", null: false
+    t.bigint "timesheet_entry_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invoice_line_item_id", "timesheet_entry_id"], name: "idx_line_item_time_entries_unique_pair", unique: true
+    t.index ["invoice_line_item_id"], name: "idx_line_item_time_entries_on_invoice_line_item_id"
+    t.index ["timesheet_entry_id"], name: "idx_line_item_time_entries_on_timesheet_entry_id"
   end
 
   create_table "invoice_line_items", force: :cascade do |t|
@@ -1077,6 +1087,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_123500) do
   add_foreign_key "invitations", "clients"
   add_foreign_key "invitations", "companies"
   add_foreign_key "invitations", "users", column: "sender_id"
+  add_foreign_key "invoice_line_item_time_entries", "invoice_line_items"
+  add_foreign_key "invoice_line_item_time_entries", "timesheet_entries"
   add_foreign_key "invoice_line_items", "invoices"
   add_foreign_key "invoice_line_items", "timesheet_entries"
   add_foreign_key "invoices", "clients"

--- a/spec/factories/invoice_line_item_time_entries.rb
+++ b/spec/factories/invoice_line_item_time_entries.rb
@@ -4,10 +4,22 @@ FactoryBot.define do
   factory :invoice_line_item_time_entry do
     invoice_line_item
     timesheet_entry do
-      create(:timesheet_entry,
-        user: invoice_line_item.timesheet_entry.user,
-        project: invoice_line_item.timesheet_entry.project,
-        bill_status: "unbilled")
+      source_entry = invoice_line_item.timesheet_entry
+
+      if source_entry.present?
+        create(:timesheet_entry,
+          user: source_entry.user,
+          project: source_entry.project,
+          bill_status: "unbilled")
+      else
+        project = create(:project, client: invoice_line_item.invoice.client, billable: true)
+        user = create(:user, current_workspace: invoice_line_item.invoice.company)
+
+        create(:timesheet_entry,
+          user:,
+          project:,
+          bill_status: "unbilled")
+      end
     end
   end
 end

--- a/spec/factories/invoice_line_item_time_entries.rb
+++ b/spec/factories/invoice_line_item_time_entries.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :invoice_line_item_time_entry do
+    invoice_line_item
+    timesheet_entry do
+      create(:timesheet_entry,
+        user: invoice_line_item.timesheet_entry.user,
+        project: invoice_line_item.timesheet_entry.project,
+        bill_status: "unbilled")
+    end
+  end
+end

--- a/spec/models/invoice_line_item_spec.rb
+++ b/spec/models/invoice_line_item_spec.rb
@@ -45,13 +45,18 @@ RSpec.describe InvoiceLineItem, type: :model do
   end
 
   describe "callbacks" do
-    it { is_expected.to callback(:unlock_timesheet_entry).before(:destroy) }
+    it { is_expected.to callback(:unlock_timesheet_entries).before(:destroy) }
   end
 
   describe "Associations" do
     describe "belongs to" do
       it { is_expected.to belong_to(:invoice) }
       it { is_expected.to belong_to(:timesheet_entry).optional(true) }
+    end
+
+    describe "has many" do
+      it { is_expected.to have_many(:invoice_line_item_time_entries).dependent(:destroy) }
+      it { is_expected.to have_many(:linked_timesheet_entries).through(:invoice_line_item_time_entries) }
     end
   end
 

--- a/spec/models/invoice_line_item_time_entry_spec.rb
+++ b/spec/models/invoice_line_item_time_entry_spec.rb
@@ -10,11 +10,15 @@ RSpec.describe InvoiceLineItemTimeEntry, type: :model do
 
   describe "validations" do
     it "does not allow the same time entry to be linked twice to one line item" do
-      invoice_line_item = create(:invoice_line_item)
+      invoice = create(:invoice)
+      project = create(:project, client: invoice.client, billable: true)
+      user = create(:user, current_workspace: invoice.company)
+      source_entry = create(:timesheet_entry, user:, project:, bill_status: "unbilled")
+      invoice_line_item = create(:invoice_line_item, invoice:, timesheet_entry: source_entry)
       time_entry = create(
         :timesheet_entry,
-        user: invoice_line_item.timesheet_entry.user,
-        project: invoice_line_item.timesheet_entry.project,
+        user:,
+        project:,
         bill_status: "unbilled"
       )
       create(:invoice_line_item_time_entry, invoice_line_item:, timesheet_entry: time_entry)

--- a/spec/models/invoice_line_item_time_entry_spec.rb
+++ b/spec/models/invoice_line_item_time_entry_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InvoiceLineItemTimeEntry, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:invoice_line_item) }
+    it { is_expected.to belong_to(:timesheet_entry) }
+  end
+
+  describe "validations" do
+    it "does not allow the same time entry to be linked twice to one line item" do
+      invoice_line_item = create(:invoice_line_item)
+      time_entry = create(
+        :timesheet_entry,
+        user: invoice_line_item.timesheet_entry.user,
+        project: invoice_line_item.timesheet_entry.project,
+        bill_status: "unbilled"
+      )
+      create(:invoice_line_item_time_entry, invoice_line_item:, timesheet_entry: time_entry)
+
+      duplicate_link = build(:invoice_line_item_time_entry, invoice_line_item:, timesheet_entry: time_entry)
+
+      expect(duplicate_link).not_to be_valid
+      expect(duplicate_link.errors[:timesheet_entry_id]).to include("has already been taken")
+    end
+  end
+end

--- a/spec/policies/invoice_policy_spec.rb
+++ b/spec/policies/invoice_policy_spec.rb
@@ -103,7 +103,10 @@ RSpec.describe InvoicePolicy, type: :policy do
     subject { described_class.new(employee, company).permitted_attributes }
 
     let(:invoice_line_items_attributes) do
-      %i[id name description date timesheet_entry_id rate quantity _destroy]
+      [
+        :id, :name, :description, :date, :timesheet_entry_id,
+        :rate, :quantity, :_destroy, { linked_timesheet_entry_ids: [] }
+      ]
     end
     let(:attributes) do
       %i[

--- a/spec/requests/api/v1/invoices/create_spec.rb
+++ b/spec/requests/api/v1/invoices/create_spec.rb
@@ -131,6 +131,49 @@ RSpec.describe "Api::V1::Invoices#create", type: :request do
         expect(line_item.timesheet_entry_id).to eq(timesheet_entry.id)
       end
 
+      it "creates aggregate invoice line items linked to multiple timesheet entries" do
+        project = create(:project, client:, name: "Platform Build", billable: true)
+        entries = create_list(
+          :timesheet_entry,
+          2,
+          user:,
+          project:,
+          bill_status: :unbilled,
+          locked: false,
+          work_date: Date.current
+        )
+
+        send_request :post, api_v1_invoices_path(
+          invoice: {
+            client_id: client.id,
+            invoice_number: "INV-AGGREGATE-001",
+            issue_date: Date.current.iso8601,
+            due_date: 30.days.from_now.to_date.iso8601,
+            status: "draft",
+            currency: company.base_currency,
+            invoice_line_items_attributes: [
+              {
+                name: project.name,
+                description: "Aggregated project work",
+                date: Date.current.iso8601,
+                rate: 100,
+                quantity: entries.sum(&:duration),
+                linked_timesheet_entry_ids: entries.map(&:id)
+              }
+            ]
+          }), headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+
+        invoice = Invoice.find_by!(invoice_number: "INV-AGGREGATE-001")
+        line_item = invoice.invoice_line_items.last
+
+        expect(line_item.name).to eq("Platform Build")
+        expect(line_item.timesheet_entry_id).to be_nil
+        expect(line_item.linked_timesheet_entry_ids).to match_array(entries.map(&:id))
+        expect(entries.map { |entry| entry.reload.locked }).to all(be(true))
+      end
+
       it "calculates invoice totals from line items, discount, and tax" do
         send_request :post, api_v1_invoices_path(
           invoice: {

--- a/spec/requests/api/v1/invoices/line_items/index_spec.rb
+++ b/spec/requests/api/v1/invoices/line_items/index_spec.rb
@@ -12,15 +12,21 @@ RSpec.describe "Api::V1::Invoices::LineItems#index", type: :request do
 
   let(:expected_invoice_line_items) do
     [{
+      "selection_id": "timesheet-entry-#{timesheet_entry.id}",
       "timesheet_entry_id": timesheet_entry.id,
+      "linked_timesheet_entry_ids": [],
       "user_id": user.id,
       "project_id": project.id,
+      "project_name": project.name,
       "first_name": user.first_name,
       "last_name": user.last_name,
+      "name": nil,
       "description": timesheet_entry.note,
       "date": timesheet_entry.work_date,
+      "date_range": nil,
       "quantity": timesheet_entry.duration,
-      "rate": project_member.hourly_rate
+      "rate": project_member.hourly_rate,
+      "entry_count": nil
     }]
   end
 
@@ -116,6 +122,51 @@ RSpec.describe "Api::V1::Invoices::LineItems#index", type: :request do
       expect(response).to have_http_status(:ok)
       expect(json_response["filter_options"]).to eq(JSON.parse(filter_options.to_json))
       expect(json_response["new_line_item_entries"]).to eq(JSON.parse(expected_invoice_line_items.to_json))
+    end
+
+    it "aggregates unbilled entries by project, member, and rate" do
+      project_member.update!(hourly_rate: 100)
+      second_entry = create(
+        :timesheet_entry,
+        user:,
+        project:,
+        bill_status: "unbilled",
+        duration: 90,
+        work_date: timesheet_entry.work_date + 1.day
+      )
+      other_project = create(:project, billable: true, client:, name: "Mobile App")
+      create(:project_member, user:, project: other_project, hourly_rate: 125)
+      other_entry = create(
+        :timesheet_entry,
+        user:,
+        project: other_project,
+        bill_status: "unbilled",
+        duration: 60
+      )
+
+      send_request :get, api_v1_line_items_invoices_path(client_id: client.id), params: {
+        group_by_project: true
+      }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response["new_line_item_entries"].size).to eq(2)
+
+      project_group = json_response["new_line_item_entries"].detect { |entry| entry["project_id"] == project.id }
+      expect(project_group).to include(
+        "selection_id" => "project-aggregate-#{project.id}-#{user.id}-100.0",
+        "timesheet_entry_id" => nil,
+        "project_name" => project.name,
+        "name" => project.name,
+        "description" => "#{user.full_name} - 2 entries",
+        "quantity" => timesheet_entry.duration + second_entry.duration,
+        "rate" => "100.0",
+        "entry_count" => 2
+      )
+      expect(project_group["linked_timesheet_entry_ids"]).to match_array([timesheet_entry.id, second_entry.id])
+
+      other_group = json_response["new_line_item_entries"].detect { |entry| entry["project_id"] == other_project.id }
+      expect(other_group["linked_timesheet_entry_ids"]).to eq([other_entry.id])
+      expect(other_group["quantity"]).to eq(60)
     end
 
     it "excludes entries already used by another draft invoice" do

--- a/spec/system/invoices/create_spec.rb
+++ b/spec/system/invoices/create_spec.rb
@@ -325,6 +325,57 @@ RSpec.describe "Invoice creation", type: :system, js: true do
     end
   end
 
+  it "creates grouped project invoice line items from selected time entries" do
+    employee = create(:user, current_workspace_id: company.id, first_name: "Nina", last_name: "Sharp")
+    create(:employment, company:, user: employee)
+    employee.add_role :employee, company
+
+    platform_project = create(:project, client:, name: "Platform Build", billable: true)
+    mobile_project = create(:project, client:, name: "Mobile App", billable: true)
+    create(:project_member, project: platform_project, user: employee, hourly_rate: 100)
+    create(:project_member, project: mobile_project, user: employee, hourly_rate: 125)
+    platform_entries = [
+      create(:timesheet_entry, user: employee, project: platform_project, bill_status: :unbilled, duration: 120, note: "API work"),
+      create(:timesheet_entry, user: employee, project: platform_project, bill_status: :unbilled, duration: 60, note: "Review work")
+    ]
+    mobile_entry = create(:timesheet_entry, user: employee, project: mobile_project, bill_status: :unbilled, duration: 90, note: "Mobile QA")
+
+    with_forgery_protection do
+      visit_new_invoice_for(client)
+
+      fill_in "invoiceNumber", with: "INV-PROJECT-GROUP-001"
+      click_button "LINE ITEMS"
+      find("[data-testid='invoice-manual-entry-name']", wait: 10).click
+      click_button "Select Time Entries"
+      check "Group by project"
+      click_button "APPLY"
+
+      expect(page).to have_text("Platform Build", wait: 10)
+      expect(page).to have_text("Mobile App", wait: 10)
+
+      find("thead input.custom__checkbox", visible: :all, wait: 10).click
+      click_button "ADD ENTRIES"
+
+      expect_invoice_line_item("Platform Build")
+      expect_invoice_line_item("Mobile App")
+      expect(page).to have_css("[data-testid='invoice-line-item-quantity'][value='03:00']", wait: 10)
+      expect(page).to have_css("[data-testid='invoice-line-item-quantity'][value='01:30']", wait: 10)
+
+      save_invoice
+
+      expect(page).to have_text("Invoice created successfully", wait: 10)
+
+      invoice = Invoice.find_by!(invoice_number: "INV-PROJECT-GROUP-001")
+      platform_line_item = invoice.invoice_line_items.find_by!(name: "Platform Build")
+      mobile_line_item = invoice.invoice_line_items.find_by!(name: "Mobile App")
+
+      expect(platform_line_item.quantity).to eq(180)
+      expect(platform_line_item.linked_timesheet_entry_ids).to match_array(platform_entries.map(&:id))
+      expect(mobile_line_item.quantity).to eq(90)
+      expect(mobile_line_item.linked_timesheet_entry_ids).to eq([mobile_entry.id])
+    end
+  end
+
   {
     "USD" => { subtotal: 410.0, total_due: 395.0 },
     "EUR" => { subtotal: 410.0, total_due: 395.0 },


### PR DESCRIPTION
Fixes #1984

## Summary
- add grouped invoice line items that link back to all selected time entries
- add a Group by project option in the time-entry picker and include project names in picker rows
- keep draft locking and billed-status updates working for aggregate time entries
- cover aggregate API, invoice creation, model associations, and the invoice UI flow

## Verification
- rtk git diff --check
- rtk mise exec -- pnpm exec eslint app/javascript/src/components/Invoices/MultipleEntriesModal/Filters/index.tsx app/javascript/src/components/Invoices/MultipleEntriesModal/TimeEntrySelectionTable.tsx app/javascript/src/components/Invoices/MultipleEntriesModal/index.tsx app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx app/javascript/src/components/Invoices/common/NewLineItemRow/index.tsx app/javascript/src/components/Invoices/common/NewLineItemTable/index.tsx app/javascript/src/components/Invoices/common/utils.js app/javascript/src/i18n/locales/en.ts app/javascript/src/services/invoiceApi.ts
- rtk mise exec -- bundle exec rubocop app/models/invoice.rb app/models/invoice_line_item.rb app/models/invoice_line_item_time_entry.rb app/services/generate_invoice/new_line_items_service.rb app/policies/invoice_policy.rb spec/models/invoice_line_item_spec.rb spec/models/invoice_line_item_time_entry_spec.rb spec/requests/api/v1/invoices/create_spec.rb spec/requests/api/v1/invoices/line_items/index_spec.rb spec/system/invoices/create_spec.rb
- rtk mise exec -- env SKIP_VITE_TEST_BUILD=1 bundle exec rspec spec/models/invoice_line_item_spec.rb spec/models/invoice_line_item_time_entry_spec.rb spec/requests/api/v1/invoices/line_items/index_spec.rb spec/requests/api/v1/invoices/create_spec.rb
- CI=1 rtk mise exec -- bundle exec rspec spec/system/invoices/create_spec.rb:324
- rtk mise exec -- timeout 30 bin/vite build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Group by project" checkbox to the invoice time-entry picker to create aggregated line items per project.
* **Improvements**
  * Invoice line items now show project names and can link multiple timesheet entries with date ranges, entry counts, and formatted rates.
  * Selection behavior and checkbox identity improved for consistent selection across UI variants.
* **Tests**
  * End-to-end and request specs added/updated to cover grouping and linked-entry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2295)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->