### PR TITLE
fix: skip phone validation during password reset

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
     length: { maximum: 20 }
   validates :locale, inclusion: { in: LocaleConfig::SUPPORTED_LOCALES }
   validate :date_of_birth_cannot_be_in_future
-  validate :phone_must_be_valid
+  validate :phone_must_be_valid, if: :phone_changed?
   validate :validate_avatar_constraints
   validate :password_must_differ_from_current_password, if: :password_being_changed?
 


### PR DESCRIPTION
Phone validation ran unconditionally on every user save, causing password reset to fail with "Phone is invalid" when the user had a legacy or malformed phone number stored. Scope the validation to only run when the phone field is actually changing.

Fixes #2334 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized phone number validation to run only when the phone number field is modified, improving form performance and responsiveness during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->