### PR TITLE
fix: make line item input fields visually editable (#2360)

### DIFF
--- a/app/javascript/src/components/Invoices/common/ManualEntry/index.tsx
+++ b/app/javascript/src/components/Invoices/common/ManualEntry/index.tsx
@@ -119,7 +119,7 @@ const ManualEntry = ({
               <TooltipTrigger asChild>
                 <input
                   data-testid="invoice-manual-entry-name"
-                  className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+                  className="focus:outline-none w-full rounded border border-border bg-background p-1 text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
                   placeholder={i18n.t("invoices.enterName")}
                   type="text"
                   value={name}
@@ -159,7 +159,7 @@ const ManualEntry = ({
               <TooltipTrigger asChild>
                 <input
                   data-testid="invoice-manual-entry-rate"
-                  className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-right text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+                  className="focus:outline-none w-full rounded border border-border bg-background p-1 text-right text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
                   placeholder="0.00"
                   type="number"
                   value={rate}
@@ -177,7 +177,7 @@ const ManualEntry = ({
               <TooltipTrigger asChild>
                 <input
                   data-testid="invoice-manual-entry-quantity"
-                  className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-right text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+                  className="focus:outline-none w-full rounded border border-border bg-background p-1 text-right text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
                   placeholder="00:00"
                   type="text"
                   value={qtyInHHrMin}
@@ -247,7 +247,7 @@ const ManualEntry = ({
               <TooltipTrigger asChild>
                 <TextareaAutosize
                   data-testid="invoice-manual-entry-description"
-                  className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-sm font-medium text-muted-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+                  className="focus:outline-none w-full rounded border border-border bg-background p-1 text-sm font-medium text-muted-foreground focus:border-primary focus:ring-1 focus:ring-ring"
                   placeholder={i18n.t("invoices.enterDescription")}
                   value={description}
                   onChange={e => setDescription(e.target["value"])}

--- a/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
+++ b/app/javascript/src/components/Invoices/common/NewLineItemRow/LineItemEditorRow.tsx
@@ -119,7 +119,7 @@ const LineItemEditorRow = ({
       >
         <td className="px-1 py-3 text-left text-base font-normal text-foreground ">
           <input
-            className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+            className="focus:outline-none w-full rounded border border-border bg-background p-1 text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
             data-testid="invoice-line-item-name"
             placeholder={name}
             type="text"
@@ -139,7 +139,7 @@ const LineItemEditorRow = ({
         </td>
         <td className="px-1 py-3 text-right text-base font-normal text-foreground ">
           <input
-            className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-right text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+            className="focus:outline-none w-full rounded border border-border bg-background p-1 text-right text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
             data-testid="invoice-line-item-rate"
             placeholder={i18n.t("invoices.rate")}
             type="text"
@@ -150,7 +150,7 @@ const LineItemEditorRow = ({
         </td>
         <td className="px-1 py-3 text-right text-base font-normal text-foreground ">
           <input
-            className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-right text-sm font-medium text-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+            className="focus:outline-none w-full rounded border border-border bg-background p-1 text-right text-sm font-medium text-foreground focus:border-primary focus:ring-1 focus:ring-ring"
             data-testid="invoice-line-item-quantity"
             placeholder={i18n.t("invoices.quantity")}
             type="text"
@@ -181,7 +181,7 @@ const LineItemEditorRow = ({
           colSpan={2}
         >
           <TextareaAutosize
-            className="focus:outline-none w-full rounded border border-transparent bg-transparent p-1 text-sm font-medium text-muted-foreground focus:border-border focus:bg-background focus:ring-1 focus:ring-ring"
+            className="focus:outline-none w-full rounded border border-border bg-background p-1 text-sm font-medium text-muted-foreground focus:border-primary focus:ring-1 focus:ring-ring"
             data-testid="invoice-line-item-description"
             placeholder={i18n.t("invoices.enterDescription")}
             value={description}


### PR DESCRIPTION
Input fields for Item Name, Rate, Quantity, and Description in both ManualEntry and LineItemEditorRow had border-transparent/bg-transparent at rest, making them appear as static text. Changed to border-border/ bg-background so fields show a visible border at rest and switch to focus:border-primary on focus, consistent with other inputs in the app.

Fixes #2360 