### PR TITLE
fix: strip client name before validation to prevent duplicate bypass …

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -25,7 +25,7 @@ class Client < ApplicationRecord
   has_one_attached :logo
   belongs_to :company
 
-  before_save :strip_attributes
+  before_validation :strip_attributes
   before_validation :normalize_optional_email
   validates :name, presence: true, length: { maximum: 30 },
     uniqueness: { scope: :company_id, case_sensitive: false, message: "The client %{value} already exists" }
@@ -195,7 +195,7 @@ class Client < ApplicationRecord
     end
 
     def strip_attributes
-      name.strip!
+      self.name = name.strip if name.present?
     end
 
     # Keep optional email truly optional by avoiding duplicate blank-string collisions


### PR DESCRIPTION
…(#2337)

Move strip_attributes callback from before_save to before_validation so whitespace is normalized before the uniqueness check runs. This prevents trailing/leading spaces from bypassing duplicate detection and causing a 500 from the DB unique index constraint.
Closes #2337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client name validation to properly handle whitespace and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->