### PR TITLE
fix(ui): restore sign-out button in dashboard header

### DIFF
--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -412,7 +412,7 @@ export const leavesApi = {
 };
 
 // Logout
-export const logoutApi = () => http.delete(`/users/logout`);
+export const logoutApi = (config = {}) => http.delete(`/users/logout`, config);
 
 // Payment Settings
 export const paymentSettingsApi = {

--- a/app/javascript/src/components/Dashboard/DashboardLayout.tsx
+++ b/app/javascript/src/components/Dashboard/DashboardLayout.tsx
@@ -19,10 +19,12 @@ import {
   House,
   CurrencyCircleDollar,
   Tree,
+  SignOut,
   Monitor,
 } from "phosphor-react";
 import { useLocation } from "react-router-dom";
 import { useUserContext } from "context/UserContext";
+import { logoutApi } from "apis/api";
 import ThemeToggle from "../../common/ThemeToggle";
 import useThemeMode from "../../common/useThemeMode";
 import { hasProAccess } from "../../lib/planAccess";
@@ -208,6 +210,15 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
     return item?.label || t("nav.dashboard");
   }, [location.pathname, filteredNavigation]);
 
+  const handleLogout = async () => {
+    try {
+      await logoutApi();
+      window.location.href = "/";
+    } catch (error) {
+      window.location.href = "/";
+    }
+  };
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (mobileOpen && !(event.target as Element).closest(".mobile-sidebar")) {
@@ -347,6 +358,14 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
               <DashboardTimerControl />
               <CompactLocaleSwitcher />
               <ThemeToggle compact />
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition hover:bg-accent"
+              >
+                <SignOut size={16} />
+                <span className="hidden sm:inline">{t("nav.logout")}</span>
+              </button>
             </div>
           </div>
         </header>

--- a/app/javascript/src/components/Dashboard/DashboardLayout.tsx
+++ b/app/javascript/src/components/Dashboard/DashboardLayout.tsx
@@ -25,6 +25,7 @@ import {
 import { useLocation } from "react-router-dom";
 import { useUserContext } from "context/UserContext";
 import { logoutApi } from "apis/api";
+import { Toastr } from "StyledComponents";
 import ThemeToggle from "../../common/ThemeToggle";
 import useThemeMode from "../../common/useThemeMode";
 import { hasProAccess } from "../../lib/planAccess";
@@ -212,10 +213,11 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
 
   const handleLogout = async () => {
     try {
-      await logoutApi();
+      await logoutApi({ skipErrorToast: true });
       window.location.href = "/";
     } catch (error) {
-      window.location.href = "/";
+      console.error("Logout failed:", error);
+      Toastr.error(t("somethingWentWrong"));
     }
   };
 
@@ -360,11 +362,14 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
               <ThemeToggle compact />
               <button
                 type="button"
+                aria-label={t("nav.logout")}
                 onClick={handleLogout}
                 className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition hover:bg-accent"
               >
-                <SignOut size={16} />
-                <span className="hidden sm:inline">{t("nav.logout")}</span>
+                <SignOut size={16} aria-hidden="true" />
+                <span className="sr-only sm:not-sr-only">
+                  {t("nav.logout")}
+                </span>
               </button>
             </div>
           </div>

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe "Profile Settings", type: :system, js: true do
     end
   end
 
-  it "moves logout from the dashboard header to profile account settings" do
+  it "shows logout in the dashboard header and profile account settings" do
     with_forgery_protection do
       visit "/dashboard"
 
       expect(page).to have_css("#react-root", wait: 10)
       within("header") do
-        expect(page).not_to have_button("Logout")
+        expect(page).to have_button("Logout", wait: 10)
       end
 
       visit "/settings/profile"


### PR DESCRIPTION
Fixes #2305 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an explicit logout button to the dashboard header, allowing users to securely sign out and return to the home page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->