### PR TITLE
fix: project team updates not reflected and last member cannot be rem…

### DIFF
--- a/app/javascript/src/components/Projects/Details/EditMembersList.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersList.tsx
@@ -104,8 +104,7 @@ const EditMembersList = ({
           removed_member_ids: removedIds,
         },
       });
-      setExistingMembers(members);
-      handleAddProjectDetails();
+      await handleAddProjectDetails();
       closeAddRemoveMembers();
       toast.success(i18n.t("projects.teamMembersUpdated"));
     } catch (error) {

--- a/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
+++ b/app/javascript/src/components/Projects/Details/EditMembersListForm.tsx
@@ -60,12 +60,10 @@ const EditMembersListForm = ({
   };
 
   const isSubmitDisabled =
-    members.length === 0 ||
     members.some(
       member =>
         !member.id || member.hourlyRate === "" || Number(member.hourlyRate) < 0
-    ) ||
-    Object.keys(errors).length > 0;
+    ) || Object.keys(errors).length > 0;
 
   return (
     <form className="space-y-6" onSubmit={handleSubmit}>

--- a/app/javascript/src/components/Projects/Details/Mobile/MemberListForm.tsx
+++ b/app/javascript/src/components/Projects/Details/Mobile/MemberListForm.tsx
@@ -71,8 +71,7 @@ const MembersListForm = ({
           removed_member_ids: removedIds,
         },
       });
-      setExistingMembers(members);
-      handleAddProjectDetails();
+      await handleAddProjectDetails();
       closeAddRemoveMembers();
       toast.success(i18n.t("projects.teamMembersUpdated"));
     }

--- a/app/javascript/src/components/Projects/Details/index.tsx
+++ b/app/javascript/src/components/Projects/Details/index.tsx
@@ -70,9 +70,7 @@ const ProjectDetails = () => {
 
   const currencySymb = currencySymbol(project?.client_currency);
 
-  const handleAddProjectDetails = () => {
-    fetchProject();
-  };
+  const handleAddProjectDetails = () => fetchProject();
 
   useEffect(() => {
     sendGAPageView();


### PR DESCRIPTION
…oved

- Remove members.length === 0 guard from isSubmitDisabled so saving with all members removed (empty team) is allowed
- Await handleAddProjectDetails() before closing the dialog so the parent project state is refreshed before the modal closes, preventing stale members from appearing on re-open
- Apply both fixes to desktop (EditMembersList) and mobile (Mobile/MemberListForm) flows
- Return the fetchProject promise from handleAddProjectDetails so it can be awaited by callers

Fixes #2359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved asynchronous handling in project member update workflows for better reliability.
  * Simplified project details refresh logic.
  * Code formatting and indentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->