### PR TITLE
chore: promote deploy-safe migration fix to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ Keep this file short. Treat it as a router for repo-specific rules.
 - Use gstack skills for QA, review, investigate, ship, land-and-deploy, canary, and browser workflows when they match the task.
 - Keep gstack as a global install. Do not vendor `.claude/skills/gstack/` or `.agents/skills/gstack/` into this repo.
 
+## Superpowers, gstack, and gbrain
+
+- Superpowers workflows may use gstack and gbrain together: use Superpowers for worktree/TDD/debugging discipline, gstack for repo QA/review/ship/deploy workflows, and gbrain for memory, persona, mentor, and semantic history lookup.
+- Before non-trivial planning, review, or bug work, query gbrain for relevant Miru/HaulHub/review history when it is available; if gbrain is unhealthy, continue with local repo evidence and say so plainly.
+- Do not paste secrets or private raw dumps into prompts. Prefer `gbrain query`, `gbrain search`, `gbrain capture`, or source-backed summaries over loading large private corpora directly.
+
 ## Local Development
 
 - Primary local app URL: `http://127.0.0.1:3000`

--- a/db/migrate/20260528190533_create_quickbooks_sync_events.rb
+++ b/db/migrate/20260528190533_create_quickbooks_sync_events.rb
@@ -19,7 +19,7 @@ class CreateQuickbooksSyncEvents < ActiveRecord::Migration[8.1]
     end
 
     add_index :quickbooks_sync_events,
-      [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id, :payload_digest],
+      [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id],
       name: "idx_qbo_events_lookup"
 
     add_index :quickbooks_sync_events, [:company_id, :status]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -796,7 +796,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_120000) do
     t.datetime "updated_at", null: false
     t.index ["company_id", "status"], name: "index_quickbooks_sync_events_on_company_id_and_status"
     t.index ["company_id"], name: "index_quickbooks_sync_events_on_company_id"
-    t.index ["quickbooks_connection_id", "quickbooks_entity_type", "quickbooks_entity_id", "payload_digest"], name: "idx_qbo_events_lookup"
+    t.index ["quickbooks_connection_id", "quickbooks_entity_type", "quickbooks_entity_id"], name: "idx_qbo_events_lookup"
     t.index ["quickbooks_connection_id"], name: "index_quickbooks_sync_events_on_quickbooks_connection_id"
     t.index ["quickbooks_sync_run_id"], name: "index_quickbooks_sync_events_on_quickbooks_sync_run_id"
   end


### PR DESCRIPTION
## Summary
- Promotes the deploy-safe QuickBooks sync event migration fix from `develop` to `production`
- Includes the already-merged AGENTS routing update from `develop`
- Intended to fix Render web predeploy failure `dep-d8ldssa8qa3s73eqn44g`

## Root Cause
The previous production web deploy failed in `./bin/render-predeploy` during `rails db:prepare` because `strong_migrations` rejected a non-unique four-column index in `20260528190533_create_quickbooks_sync_events.rb`.

## Verification
- Develop PR #2357 green across CI, CodeQL, Docker build, Socket, Snyk, and CodeRabbit
- Local: `RAILS_ENV=test rtk mise exec -- timeout 240 bundle exec rails db:drop db:create db:migrate`
- Local: `SKIP_VITE_TEST_BUILD=1 RAILS_ENV=test rtk mise exec -- timeout 240 bundle exec rspec spec/models/quickbooks_sync_event_spec.rb spec/services/quick_books/exporters/customer_spec.rb`

## Deploy Gate
Merging this PR triggers Render production deploy for web and worker via `.github/workflows/docker-build.yml`.
