### PR TITLE
chore: require worktrees for GitHub issue fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Keep this file short. Treat it as a router for repo-specific rules.
 11. When the user asks for a larger batch, keep going until the batch is done, blocked, or risky without input.
 12. When resolving GitHub issues and posting resolution comments (with user approval), include verification images/screenshots as evidence.
 13. Before merging any PR, inspect CodeRabbit review feedback and fix every actionable item. Do not merge with unresolved CodeRabbit feedback unless the user explicitly approves deferring a specific item.
+14. For GitHub issue fixes, always create or use a dedicated git worktree before editing files; do not make issue fixes directly in the primary checkout.
 
 ## Repo Workflow
 


### PR DESCRIPTION
## Summary
- Require a dedicated git worktree for GitHub issue fixes in AGENTS.md.

## Verification
- Read AGENTS.md back with line numbers and confirmed the new rule at line 24.

## Notes
- Docs-only instruction update; no runtime tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development process guidelines for handling GitHub issue fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->