### PR TITLE
fix: keep invoice infinite scroll visible for filters

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceList.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceList.tsx
@@ -613,15 +613,11 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
                   total: totalInvoices,
                 })}
           </span>
-          {!hasActiveFilters && hasMore && !isLoadingMore && (
+          {hasMore && !isLoadingMore && (
             <span>{i18n.t("invoices.scrollToLoadMore")}</span>
           )}
-          {!hasActiveFilters && hasMore && !isLoadingMore && (
-            <div className="h-8 w-full" />
-          )}
-          {!hasActiveFilters && !hasMore && (
-            <span>{i18n.t("invoices.allInvoicesLoaded")}</span>
-          )}
+          {hasMore && !isLoadingMore && <div className="h-8 w-full" />}
+          {!hasMore && <span>{i18n.t("invoices.allInvoicesLoaded")}</span>}
         </div>
       )}
 

--- a/spec/e2e/invoices-infinite-scroll.spec.ts
+++ b/spec/e2e/invoices-infinite-scroll.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "playwright/test";
+
+const invoice = (id: number) => ({
+  id,
+  amount: "100.0",
+  client: { name: "Acme", logo: "" },
+  company: { baseCurrency: "USD" },
+  currency: "USD",
+  dueDate: "Jun 30, 2026",
+  invoiceNumber: `INV-${String(id).padStart(3, "0")}`,
+  issueDate: "Jun 01, 2026",
+  status: "draft",
+});
+
+const invoiceResponse = (page: number) => ({
+  invoices: Array.from({ length: 20 }, (_, index) =>
+    invoice((page - 1) * 20 + index + 1)
+  ),
+  paginationDetails: { page, pages: 2, total: 40 },
+  summary: {
+    draftAmount: 4000,
+    openAmount: 0,
+    outstandingAmount: 0,
+    overdueAmount: 0,
+    draftCount: 40,
+    openCount: 0,
+    outstandingCount: 0,
+    overdueCount: 0,
+    paidCount: 0,
+    totalCount: 40,
+    totalAmount: 4000,
+    currency: "USD",
+  },
+  recentlyUpdatedInvoices: [],
+  recentlyUpdatedTotalCount: 40,
+  meta: {},
+});
+
+test("invoice infinite scroll loads the next filtered page", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  const requestedUrls: URL[] = [];
+
+  page.on("console", message => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", error => consoleErrors.push(error.message));
+
+  await page.goto("http://127.0.0.1:3001/user/sign_in");
+  await page.getByRole("textbox", { name: "Email" }).fill("vipul@saeloun.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("password");
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.waitForURL("**/dashboard", { timeout: 10000 });
+
+  await page.route("**/api/v1/payments/settings", route =>
+    route.fulfill({
+      json: { providers: { stripe: {}, upi: {}, razorpay: {} } },
+    })
+  );
+  await page.route("**/api/v1/invoices/analytics/monthly_revenue", route =>
+    route.fulfill({
+      json: { chart_data: [], statistics: {} },
+    })
+  );
+  await page.route("**/api/v1/invoices/recently_updated?**", route =>
+    route.fulfill({
+      json: {
+        invoices: [],
+        meta: { has_more: false, total_count: 0 },
+      },
+    })
+  );
+  await page.route("**/api/v1/invoices**", route => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== "/api/v1/invoices") return route.fallback();
+
+    requestedUrls.push(url);
+
+    return route.fulfill({
+      json: invoiceResponse(Number(url.searchParams.get("page") || 1)),
+    });
+  });
+
+  await page.goto("http://127.0.0.1:3001/invoices");
+  await expect(page.getByText("INV-001")).toBeVisible();
+  await page.getByRole("button", { name: /Draft.*40 Invoices/ }).click();
+  await expect(page.getByText("Scroll to load more invoices")).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect
+    .poll(() => requestedUrls.some(url => url.searchParams.get("page") === "2"))
+    .toBe(true);
+  expect(consoleErrors).toEqual([]);
+});

--- a/spec/e2e/invoices-infinite-scroll.spec.ts
+++ b/spec/e2e/invoices-infinite-scroll.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "playwright/test";
 
+const appUrl = process.env.PLAYWRIGHT_APP_URL || "http://127.0.0.1:3000";
+
 const invoice = (id: number) => ({
   id,
   amount: "100.0",
@@ -47,7 +49,7 @@ test("invoice infinite scroll loads the next filtered page", async ({
   });
   page.on("pageerror", error => consoleErrors.push(error.message));
 
-  await page.goto("http://127.0.0.1:3001/user/sign_in");
+  await page.goto(`${appUrl}/user/sign_in`);
   await page.getByRole("textbox", { name: "Email" }).fill("vipul@saeloun.com");
   await page.getByRole("textbox", { name: "Password" }).fill("password");
   await page.getByRole("button", { name: "Sign in", exact: true }).click();
@@ -82,7 +84,7 @@ test("invoice infinite scroll loads the next filtered page", async ({
     });
   });
 
-  await page.goto("http://127.0.0.1:3001/invoices");
+  await page.goto(`${appUrl}/invoices`);
   await expect(page.getByText("INV-001")).toBeVisible();
   await page.getByRole("button", { name: /Draft.*40 Invoices/ }).click();
   await expect(page.getByText("Scroll to load more invoices")).toBeVisible();


### PR DESCRIPTION
## Summary
- Keep invoice infinite-scroll load state visible when a status/search filter is active.
- Add a Playwright regression that filters to Draft invoices, verifies the load-more state, scrolls, confirms page 2 is requested, and checks for console/page errors.

## Verification
- `rtk mise exec -- env PLAYWRIGHT_APP_URL=http://127.0.0.1:3001 pnpm exec playwright test spec/e2e/invoices-infinite-scroll.spec.ts`
- `rtk mise exec -- timeout 30 bin/vite build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "scroll to load more" indicator and "all invoices loaded" message now display correctly when active search or filter criteria are applied to the invoice list view.

* **Tests**
  * Added end-to-end tests to verify that infinite scroll pagination behavior works correctly on the invoices page when search filters and other filter options are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->