### PR TITLE
fix: enforce owner removal permissions on team (#2362)

### DIFF
--- a/app/javascript/src/components/Team/List/Table/MoreOptions.tsx
+++ b/app/javascript/src/components/Team/List/Table/MoreOptions.tsx
@@ -1,4 +1,4 @@
-import { TeamModalType } from "constants/index";
+import { TeamModalType, Roles } from "constants/index";
 
 import React from "react";
 
@@ -18,10 +18,26 @@ type Iprops = {
 
 const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
   const { setModalState } = useList();
-  const { isDesktop } = useUserContext();
+  const { isDesktop, companyRole, user: currentUser } = useUserContext();
 
   const handleResendInvite = async () => {
     await teamApi.resendInvite(item.id);
+  };
+
+  // Returns true when the current user is permitted to delete a member.
+  // Mirrors TeamPolicy on the server:
+  //  - Owners cannot delete themselves (ownership transfer required).
+  //  - Admins cannot delete owners.
+  const canDeleteMember = (member: any): boolean => {
+    if (companyRole === Roles.OWNER && member.id === currentUser.id) {
+      return false;
+    }
+
+    if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) {
+      return false;
+    }
+
+    return true;
   };
 
   const handleAction = (e, action) => {
@@ -51,16 +67,18 @@ const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
           <EditIcon size={16} weight="bold" />
         </Button>
       </Tooltip>
-      <Tooltip content={i18n.t("delete")}>
-        <Button
-          style="ternary"
-          onClick={e => {
-            handleAction(e, TeamModalType.DELETE);
-          }}
-        >
-          <DeleteIcon className="text-destructive" size={16} weight="bold" />
-        </Button>
-      </Tooltip>
+      {canDeleteMember(item) && (
+        <Tooltip content={i18n.t("delete")}>
+          <Button
+            style="ternary"
+            onClick={e => {
+              handleAction(e, TeamModalType.DELETE);
+            }}
+          >
+            <DeleteIcon className="text-destructive" size={16} weight="bold" />
+          </Button>
+        </Tooltip>
+      )}
     </HoverMoreOptions>
   ) : (
     <MobileMoreOptions
@@ -77,16 +95,18 @@ const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
         <EditIcon className="mr-4" color="#5E58F1" size={16} />
         {i18n.t("edit")}
       </li>
-      <li
-        className="flex items-center px-2 pt-3 text-sm leading-5 text-destructive"
-        onClick={e => {
-          setShowMoreOptions(false);
-          handleAction(e, TeamModalType.DELETE);
-        }}
-      >
-        <DeleteIcon className="mr-4" size={16} />
-        {i18n.t("delete")}
-      </li>
+      {canDeleteMember(item) && (
+        <li
+          className="flex items-center px-2 pt-3 text-sm leading-5 text-destructive"
+          onClick={e => {
+            setShowMoreOptions(false);
+            handleAction(e, TeamModalType.DELETE);
+          }}
+        >
+          <DeleteIcon className="mr-4" size={16} />
+          {i18n.t("delete")}
+        </li>
+      )}
     </MobileMoreOptions>
   );
 };

--- a/app/javascript/src/components/Team/List/Table/MoreOptions.tsx
+++ b/app/javascript/src/components/Team/List/Table/MoreOptions.tsx
@@ -1,4 +1,4 @@
-import { TeamModalType, Roles } from "constants/index";
+import { TeamModalType } from "constants/index";
 
 import React from "react";
 
@@ -6,6 +6,7 @@ import { teamApi } from "apis/api";
 import HoverMoreOptions from "common/HoverMoreOptions";
 import { useList } from "context/TeamContext";
 import { useUserContext } from "context/UserContext";
+import { canDeleteTeamMember } from "helpers/teamPermissions";
 import { i18n } from "../../../../i18n";
 import { DeleteIcon, EditIcon, ResendInviteIcon } from "miruIcons";
 import { Button, MobileMoreOptions, Tooltip } from "StyledComponents";
@@ -22,22 +23,6 @@ const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
 
   const handleResendInvite = async () => {
     await teamApi.resendInvite(item.id);
-  };
-
-  // Returns true when the current user is permitted to delete a member.
-  // Mirrors TeamPolicy on the server:
-  //  - Owners cannot delete themselves (ownership transfer required).
-  //  - Admins cannot delete owners.
-  const canDeleteMember = (member: any): boolean => {
-    if (companyRole === Roles.OWNER && member.id === currentUser.id) {
-      return false;
-    }
-
-    if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) {
-      return false;
-    }
-
-    return true;
   };
 
   const handleAction = (e, action) => {
@@ -67,7 +52,7 @@ const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
           <EditIcon size={16} weight="bold" />
         </Button>
       </Tooltip>
-      {canDeleteMember(item) && (
+      {canDeleteTeamMember(companyRole, item, currentUser) && (
         <Tooltip content={i18n.t("delete")}>
           <Button
             style="ternary"
@@ -95,7 +80,7 @@ const MoreOptions = ({ item, setShowMoreOptions, showMoreOptions }: Iprops) => {
         <EditIcon className="mr-4" color="#5E58F1" size={16} />
         {i18n.t("edit")}
       </li>
-      {canDeleteMember(item) && (
+      {canDeleteTeamMember(companyRole, item, currentUser) && (
         <li
           className="flex items-center px-2 pt-3 text-sm leading-5 text-destructive"
           onClick={e => {

--- a/app/javascript/src/components/Team/TeamTable.tsx
+++ b/app/javascript/src/components/Team/TeamTable.tsx
@@ -46,7 +46,7 @@ import { teamApi } from "apis/api";
 import { unmapList, unmapPagyData } from "../../mapper/team.mapper";
 import { toast } from "sonner";
 import { Roles } from "../../constants/index";
-import { getDisplayAvatarUrl } from "../../helpers";
+import { canDeleteTeamMember, getDisplayAvatarUrl } from "../../helpers";
 
 interface TeamMember {
   id: string;
@@ -271,22 +271,6 @@ const TeamTable: React.FC = () => {
     if (selectedMember) {
       deleteMutation.mutate(selectedMember);
     }
-  };
-
-  // Returns true when the current user is permitted to delete a member.
-  // Rules (mirrors TeamPolicy on the server):
-  //  - Owners cannot delete themselves (ownership transfer required).
-  //  - Admins cannot delete owners.
-  const canDeleteMember = (member: TeamMember): boolean => {
-    if (companyRole === Roles.OWNER && member.id === currentUser.id) {
-      return false;
-    }
-
-    if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) {
-      return false;
-    }
-
-    return true;
   };
 
   const getRoleIcon = (role: string) => {
@@ -559,7 +543,7 @@ const TeamTable: React.FC = () => {
                 <PencilSimple size={16} className="mr-2" />
                 {i18n.t("team.editMember")}
               </DropdownMenuItem>
-              {canDeleteMember(member) && (
+              {canDeleteTeamMember(companyRole, member, currentUser) && (
                 <DropdownMenuItem
                   onClick={() => handleDelete(member)}
                   className="text-destructive"

--- a/app/javascript/src/components/Team/TeamTable.tsx
+++ b/app/javascript/src/components/Team/TeamTable.tsx
@@ -121,7 +121,12 @@ const isInvitedMember = (member: TeamMember | null) =>
 const TeamTable: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { isAdminUser, company } = useUserContext();
+  const {
+    isAdminUser,
+    company,
+    companyRole,
+    user: currentUser,
+  } = useUserContext();
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -266,6 +271,22 @@ const TeamTable: React.FC = () => {
     if (selectedMember) {
       deleteMutation.mutate(selectedMember);
     }
+  };
+
+  // Returns true when the current user is permitted to delete a member.
+  // Rules (mirrors TeamPolicy on the server):
+  //  - Owners cannot delete themselves (ownership transfer required).
+  //  - Admins cannot delete owners.
+  const canDeleteMember = (member: TeamMember): boolean => {
+    if (companyRole === Roles.OWNER && member.id === currentUser.id) {
+      return false;
+    }
+
+    if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) {
+      return false;
+    }
+
+    return true;
   };
 
   const getRoleIcon = (role: string) => {
@@ -538,15 +559,17 @@ const TeamTable: React.FC = () => {
                 <PencilSimple size={16} className="mr-2" />
                 {i18n.t("team.editMember")}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => handleDelete(member)}
-                className="text-destructive"
-              >
-                <Trash size={16} className="mr-2" />
-                {isInvitedMember(member)
-                  ? i18n.t("team.deleteInvite")
-                  : i18n.t("team.deleteUser")}
-              </DropdownMenuItem>
+              {canDeleteMember(member) && (
+                <DropdownMenuItem
+                  onClick={() => handleDelete(member)}
+                  className="text-destructive"
+                >
+                  <Trash size={16} className="mr-2" />
+                  {isInvitedMember(member)
+                    ? i18n.t("team.deleteInvite")
+                    : i18n.t("team.deleteUser")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         );

--- a/app/javascript/src/helpers/index.ts
+++ b/app/javascript/src/helpers/index.ts
@@ -11,6 +11,7 @@ import { lineTotalCalc } from "./lineTotalCalc";
 import { getLineItemDisplayName } from "./lineItemDisplayName";
 import { getNumberWithOrdinal } from "./ordinal";
 import { useOutsideClick } from "./outsideClick";
+import { canDeleteTeamMember } from "./teamPermissions";
 import useKeypress from "./useKeyPress";
 import { validateTimesheetEntry } from "./validateTimesheetEntry";
 
@@ -30,6 +31,7 @@ export {
   getLineItemDisplayName,
   useDebounce,
   useOutsideClick,
+  canDeleteTeamMember,
   useKeypress,
   validateTimesheetEntry,
 };

--- a/app/javascript/src/helpers/teamPermissions.ts
+++ b/app/javascript/src/helpers/teamPermissions.ts
@@ -16,7 +16,14 @@ export const canDeleteTeamMember = (
 ) => {
   if (companyRole !== Roles.OWNER && companyRole !== Roles.ADMIN) return false;
 
-  if (companyRole === Roles.OWNER && member.id === currentUser.id) return false;
+  if (
+    companyRole === Roles.OWNER &&
+    member.id != null &&
+    currentUser.id != null &&
+    String(member.id) === String(currentUser.id)
+  ) {
+    return false;
+  }
 
   if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) return false;
 

--- a/app/javascript/src/helpers/teamPermissions.ts
+++ b/app/javascript/src/helpers/teamPermissions.ts
@@ -1,0 +1,24 @@
+import { Roles } from "constants/index";
+
+type TeamPermissionMember = {
+  id?: number | string;
+  role?: string;
+};
+
+type TeamPermissionUser = {
+  id?: number | string;
+};
+
+export const canDeleteTeamMember = (
+  companyRole: string,
+  member: TeamPermissionMember,
+  currentUser: TeamPermissionUser
+) => {
+  if (companyRole !== Roles.OWNER && companyRole !== Roles.ADMIN) return false;
+
+  if (companyRole === Roles.OWNER && member.id === currentUser.id) return false;
+
+  if (companyRole === Roles.ADMIN && member.role === Roles.OWNER) return false;
+
+  return true;
+};

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -25,27 +25,27 @@ class TeamPolicy < ApplicationPolicy
       return false
     end
 
-    return false if only_owner_removing_self?
+    return false if owner_removing_self?
+    return false if admin_removing_owner?
 
     user_owner_role? || user_admin_role?
   end
 
-  def only_owner_removing_self?
+  # Owners must transfer ownership before removing themselves.
+  def owner_removing_self?
     return false unless record.user_id == user.id
     return false unless user.has_role?(:owner, record.company)
 
-    is_last_owner = owner_role_count_for_company <= 1
-    @error_message_key = :last_owner_self_removal if is_last_owner
-    is_last_owner
+    @error_message_key = :owner_self_removal
+    true
   end
 
-  def owner_role_count_for_company
-    User
-      .joins(:roles, :employments)
-      .where(roles: { name: "owner", resource_type: "Company", resource_id: record.company_id })
-      .merge(User.kept)
-      .merge(Employment.kept.where(company_id: record.company_id))
-      .distinct
-      .count
+  # Admins are not permitted to remove owners.
+  def admin_removing_owner?
+    return false unless user_admin_role?
+    return false unless record.user.has_role?(:owner, record.company)
+
+    @error_message_key = :admin_cannot_remove_owner
+    true
   end
 end

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -636,7 +636,8 @@ en-US:
     team_policy:
       destroy?: You are not authorized to destroy team.
       edit?: You are not authorized to edit team.
-      last_owner_self_removal: You cannot remove yourself because you are the only workspace owner.
+      owner_self_removal: You cannot remove yourself. Transfer ownership to another user first.
+      admin_cannot_remove_owner: Admins cannot remove the workspace owner.
       update?: You are not authorized to update team.
   registration:
     confirm_password: confirm password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -652,7 +652,8 @@ en:
     team_policy:
       destroy?: You are not authorized to destroy team.
       edit?: You are not authorized to edit team.
-      last_owner_self_removal: You cannot remove yourself because you are the only workspace owner.
+      owner_self_removal: You cannot remove yourself. Transfer ownership to another user first.
+      admin_cannot_remove_owner: Admins cannot remove the workspace owner.
       update?: You are not authorized to update team.
   registration:
     confirm_password: confirm password

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe TeamPolicy, type: :policy, test_ploi: true do
       end
     end
 
+    context "when an admin removes another admin" do
+      let(:other_admin) { create(:user, current_workspace_id: company.id) }
+      let(:other_admin_employment) do
+        create(:employment, company:, user: other_admin)
+      end
+
+      before do
+        other_admin.add_role :admin, company
+      end
+
+      it "grants permission" do
+        expect(described_class).to permit(admin, other_admin_employment)
+      end
+    end
+
     context "when an owner tries to remove themselves" do
       it "does not grant permission" do
         expect(described_class).not_to permit(owner, owner_employment)

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -70,4 +70,35 @@ RSpec.describe TeamPolicy, type: :policy, test_ploi: true do
       end
     end
   end
+
+  permissions :destroy? do
+    let(:owner_employment) { create(:employment, company:, user: owner) }
+    let(:admin_employment) { create(:employment, company:, user: admin) }
+    let(:employee_employment) { create(:employment, company:, user: employee) }
+
+    context "when an admin tries to remove the owner" do
+      it "does not grant permission" do
+        expect(described_class).not_to permit(admin, owner_employment)
+      end
+    end
+
+    context "when an admin removes a non-owner member" do
+      it "grants permission" do
+        expect(described_class).to permit(admin, employee_employment)
+      end
+    end
+
+    context "when an owner tries to remove themselves" do
+      it "does not grant permission" do
+        expect(described_class).not_to permit(owner, owner_employment)
+      end
+    end
+
+    context "when an owner removes another member" do
+      it "grants permission" do
+        expect(described_class).to permit(owner, admin_employment)
+        expect(described_class).to permit(owner, employee_employment)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/team/destroy_spec.rb
+++ b/spec/requests/api/v1/team/destroy_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Api::V1::Team#destroy", type: :request do
         send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(owner_user)
 
         expect(response).to have_http_status(:forbidden)
-        expect(json_response["errors"]).to eq(I18n.t("pundit.team_policy.last_owner_self_removal"))
+        expect(json_response["errors"]).to eq(I18n.t("pundit.team_policy.owner_self_removal"))
       end
 
       it "does not discard the owner employment" do
@@ -177,16 +177,66 @@ RSpec.describe "Api::V1::Team#destroy", type: :request do
         sign_in owner_user
       end
 
-      it "allows self removal" do
+      it "still forbids self removal until ownership is transferred" do
         owner_employment = company.employments.kept.find_by!(user: owner_user)
 
         expect {
           send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(owner_user)
+        }.not_to change(company.employments.kept, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response["errors"]).to eq(I18n.t("pundit.team_policy.owner_self_removal"))
+        expect(owner_employment.reload.discarded?).to be_falsey
+      end
+    end
+
+    context "when owner removes another member" do
+      let(:team_user) { create(:user, current_workspace_id: company.id) }
+
+      before do
+        create(:employment, company:, user: owner_user)
+        @team_company_user = create(:employment, company:, user: team_user)
+        owner_user.add_role :owner, company
+        team_user.add_role :employee, company
+        sign_in owner_user
+      end
+
+      it "allows removing the member" do
+        expect {
+          send_request :delete, api_v1_team_path(team_user), headers: auth_headers(owner_user)
         }.to change(company.employments.kept, :count).by(-1)
 
         expect(response).to be_successful
-        expect(owner_employment.reload.discarded?).to be_truthy
+        expect(@team_company_user.reload.discarded?).to be_truthy
       end
+    end
+  end
+
+  describe "when admin tries to remove the owner" do
+    let(:admin_user) { create(:user, current_workspace_id: company.id) }
+    let(:owner_user) { create(:user, current_workspace_id: company.id) }
+
+    before do
+      create(:employment, company:, user: admin_user)
+      @owner_employment = create(:employment, company:, user: owner_user)
+      admin_user.add_role :admin, company
+      owner_user.add_role :owner, company
+      sign_in admin_user
+    end
+
+    it "returns forbidden response with a clear message" do
+      send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(admin_user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response["errors"]).to eq(I18n.t("pundit.team_policy.admin_cannot_remove_owner"))
+    end
+
+    it "does not discard the owner employment" do
+      expect {
+        send_request :delete, api_v1_team_path(owner_user), headers: auth_headers(admin_user)
+      }.not_to change(company.employments.kept, :count)
+
+      expect(@owner_employment.reload.discarded?).to be_falsey
     end
   end
 


### PR DESCRIPTION
TeamPolicy#destroy? only checked the acting user's role, so admins could remove the workspace owner and owners could remove themselves without transferring ownership.

- Block admins from removing a member who holds the owner role
- Block owners from removing themselves until ownership is transferred
- Hide the delete action in the team UI for these cases (backend stays the enforcement point)
- Add owner_self_removal and admin_cannot_remove_owner locale messages
- Cover the new rules in team policy and destroy request specs

Fixes #2362 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Team member deletion now follows stricter role-based rules: owners can’t remove themselves, and admins can’t remove workspace owners. The delete option in team action menus (desktop and mobile) is now shown only when the current user is permitted, and forbidden responses use updated, more specific error messages.

## Tests
* Updated and expanded policy and API request coverage to match the new owner/admin deletion behaviors and updated I18n error keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->