### PR TITLE
fix: improve dark project row hover

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -755,8 +755,12 @@
   transition: opacity 3000ms ease-in;
 }
 
+.hoverIcon {
+  @apply transition-colors;
+}
+
 .hoverIcon:hover {
-  background-color: #f5f7f9;
+  background-color: hsl(var(--muted));
 
   .iconWrapper {
     @apply visible;


### PR DESCRIPTION
## Summary
- Fixes #2354
- Replace the shared project-row hover background with the theme-aware muted token
- Keep the row hover transition explicit on the shared hover class

## Verification
- `rtk mise exec -- timeout 30 bin/vite build`
- Browser verified `http://127.0.0.1:3002/clients/1` in dark mode against this worktree: project row hover background computed as `rgb(38, 38, 38)` with foreground text `rgb(250, 250, 250)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced icon hover interactions with smooth color transitions and theme-aware styling for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->