### PR TITLE
fix: remove outstanding invoice metric

### DIFF
--- a/app/javascript/src/components/Invoices/ChartWithSummary/index.tsx
+++ b/app/javascript/src/components/Invoices/ChartWithSummary/index.tsx
@@ -27,7 +27,6 @@ interface ChartWithSummaryProps {
   statusCounts?: {
     all?: number;
     overdue?: number;
-    outstanding?: number;
     draft?: number;
   };
 }
@@ -217,18 +216,6 @@ const ChartWithSummary: React.FC<ChartWithSummaryProps> = ({
       colorClass: "text-foreground",
       bgClass: "bg-muted/40 hover:bg-accent",
       onClick: () => applyFilter([{ value: "overdue", label: "OVERDUE" }]),
-    },
-    {
-      label: i18n.t("invoices.outstanding"),
-      value: openAmount,
-      count: statusCounts?.outstanding ?? 0,
-      colorClass: "text-foreground",
-      bgClass: "bg-muted/40 hover:bg-accent",
-      onClick: () =>
-        applyFilter([
-          { value: "sent", label: "SENT" },
-          { value: "viewed", label: "VIEWED" },
-        ]),
     },
     {
       label: i18n.t("invoices.draft"),

--- a/app/javascript/src/components/Invoices/InvoiceList.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceList.tsx
@@ -444,7 +444,6 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
             all: allCardCount,
             draft: cardCounts.draft,
             overdue: cardCounts.overdue,
-            outstanding: cardCounts.outstanding,
           }}
         />
       )}


### PR DESCRIPTION
Fixes #2344.

## Summary
- remove the standalone Outstanding metric card from the invoice dashboard summary
- keep Unpaid as the aggregate invoice overview card and retain Overdue/Draft filters

## Verification
- rtk mise exec -- timeout 120 pnpm exec eslint app/javascript/src/components/Invoices/ChartWithSummary/index.tsx app/javascript/src/components/Invoices/InvoiceList.tsx
- rtk mise exec -- timeout 30 bin/vite build
- Playwright browser QA on http://127.0.0.1:3001/invoices: summary labels were UNPAID, OVERDUE, DRAFT; no Outstanding card; console errors 0
- screenshot: /tmp/miru-web-issue-2344-invoice-dashboard.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the outstanding invoice count from the invoice summary display. Invoice summaries now display only unpaid, overdue, and draft status counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->