### PR TITLE
fix(payments): align Invoice field label with floating label pattern …

### DIFF
--- a/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
+++ b/app/javascript/src/components/payments/Modals/PaymentEntryForm.tsx
@@ -271,7 +271,7 @@ const PaymentEntryForm = ({
                 <div className="mt-1" id="invoice" ref={wrapperSelectRef}>
                   <div className="relative mt-3" id="invoicesList">
                     <label
-                      className="absolute top-0.5 left-1 z-1 h-6 origin-0 bg-background p-2 text-base font-medium text-muted-foreground duration-300"
+                      className="absolute top-2 left-1 z-10 ml-3 -translate-y-4 scale-75 origin-0 transform bg-background px-1 py-0 text-base font-medium text-muted-foreground whitespace-nowrap"
                       htmlFor="manual-payment-invoice-select"
                     >
                       {i18n.t("payments.invoice")}
@@ -285,7 +285,7 @@ const PaymentEntryForm = ({
                       aria-controls="manual-payment-invoice-options"
                       aria-expanded={showSelectMenu}
                       aria-haspopup="listbox"
-                      className="flex min-h-14 w-full items-center justify-between rounded-md border border-border bg-background px-4 pt-6 pb-2 text-left text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      className="flex min-h-12 w-full items-center justify-between rounded-md border border-border bg-background px-4 py-3 text-left text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                       data-testid="manual-payment-invoice-select"
                       id="manual-payment-invoice-select"
                       type="button"


### PR DESCRIPTION
…(#2322)

  The Invoice dropdown in the Add Payment modal used a static in-field label
  (`top-0.5`, `text-base`, `min-h-14` button) that always showed as large text
  inside the button alongside the placeholder, making the field visually taller
  and inconsistent with the rest of the form.

  - Apply floated-label CSS classes to the Invoice label (`top-2 -translate-y-4 scale-75 origin-0`) so it renders as a small chip on the top border, matching Transaction Date and Payment Amount in their filled state
  - Change button height from `min-h-14 pt-6 pb-2` to `min-h-12 py-3` so the empty state matches `h-12` used by other form fields; button still expands when a two-line selected invoice is shown

  Fixes #2322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced invoice selector styling in the payment form with refined label appearance and dropdown button layout adjustments for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->