### PR TITLE
feat: add super-admin permanent delete user from team UI

### DIFF
--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -49,7 +49,8 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
           "social_accounts" => current_user.social_accounts,
           "date_format" => current_company&.date_format,
           "avatar_url" => current_user.avatar_url,
-          "password_changed_at" => current_user.password_changed_at
+          "password_changed_at" => current_user.password_changed_at,
+          "is_super_admin" => current_user.super_admin?
         ),
         company_role: company_role_payload(current_user, current_company),
         company: company_payload(current_company)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -47,4 +47,17 @@ class Api::V1::UsersController < Api::V1::BaseController
       render json: { user: nil, company: nil, company_role: nil }, status: 401
     end
   end
+
+  def destroy
+    target_user = User.find(params[:id])
+    authorize target_user, policy_class: SuperAdminUserPolicy
+
+    raise ActiveRecord::RecordNotFound if target_user.id == current_user.id
+
+    target_user.destroy!
+
+    render json: {
+      notice: I18n.t("user.super_admin_delete.success", email: target_user.email)
+    }, status: 200
+  end
 end

--- a/app/controllers/concerns/auth_response_payload.rb
+++ b/app/controllers/concerns/auth_response_payload.rb
@@ -12,6 +12,7 @@ module AuthResponsePayload
       payload[:token] = user.token if include_token
       payload[:avatar_url] = user.avatar_url if include_avatar
       payload[:confirmed] = user.confirmed? if include_confirmed
+      payload[:is_super_admin] = user.super_admin?
       payload
     end
 

--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -648,6 +648,7 @@ export const teamApi = {
   updateInvitedMember: (id: any, payload: any) =>
     http.put(`/invitations/${id}`, payload),
   deleteInvitedMember: (id: any) => http.delete(`/invitations/${id}`),
+  deleteUser: (id: any) => http.delete(`/users/${id}`),
 };
 
 // Subscriptions

--- a/app/javascript/src/components/AppWithUserData.tsx
+++ b/app/javascript/src/components/AppWithUserData.tsx
@@ -283,6 +283,7 @@ const AppWithUserData = (props: any) => {
   const calendarConnected = user?.calendar_connected;
 
   const isAdminUser = [Roles.ADMIN, Roles.OWNER].includes(companyRole);
+  const isSuperAdmin = Boolean(user?.is_super_admin);
 
   const [isDesktop, setIsDesktop] = useState<boolean>(window.innerWidth > 1023);
   const [selectedTab, setSelectedTab] = useState(null);
@@ -334,6 +335,7 @@ const AppWithUserData = (props: any) => {
           setCurrentAvatarUrl,
           companyRole,
           isAdminUser,
+          isSuperAdmin,
           calendarEnabled,
           calendarConnected,
           confirmedUser,

--- a/app/javascript/src/components/Team/TeamTable.tsx
+++ b/app/javascript/src/components/Team/TeamTable.tsx
@@ -121,10 +121,15 @@ const isInvitedMember = (member: TeamMember | null) =>
 const TeamTable: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { isAdminUser, company } = useUserContext();
+  const { isAdminUser, company, isSuperAdmin } = useUserContext();
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showPermanentDeleteDialog, setShowPermanentDeleteDialog] =
+    useState(false);
+
+  const [permanentDeleteConfirmEmail, setPermanentDeleteConfirmEmail] =
+    useState("");
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
   const [deleteImpact, setDeleteImpact] = useState<RemovalImpact | null>(null);
   const [filteredTeamCount, setFilteredTeamCount] = useState<number | null>(
@@ -221,6 +226,33 @@ const TeamTable: React.FC = () => {
       );
     },
   });
+
+  const permanentDeleteMutation = useMutation({
+    mutationFn: async (member: TeamMember) => {
+      await teamApi.deleteUser(member.id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["team"] });
+      setShowPermanentDeleteDialog(false);
+      setPermanentDeleteConfirmEmail("");
+      toast.success(i18n.t("team.permanentDeleteSuccess"));
+    },
+    onError: () => {
+      toast.error(i18n.t("team.permanentDeleteFailed"));
+    },
+  });
+
+  const handlePermanentDelete = (member: TeamMember) => {
+    setSelectedMember(member);
+    setPermanentDeleteConfirmEmail("");
+    setShowPermanentDeleteDialog(true);
+  };
+
+  const confirmPermanentDelete = () => {
+    if (selectedMember) {
+      permanentDeleteMutation.mutate(selectedMember);
+    }
+  };
 
   const handleEdit = (member: TeamMember) => {
     setSelectedMember(member);
@@ -547,6 +579,15 @@ const TeamTable: React.FC = () => {
                   ? i18n.t("team.deleteInvite")
                   : i18n.t("team.deleteUser")}
               </DropdownMenuItem>
+              {isSuperAdmin && !isInvitedMember(member) && (
+                <DropdownMenuItem
+                  onClick={() => handlePermanentDelete(member)}
+                  className="text-destructive font-semibold"
+                >
+                  <Trash size={16} className="mr-2" />
+                  {i18n.t("team.permanentlyDeleteUser")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         );
@@ -929,6 +970,7 @@ const TeamTable: React.FC = () => {
         open={showEditDialog}
         onOpenChange={handleDialogClose(setShowEditDialog)}
       >
+        {" "}
         <DialogContent className="border-border bg-card text-foreground sm:max-w-xl">
           <DialogHeader>
             <DialogTitle>{i18n.t("team.editMember")}</DialogTitle>
@@ -1019,6 +1061,64 @@ const TeamTable: React.FC = () => {
               disabled={!memberFormComplete || editMutation.isPending}
             >
               {i18n.t("save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Permanent Delete Confirmation Dialog — super admins only */}
+      <Dialog
+        open={showPermanentDeleteDialog}
+        onOpenChange={value => {
+          setShowPermanentDeleteDialog(value);
+          if (!value) {
+            setPermanentDeleteConfirmEmail("");
+            setSelectedMember(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="text-destructive">
+              {i18n.t("team.permanentlyDeleteUser")}
+            </DialogTitle>
+            <DialogDescription>
+              {i18n.t("team.permanentlyDeleteUserConfirm")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <p className="text-sm font-medium text-foreground">
+              {i18n.t("team.typeEmailToConfirm")}
+            </p>
+            <p className="text-sm font-mono text-muted-foreground">
+              {selectedMember?.email}
+            </p>
+            <input
+              type="email"
+              value={permanentDeleteConfirmEmail}
+              onChange={e => setPermanentDeleteConfirmEmail(e.target.value)}
+              placeholder={selectedMember?.email ?? ""}
+              className="flex h-11 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowPermanentDeleteDialog(false)}
+            >
+              {i18n.t("cancel")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmPermanentDelete}
+              disabled={
+                permanentDeleteConfirmEmail !== selectedMember?.email ||
+                permanentDeleteMutation.isPending
+              }
+            >
+              {permanentDeleteMutation.isPending
+                ? i18n.t("team.permanentlyDeleting")
+                : i18n.t("team.permanentlyDeleteUser")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/javascript/src/context/UserContext.tsx
+++ b/app/javascript/src/context/UserContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from "react";
 
 const UserContext = createContext({
   isAdminUser: false,
+  isSuperAdmin: false,
   locale: "en-US",
   setLocale: value => {},
   user: {
@@ -12,6 +13,7 @@ const UserContext = createContext({
     last_name: "",
     id: "",
     locale: "en-US",
+    is_super_admin: false,
   },
   avatarUrl: "",
   setCurrentAvatarUrl: value => {},

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -499,6 +499,13 @@ const en = {
     lastNameRequired: "Last Name cannot be blank",
     invalidEmail: "Invalid email ID",
     emailRequired: "Email ID cannot be blank",
+    permanentlyDeleteUser: "Permanently Delete User",
+    permanentlyDeleteUserConfirm:
+      "This will permanently delete the user account and all associated data. This action cannot be undone.",
+    typeEmailToConfirm: "Type the user's email address to confirm:",
+    permanentlyDeleting: "Deleting...",
+    permanentDeleteSuccess: "User has been permanently deleted.",
+    permanentDeleteFailed: "Failed to permanently delete user.",
   },
 
   // Invoices

--- a/app/policies/super_admin_user_policy.rb
+++ b/app/policies/super_admin_user_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Policy that gates destructive user operations to super admins only.
+# Used by Api::V1::UsersController#destroy.
+class SuperAdminUserPolicy < ApplicationPolicy
+  def destroy?
+    user.super_admin? && record.id != user.id
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -731,6 +731,9 @@ en:
       success:
         message: Changes saved successfully
     update_user: Update User
+  user:
+    super_admin_delete:
+      success: User %{email} has been permanently deleted.
   timeoff_entries:
     create:
       success: Added time off successfully

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -239,6 +239,9 @@ namespace :api, defaults: { format: "json" } do
     resources :users, concerns: :addressable do
       resources :previous_employments, only: [:create, :index, :show, :update], controller: "users/previous_employments"
       resources :devices, only: [:create, :index, :show, :update, :destroy], controller: "users/devices"
+      collection do
+        get "me"
+      end
     end
 
     resource :profile, only: [:update], controller: "profile"


### PR DESCRIPTION
- Add SuperAdminUserPolicy (Pundit) gating destroy to super admins only, preventing self-deletion
- Add DELETE /api/v1/users/:id controller action with hard destroy
- Expose is_super_admin in /users/_me and auth_user_payload
- Surface isSuperAdmin via UserContext and AppWithUserData
- Add teamApi.deleteUser to api.ts
- Add "Permanently Delete User" menu item in TeamTable (super admins only, active members only) with email-confirmation dialog before delete
- Add i18n keys for permanent delete flow (en.ts, en.yml)

Closes #2363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Super admins can now permanently delete team members with email confirmation.
  * User authentication responses now include super admin status indicator.

* **Documentation**
  * Added translation strings for permanent user deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->