### PR TITLE
fix: wire up Download Receipt action on Payments page

### DIFF
--- a/app/javascript/src/components/payments/PaymentsTable.tsx
+++ b/app/javascript/src/components/payments/PaymentsTable.tsx
@@ -594,10 +594,12 @@ const PaymentsTable: React.FC = () => {
                     : i18n.t("payments.withdrawToUpi")}
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onClick={() => downloadReceipt(payment)}>
-                <Download className="h-4 w-4 mr-2" />
-                {i18n.t("payments.downloadReceipt")}
-              </DropdownMenuItem>
+              {payment.invoiceId && (
+                <DropdownMenuItem onClick={() => downloadReceipt(payment)}>
+                  <Download className="h-4 w-4 mr-2" />
+                  {i18n.t("payments.downloadReceipt")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         );

--- a/app/javascript/src/components/payments/PaymentsTable.tsx
+++ b/app/javascript/src/components/payments/PaymentsTable.tsx
@@ -40,7 +40,7 @@ import {
 } from "phosphor-react";
 import { currencyFormat } from "../../helpers/currency";
 import { useUserContext } from "../../context/UserContext";
-import { payment, paymentsApi } from "apis/api";
+import { invoicesApi, payment, paymentsApi } from "apis/api";
 import { toast } from "sonner";
 import { unmapPayment } from "../../mapper/mappedIndex";
 import AddManualEntry from "./Modals/AddManualEntry";
@@ -234,6 +234,29 @@ const PaymentsTable: React.FC = () => {
       );
     } catch {
       toast.error(i18n.t("payments.bulkDownloadFailed"));
+    }
+  };
+
+  const downloadReceipt = async (payment: Payment) => {
+    if (!payment.invoiceId) {
+      toast.error(i18n.t("payments.downloadReceiptFailed"));
+
+      return;
+    }
+
+    try {
+      const response = await invoicesApi.downloadInvoice(payment.invoiceId);
+      const blob = new Blob([response.data], { type: "application/pdf" });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `receipt-${payment.invoiceNumber}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch {
+      toast.error(i18n.t("payments.downloadReceiptFailed"));
     }
   };
 
@@ -571,7 +594,7 @@ const PaymentsTable: React.FC = () => {
                     : i18n.t("payments.withdrawToUpi")}
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem>
+              <DropdownMenuItem onClick={() => downloadReceipt(payment)}>
                 <Download className="h-4 w-4 mr-2" />
                 {i18n.t("payments.downloadReceipt")}
               </DropdownMenuItem>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -793,6 +793,7 @@ const en = {
     bulkDownloadFailed: "Failed to download selected payments.",
     viewInvoice: "View invoice",
     downloadReceipt: "Download receipt",
+    downloadReceiptFailed: "Failed to download receipt.",
     withdrawToUpi: "Withdraw to UPI",
     retryWithdrawal: "Retry withdrawal",
     withdrawing: "Withdrawing...",


### PR DESCRIPTION
## Summary

Fixes #2361

The "Download receipt" option in the Payments page three-dot menu was a dead UI element — rendered correctly but with no `onClick` handler, so clicking it did nothing.

## What changed

- **`PaymentsTable.tsx`**: Added `invoicesApi` import, a `downloadReceipt(payment)` handler, and wired up `onClick` on the `DropdownMenuItem`
- **`en.ts`**: Added `downloadReceiptFailed` i18n key for error feedback

## How it works

The handler calls the existing `invoicesApi.downloadInvoice(payment.invoiceId)` which hits `GET /api/v1/invoices/:id/download` — the same endpoint used by the invoice detail page. It triggers a browser file download named `receipt-<invoiceNumber>.pdf`. If the payment has no associated invoice or the request fails, an error toast is shown.

## Testing

1. Go to Payments
2. Click the three-dot menu for any payment entry
3. Click **Download receipt**
4. A PDF receipt should download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to download a payment receipt directly from the payments table.
  * Receipt downloads now use the payment’s invoice details and save with a clear filename.
* **Bug Fixes**
  * Added error handling for missing receipt information and failed downloads.
  * Displayed a user-friendly message when a receipt can’t be downloaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->