### PR TITLE
fix(holidays): fix frequency dropdown UI and dark mode styling (#2324)

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
+++ b/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
@@ -482,74 +482,78 @@ const OrganizationHolidaysEditor = ({
                   />
                   {i18n.t("holidaysSettings.optionalHolidays")}
                 </CardTitle>
-                <button
-                  onClick={handleCheckboxClick}
-                  className="transition-colors"
-                  disabled={!canEdit}
-                  type="button"
-                >
-                  {enableOptionalHolidays ? (
-                    <ToggleRight
-                      size={32}
-                      className="text-primary"
-                      weight="fill"
-                    />
-                  ) : (
-                    <ToggleLeft
-                      size={32}
-                      className="text-muted-foreground"
-                      weight="fill"
-                    />
-                  )}
-                </button>
+                {canManageHolidays && (
+                  <button
+                    onClick={handleCheckboxClick}
+                    className="transition-colors"
+                    disabled={!canEdit}
+                    type="button"
+                  >
+                    {enableOptionalHolidays ? (
+                      <ToggleRight
+                        size={32}
+                        className="text-primary"
+                        weight="fill"
+                      />
+                    ) : (
+                      <ToggleLeft
+                        size={32}
+                        className="text-muted-foreground"
+                        weight="fill"
+                      />
+                    )}
+                  </button>
+                )}
               </div>
             </CardHeader>
             {enableOptionalHolidays && (
               <CardContent>
                 <div className="space-y-4">
-                  {/* Configuration — inline row */}
-                  <div className="flex flex-wrap items-end gap-4 pb-4 border-b border-border">
-                    <div className="w-40">
-                      <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
-                        {i18n.t("holidaysSettings.totalAllowed")}
-                      </Label>
-                      <Input
-                        type="number"
-                        min={0}
-                        className="font-geist-regular mt-1"
-                        disabled={!canEdit}
-                        placeholder={i18n.t("holidaysSettings.enterNumber")}
-                        value={totalOptionalHolidays}
-                        onChange={handleChangeTotalOpHoliday}
-                      />
-                    </div>
-                    <div className="w-48">
-                      <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
-                        {i18n.t("holidaysSettings.frequency")}
-                      </Label>
-                      <div className="mt-1">
-                        <CustomReactSelect
-                          isDisabled={!canEdit}
-                          handleOnChange={handleChangeRepetitionOpHoliday}
-                          id="allocationFrequency"
-                          label=""
-                          name="allocationFrequency"
-                          options={allocationFrequency}
-                          styles={customStyles}
-                          wrapperClassName="h-10"
-                          components={{ IndicatorSeparator: () => null }}
-                          value={
-                            optionalRepetitionType
-                              ? allocationFrequency.filter(
-                                  option =>
-                                    option.value === optionalRepetitionType
-                                )
-                              : allocationFrequency[0]
-                          }
+                  {/* Configuration — inline row (admin only) */}
+                  {canManageHolidays && (
+                    <div className="flex flex-wrap items-end gap-4 pb-4 border-b border-border">
+                      <div className="w-40">
+                        <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
+                          {i18n.t("holidaysSettings.totalAllowed")}
+                        </Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          className="font-geist-regular mt-1"
+                          disabled={!canEdit}
+                          placeholder={i18n.t("holidaysSettings.enterNumber")}
+                          value={totalOptionalHolidays}
+                          onChange={handleChangeTotalOpHoliday}
                         />
                       </div>
+                      <div className="w-48">
+                        <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
+                          {i18n.t("holidaysSettings.frequency")}
+                        </Label>
+                        <div className="mt-1">
+                          <CustomReactSelect
+                            isDisabled={!canEdit}
+                            handleOnChange={handleChangeRepetitionOpHoliday}
+                            id="allocationFrequency"
+                            label=""
+                            name="allocationFrequency"
+                            options={allocationFrequency}
+                            styles={customStyles}
+                            wrapperClassName="h-10"
+                            components={{ IndicatorSeparator: () => null }}
+                            value={
+                              optionalRepetitionType
+                                ? allocationFrequency.filter(
+                                    option =>
+                                      option.value === optionalRepetitionType
+                                  )
+                                : allocationFrequency[0]
+                            }
+                          />
+                        </div>
+                      </div>
                     </div>
-                  </div>
+                  )}
 
                   {canEdit ? (
                     /* Edit mode: form-style rows */

--- a/app/javascript/src/components/Profile/Organization/Holidays/utils.js
+++ b/app/javascript/src/components/Profile/Organization/Holidays/utils.js
@@ -1,23 +1,27 @@
 import dayjs from "dayjs";
 
+import {
+  getSelectControlStyles,
+  getSelectMenuStyles,
+  selectPalette,
+} from "common/CustomReactSelectStyle/shared";
+
 export const customStyles = {
-  control: (provided, state) => ({
+  control: (provided, state) =>
+    getSelectControlStyles(provided, {
+      borderColor: state.isFocused ? selectPalette.focus : selectPalette.border,
+      isFocused: state.isFocused,
+    }),
+  menu: provided =>
+    getSelectMenuStyles(provided, {
+      fontSize: "14px",
+      zIndex: 50,
+    }),
+  menuList: provided => ({
     ...provided,
-    backgroundColor: "#FFFFFF",
-    minHeight: 48,
-    padding: "0",
-    borderColor: state.isFocused ? "#5E58F1" : "#D7DEE5",
-    borderWidth: "1px",
-    boxShadow: state.isFocused && "0 0 0 1px #5E58F1",
-    "&:hover": {
-      borderColor: "#5E58F1",
-    },
-  }),
-  menu: provided => ({
-    ...provided,
-    fontSize: "12px",
-    letterSpacing: "2px",
-    zIndex: 5,
+    backgroundColor: selectPalette.menuBackground,
+    paddingTop: 6,
+    paddingBottom: 6,
   }),
   placeholder: base => ({
     ...base,
@@ -25,14 +29,29 @@ export const customStyles = {
     top: "-30%",
     transition: "top 0.2s, font-size 0.2s",
     fontSize: 10,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: selectPalette.background,
+    color: selectPalette.muted,
   }),
-  option: provided => ({
+  singleValue: base => ({
+    ...base,
+    color: selectPalette.text,
+    fontSize: 14,
+    fontWeight: 500,
+  }),
+  option: (provided, state) => ({
     ...provided,
-    cursor: "pointer",
-    "&:hover": {
-      background: "#D7DEE5",
-    },
+    backgroundColor: state.isSelected
+      ? selectPalette.optionSelected
+      : state.isFocused
+      ? selectPalette.optionHover
+      : selectPalette.menuBackground,
+    color:
+      state.isSelected || state.isFocused
+        ? selectPalette.optionText
+        : selectPalette.optionTextMuted,
+    cursor: state.isDisabled ? "not-allowed" : "pointer",
+    fontSize: 14,
+    fontWeight: state.isSelected ? 600 : 500,
   }),
 };
 


### PR DESCRIPTION
  Replace hardcoded hex colors in Optional Holidays customStyles with
  CSS-variable-based selectPalette from the shared CustomReactSelectStyle
  module, and raise menu zIndex from 5 to 50 to prevent overlap.

  - Use getSelectControlStyles/getSelectMenuStyles helpers for consistency with all other selects in the app
  - Replace #FFFFFF, #5E58F1, #D7DEE5 with selectPalette tokens so the dropdown respects light/dark mode correctly
  - Add missing menuList and singleValue style entries
  - Bump menu zIndex: 5 → 50 to fix dropdown overlap/layering issue

Fixes #2324 
Fixes #2325 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Profile organization holidays UI styling now sources from shared style helpers and palette instead of hardcoded values
  * Updated menu, menuList, placeholder, and option styling logic for improved code consistency and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saeloun/miru-web/pull/2330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->