### PR TITLE
fix: keep QuickBooks sync event index deploy-safe

### DIFF
--- a/db/migrate/20260528190533_create_quickbooks_sync_events.rb
+++ b/db/migrate/20260528190533_create_quickbooks_sync_events.rb
@@ -19,7 +19,7 @@ class CreateQuickbooksSyncEvents < ActiveRecord::Migration[8.1]
     end
 
     add_index :quickbooks_sync_events,
-      [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id, :payload_digest],
+      [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id],
       name: "idx_qbo_events_lookup"
 
     add_index :quickbooks_sync_events, [:company_id, :status]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -796,7 +796,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_120000) do
     t.datetime "updated_at", null: false
     t.index ["company_id", "status"], name: "index_quickbooks_sync_events_on_company_id_and_status"
     t.index ["company_id"], name: "index_quickbooks_sync_events_on_company_id"
-    t.index ["quickbooks_connection_id", "quickbooks_entity_type", "quickbooks_entity_id", "payload_digest"], name: "idx_qbo_events_lookup"
+    t.index ["quickbooks_connection_id", "quickbooks_entity_type", "quickbooks_entity_id"], name: "idx_qbo_events_lookup"
     t.index ["quickbooks_connection_id"], name: "index_quickbooks_sync_events_on_quickbooks_connection_id"
     t.index ["quickbooks_sync_run_id"], name: "index_quickbooks_sync_events_on_quickbooks_sync_run_id"
   end


### PR DESCRIPTION
## Summary
- Fixes Render production predeploy failure from strong_migrations rejecting the QuickBooks sync events lookup index
- Reduces idx_qbo_events_lookup from four columns to the three entity lookup columns
- Keeps db/schema.rb aligned with the migration

## Root Cause
Render web deploy dep-d8ldssa8qa3s73eqn44g failed in ./bin/render-predeploy during `rails db:prepare` at `db/migrate/20260528190533_create_quickbooks_sync_events.rb:21`. strong_migrations blocks non-unique indexes with more than three columns.

## Verification
- `RAILS_ENV=test rtk mise exec -- timeout 240 bundle exec rails db:drop db:create db:migrate`
- `SKIP_VITE_TEST_BUILD=1 RAILS_ENV=test rtk mise exec -- timeout 240 bundle exec rspec spec/models/quickbooks_sync_event_spec.rb spec/services/quick_books/exporters/customer_spec.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database indexing for QuickBooks sync event lookups to improve system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->