### PR TITLE
fix(holidays): redesign optional holidays read-mode UI (#2338)

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
+++ b/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
@@ -293,11 +293,10 @@ const OrganizationHolidaysEditor = ({
             <button
               key={tab.key}
               onClick={() => setActiveTab(tab.key)}
-              className={`flex flex-1 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 sm:px-4 py-2.5 text-xs sm:text-sm font-geist-medium transition-colors ${
-                activeTab === tab.key
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
+              className={`flex flex-1 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 sm:px-4 py-2.5 text-xs sm:text-sm font-geist-medium transition-colors ${activeTab === tab.key
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+                }`}
             >
               <span className="shrink-0">{tab.icon}</span>
               <span className="truncate">{tab.label}</span>
@@ -339,11 +338,10 @@ const OrganizationHolidaysEditor = ({
                           >
                             <Input
                               readOnly
-                              className={`font-geist-regular cursor-pointer pr-10 ${
-                                holidayErrors[index]?.date
-                                  ? "border-destructive"
-                                  : ""
-                              }`}
+                              className={`font-geist-regular cursor-pointer pr-10 ${holidayErrors[index]?.date
+                                ? "border-destructive"
+                                : ""
+                                }`}
                               placeholder={i18n.t(
                                 "holidaysSettings.selectDate"
                               )}
@@ -384,11 +382,10 @@ const OrganizationHolidaysEditor = ({
                             {i18n.t("holidaysSettings.holidayName")}
                           </Label>
                           <Input
-                            className={`font-geist-regular ${
-                              holidayErrors[index]?.name
-                                ? "border-destructive"
-                                : ""
-                            }`}
+                            className={`font-geist-regular ${holidayErrors[index]?.name
+                              ? "border-destructive"
+                              : ""
+                              }`}
                             placeholder={i18n.t(
                               "holidaysSettings.enterHolidayName"
                             )}
@@ -475,19 +472,38 @@ const OrganizationHolidaysEditor = ({
           <Card className="border-border shadow-sm">
             <CardHeader className="pb-4">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-lg font-geist-semibold flex items-center gap-2">
-                  <CalendarPlus
-                    className="h-5 w-5 text-muted-foreground"
-                    weight="bold"
-                  />
-                  {i18n.t("holidaysSettings.optionalHolidays")}
-                </CardTitle>
-                {canManageHolidays && (
+                <div className="flex items-center gap-3">
+                  <CardTitle className="text-lg font-geist-semibold flex items-center gap-2">
+                    <CalendarPlus
+                      className="h-5 w-5 text-muted-foreground"
+                      weight="bold"
+                    />
+                    {i18n.t("holidaysSettings.optionalHolidays")}
+                  </CardTitle>
+                  {!canEdit && (
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-geist-medium ${enableOptionalHolidays
+                        ? "bg-primary/10 text-primary"
+                        : "bg-muted text-muted-foreground"
+                        }`}
+                    >
+                      {enableOptionalHolidays
+                        ? i18n.t("enabled")
+                        : i18n.t("disabled")}
+                    </span>
+                  )}
+                </div>
+                {canManageHolidays && canEdit && (
                   <button
                     onClick={handleCheckboxClick}
                     className="transition-colors"
-                    disabled={!canEdit}
                     type="button"
+                    aria-label={
+                      enableOptionalHolidays
+                        ? i18n.t("holidaysSettings.disableOptionalHolidays")
+                        : i18n.t("holidaysSettings.enableOptionalHolidays")
+                    }
+                    aria-pressed={enableOptionalHolidays}
                   >
                     {enableOptionalHolidays ? (
                       <ToggleRight
@@ -511,47 +527,62 @@ const OrganizationHolidaysEditor = ({
                 <div className="space-y-4">
                   {/* Configuration — inline row (admin only) */}
                   {canManageHolidays && (
-                    <div className="flex flex-wrap items-end gap-4 pb-4 border-b border-border">
-                      <div className="w-40">
-                        <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
-                          {i18n.t("holidaysSettings.totalAllowed")}
-                        </Label>
-                        <Input
-                          type="number"
-                          min={0}
-                          className="font-geist-regular mt-1"
-                          disabled={!canEdit}
-                          placeholder={i18n.t("holidaysSettings.enterNumber")}
-                          value={totalOptionalHolidays}
-                          onChange={handleChangeTotalOpHoliday}
-                        />
-                      </div>
-                      <div className="w-48">
-                        <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
-                          {i18n.t("holidaysSettings.frequency")}
-                        </Label>
-                        <div className="mt-1">
-                          <CustomReactSelect
-                            isDisabled={!canEdit}
-                            handleOnChange={handleChangeRepetitionOpHoliday}
-                            id="allocationFrequency"
-                            label=""
-                            name="allocationFrequency"
-                            options={allocationFrequency}
-                            styles={customStyles}
-                            wrapperClassName="h-10"
-                            components={{ IndicatorSeparator: () => null }}
-                            value={
-                              optionalRepetitionType
-                                ? allocationFrequency.filter(
-                                    option =>
-                                      option.value === optionalRepetitionType
-                                  )
-                                : allocationFrequency[0]
-                            }
-                          />
+                    <div className="pb-4 border-b border-border">
+                      {canEdit ? (
+                        <div className="flex flex-wrap items-end gap-4">
+                          <div className="w-40">
+                            <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
+                              {i18n.t("holidaysSettings.totalAllowed")}
+                            </Label>
+                            <Input
+                              type="number"
+                              min={0}
+                              className="font-geist-regular mt-1"
+                              placeholder={i18n.t(
+                                "holidaysSettings.enterNumber"
+                              )}
+                              value={totalOptionalHolidays}
+                              onChange={handleChangeTotalOpHoliday}
+                            />
+                          </div>
+                          <div className="w-48">
+                            <Label className="text-xs font-geist-medium text-muted-foreground uppercase tracking-wider">
+                              {i18n.t("holidaysSettings.frequency")}
+                            </Label>
+                            <div className="mt-1">
+                              <CustomReactSelect
+                                handleOnChange={handleChangeRepetitionOpHoliday}
+                                id="allocationFrequency"
+                                label=""
+                                name="allocationFrequency"
+                                options={allocationFrequency}
+                                styles={customStyles}
+                                components={{ IndicatorSeparator: () => null }}
+                                value={
+                                  optionalRepetitionType
+                                    ? allocationFrequency.filter(
+                                      option =>
+                                        option.value ===
+                                        optionalRepetitionType
+                                    )
+                                    : allocationFrequency[0]
+                                }
+                              />
+                            </div>
+                          </div>
                         </div>
-                      </div>
+                      ) : (
+                        <p className="text-sm font-geist-regular text-muted-foreground">
+                          {i18n.t("holidaysSettings.optionalHolidayPolicy", {
+                            count: Number(totalOptionalHolidays) || 0,
+                            frequency:
+                              allocationFrequency.find(
+                                option =>
+                                  option.value === optionalRepetitionType
+                              )?.label || optionalRepetitionType,
+                          })}
+                        </p>
+                      )}
                     </div>
                   )}
 
@@ -580,11 +611,10 @@ const OrganizationHolidaysEditor = ({
                               >
                                 <Input
                                   readOnly
-                                  className={`font-geist-regular cursor-pointer pr-10 ${
-                                    optionalHolidayErrors[index]?.date
-                                      ? "border-destructive"
-                                      : ""
-                                  }`}
+                                  className={`font-geist-regular cursor-pointer pr-10 ${optionalHolidayErrors[index]?.date
+                                    ? "border-destructive"
+                                    : ""
+                                    }`}
                                   disabled={!canEdit}
                                   placeholder={i18n.t(
                                     "holidaysSettings.selectDate"
@@ -628,11 +658,10 @@ const OrganizationHolidaysEditor = ({
                                 {i18n.t("holidaysSettings.holidayName")}
                               </Label>
                               <Input
-                                className={`font-geist-regular ${
-                                  optionalHolidayErrors[index]?.name
-                                    ? "border-destructive"
-                                    : ""
-                                }`}
+                                className={`font-geist-regular ${optionalHolidayErrors[index]?.name
+                                  ? "border-destructive"
+                                  : ""
+                                  }`}
                                 disabled={!canEdit}
                                 placeholder={i18n.t(
                                   "holidaysSettings.enterHolidayName"
@@ -784,11 +813,10 @@ const OrganizationHolidaysEditor = ({
                                       ? `holiday-calendar-day-${isoDate}`
                                       : undefined
                                   }
-                                  className={`flex aspect-square items-center justify-center rounded-md text-[10px] sm:text-xs ${
-                                    holiday
-                                      ? "bg-primary text-primary-foreground font-geist-semibold"
-                                      : "text-foreground"
-                                  }`}
+                                  className={`flex aspect-square items-center justify-center rounded-md text-[10px] sm:text-xs ${holiday
+                                    ? "bg-primary text-primary-foreground font-geist-semibold"
+                                    : "text-foreground"
+                                    }`}
                                   title={holiday?.name}
                                 >
                                   {day}

--- a/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
+++ b/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
@@ -183,6 +183,10 @@ const OrganizationHolidaysEditor = ({
     optionalRepetitionType ||
     "";
 
+  const optionalHolidayFrequencyLabel = (
+    optionalHolidayFrequency || i18n.t("allocationFrequencies.perYear")
+  ).toLocaleLowerCase();
+
   const optionalHolidayPolicyKey =
     optionalHolidayCount === 1
       ? "holidaysSettings.optionalHolidayPolicy"
@@ -590,8 +594,7 @@ const OrganizationHolidaysEditor = ({
                         <p className="text-sm font-geist-regular text-muted-foreground">
                           {i18n.t(optionalHolidayPolicyKey, {
                             count: optionalHolidayCount,
-                            frequency:
-                              optionalHolidayFrequency.toLocaleLowerCase(),
+                            frequency: optionalHolidayFrequencyLabel,
                           })}
                         </p>
                       )}

--- a/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
+++ b/app/javascript/src/components/Profile/Organization/Holidays/Editor.tsx
@@ -176,6 +176,17 @@ const OrganizationHolidaysEditor = ({
       icon: <Calendar size={16} weight="bold" />,
     },
   ];
+  const optionalHolidayCount = Number(totalOptionalHolidays) || 0;
+  const optionalHolidayFrequency =
+    allocationFrequency.find(option => option.value === optionalRepetitionType)
+      ?.label ||
+    optionalRepetitionType ||
+    "";
+
+  const optionalHolidayPolicyKey =
+    optionalHolidayCount === 1
+      ? "holidaysSettings.optionalHolidayPolicy"
+      : "holidaysSettings.optionalHolidayPolicy_plural";
 
   return (
     <div className="min-h-screen bg-muted/40 font-geist">
@@ -293,10 +304,11 @@ const OrganizationHolidaysEditor = ({
             <button
               key={tab.key}
               onClick={() => setActiveTab(tab.key)}
-              className={`flex flex-1 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 sm:px-4 py-2.5 text-xs sm:text-sm font-geist-medium transition-colors ${activeTab === tab.key
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-                }`}
+              className={`flex flex-1 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 sm:px-4 py-2.5 text-xs sm:text-sm font-geist-medium transition-colors ${
+                activeTab === tab.key
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
             >
               <span className="shrink-0">{tab.icon}</span>
               <span className="truncate">{tab.label}</span>
@@ -338,10 +350,11 @@ const OrganizationHolidaysEditor = ({
                           >
                             <Input
                               readOnly
-                              className={`font-geist-regular cursor-pointer pr-10 ${holidayErrors[index]?.date
-                                ? "border-destructive"
-                                : ""
-                                }`}
+                              className={`font-geist-regular cursor-pointer pr-10 ${
+                                holidayErrors[index]?.date
+                                  ? "border-destructive"
+                                  : ""
+                              }`}
                               placeholder={i18n.t(
                                 "holidaysSettings.selectDate"
                               )}
@@ -382,10 +395,11 @@ const OrganizationHolidaysEditor = ({
                             {i18n.t("holidaysSettings.holidayName")}
                           </Label>
                           <Input
-                            className={`font-geist-regular ${holidayErrors[index]?.name
-                              ? "border-destructive"
-                              : ""
-                              }`}
+                            className={`font-geist-regular ${
+                              holidayErrors[index]?.name
+                                ? "border-destructive"
+                                : ""
+                            }`}
                             placeholder={i18n.t(
                               "holidaysSettings.enterHolidayName"
                             )}
@@ -482,10 +496,11 @@ const OrganizationHolidaysEditor = ({
                   </CardTitle>
                   {!canEdit && (
                     <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-geist-medium ${enableOptionalHolidays
-                        ? "bg-primary/10 text-primary"
-                        : "bg-muted text-muted-foreground"
-                        }`}
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-geist-medium ${
+                        enableOptionalHolidays
+                          ? "bg-primary/10 text-primary"
+                          : "bg-muted text-muted-foreground"
+                      }`}
                     >
                       {enableOptionalHolidays
                         ? i18n.t("enabled")
@@ -561,10 +576,10 @@ const OrganizationHolidaysEditor = ({
                                 value={
                                   optionalRepetitionType
                                     ? allocationFrequency.filter(
-                                      option =>
-                                        option.value ===
-                                        optionalRepetitionType
-                                    )
+                                        option =>
+                                          option.value ===
+                                          optionalRepetitionType
+                                      )
                                     : allocationFrequency[0]
                                 }
                               />
@@ -573,13 +588,10 @@ const OrganizationHolidaysEditor = ({
                         </div>
                       ) : (
                         <p className="text-sm font-geist-regular text-muted-foreground">
-                          {i18n.t("holidaysSettings.optionalHolidayPolicy", {
-                            count: Number(totalOptionalHolidays) || 0,
+                          {i18n.t(optionalHolidayPolicyKey, {
+                            count: optionalHolidayCount,
                             frequency:
-                              allocationFrequency.find(
-                                option =>
-                                  option.value === optionalRepetitionType
-                              )?.label || optionalRepetitionType,
+                              optionalHolidayFrequency.toLocaleLowerCase(),
                           })}
                         </p>
                       )}
@@ -611,10 +623,11 @@ const OrganizationHolidaysEditor = ({
                               >
                                 <Input
                                   readOnly
-                                  className={`font-geist-regular cursor-pointer pr-10 ${optionalHolidayErrors[index]?.date
-                                    ? "border-destructive"
-                                    : ""
-                                    }`}
+                                  className={`font-geist-regular cursor-pointer pr-10 ${
+                                    optionalHolidayErrors[index]?.date
+                                      ? "border-destructive"
+                                      : ""
+                                  }`}
                                   disabled={!canEdit}
                                   placeholder={i18n.t(
                                     "holidaysSettings.selectDate"
@@ -658,10 +671,11 @@ const OrganizationHolidaysEditor = ({
                                 {i18n.t("holidaysSettings.holidayName")}
                               </Label>
                               <Input
-                                className={`font-geist-regular ${optionalHolidayErrors[index]?.name
-                                  ? "border-destructive"
-                                  : ""
-                                  }`}
+                                className={`font-geist-regular ${
+                                  optionalHolidayErrors[index]?.name
+                                    ? "border-destructive"
+                                    : ""
+                                }`}
                                 disabled={!canEdit}
                                 placeholder={i18n.t(
                                   "holidaysSettings.enterHolidayName"
@@ -813,10 +827,11 @@ const OrganizationHolidaysEditor = ({
                                       ? `holiday-calendar-day-${isoDate}`
                                       : undefined
                                   }
-                                  className={`flex aspect-square items-center justify-center rounded-md text-[10px] sm:text-xs ${holiday
-                                    ? "bg-primary text-primary-foreground font-geist-semibold"
-                                    : "text-foreground"
-                                    }`}
+                                  className={`flex aspect-square items-center justify-center rounded-md text-[10px] sm:text-xs ${
+                                    holiday
+                                      ? "bg-primary text-primary-foreground font-geist-semibold"
+                                      : "text-foreground"
+                                  }`}
                                   title={holiday?.name}
                                 >
                                   {day}

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -23,6 +23,8 @@ const en = {
   next: "Next",
   done: "Done",
   loading: "Loading...",
+  enabled: "Enabled",
+  disabled: "Disabled",
   actions: "Actions",
   openMenu: "Open menu",
   filters: "Filters",
@@ -1283,10 +1285,10 @@ const en = {
 
   // Allocation frequencies
   allocationFrequencies: {
-    perWeek: "per week",
-    perMonth: "per month",
-    perQuarter: "per quarter",
-    perYear: "per year",
+    perWeek: "Per Week",
+    perMonth: "Per Month",
+    perQuarter: "Per Quarter",
+    perYear: "Per Year",
   },
 
   // Navbar
@@ -1676,6 +1678,12 @@ const en = {
     totalAllowed: "Total Allowed",
     enterNumber: "Enter number",
     frequency: "Frequency",
+    enableOptionalHolidays: "Enable optional holidays",
+    disableOptionalHolidays: "Disable optional holidays",
+    optionalHolidayPolicy:
+      "Employees can take up to %{count} optional holiday %{frequency}",
+    optionalHolidayPolicy_plural:
+      "Employees can take up to %{count} optional holidays %{frequency}",
     allowedPerEmployee: "Allowed per Employee",
     yearAtAGlance: "Year At A Glance",
     holidaySchedule: "Holiday Schedule",


### PR DESCRIPTION
- Remove broken frequency dropdown caused by h-10 wrapper clipping
- Show Enabled/Disabled badge next to title in read mode
- Display policy as natural sentence instead of raw form fields
- Only show toggle and form controls in edit mode
- Title-case allocation frequency labels (Per Week, Per Quarter, etc.) 

Fixes #2338

SS After fixes

<img width="2940" height="1436" alt="Miru-Agency-OS-Time-tracking-and-invoicing-06-08-2026_04_47_PM" src="https://github.com/user-attachments/assets/42ba92d8-491c-4ed2-b05b-cd520525debf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only view for optional holidays that shows policy text (singular/plural) with computed allowed count and frequency for users without edit permission.
  * Enabled / Disabled status badges for the optional holidays header.

* **Improvements**
  * Enable/disable toggle and inline edit controls now only appear for users with appropriate permissions.
  * Frequency labels changed to title case and new locale strings added for optional-holidays and status labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->