### PR TITLE
chore: promote filtered invoice scroll fix to production

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceList.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceList.tsx
@@ -48,6 +48,7 @@ import { currencyFormat } from "../../helpers/currency";
 import { useUserContext } from "../../context/UserContext";
 import { i18n } from "../../i18n";
 import { useNavigate } from "react-router-dom";
+import { INVOICES_PAGE_SIZE } from "./usePaginatedInvoices";
 
 interface InvoiceListProps {
   invoices: Invoice[];
@@ -267,6 +268,14 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
   const hasActiveFilters =
     searchTerm.trim().length > 0 || filterParams.status.length > 0;
 
+  const shouldKeepLoadingFilteredInvoices =
+    hasActiveFilters &&
+    filteredInvoices.length < INVOICES_PAGE_SIZE &&
+    hasMore &&
+    !isLoading &&
+    !isLoadingMore &&
+    Boolean(onLoadMore);
+
   // Infinite scroll implementation
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -294,6 +303,12 @@ const InvoiceList: React.FC<InvoiceListProps> = ({
       }
     };
   }, [hasMore, isLoadingMore, onLoadMore]);
+
+  useEffect(() => {
+    if (shouldKeepLoadingFilteredInvoices) {
+      onLoadMore?.();
+    }
+  }, [onLoadMore, shouldKeepLoadingFilteredInvoices]);
 
   const canManageInvoices = companyRole === "owner" || companyRole === "admin";
 

--- a/app/javascript/src/components/Invoices/usePaginatedInvoices.ts
+++ b/app/javascript/src/components/Invoices/usePaginatedInvoices.ts
@@ -20,7 +20,7 @@ interface UsePaginatedInvoicesResult {
   loadMoreInvoices: () => Promise<void>;
 }
 
-const DEFAULT_PER_PAGE = 50;
+export const INVOICES_PAGE_SIZE = 100;
 
 export const usePaginatedInvoices = (): UsePaginatedInvoicesResult => {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
@@ -52,7 +52,7 @@ export const usePaginatedInvoices = (): UsePaginatedInvoicesResult => {
         }
 
         const response = await invoiceApi.getInvoices({
-          per: DEFAULT_PER_PAGE,
+          per: INVOICES_PAGE_SIZE,
           page,
         } as any);
 

--- a/spec/e2e/invoices-infinite-scroll.spec.ts
+++ b/spec/e2e/invoices-infinite-scroll.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "playwright/test";
 
 const appUrl = process.env.PLAYWRIGHT_APP_URL || "http://127.0.0.1:3000";
 
-const invoice = (id: number) => ({
+const invoice = (id: number, status = "draft") => ({
   id,
   amount: "100.0",
   client: { name: "Acme", logo: "" },
@@ -11,30 +11,30 @@ const invoice = (id: number) => ({
   dueDate: "Jun 30, 2026",
   invoiceNumber: `INV-${String(id).padStart(3, "0")}`,
   issueDate: "Jun 01, 2026",
-  status: "draft",
+  status,
 });
 
 const invoiceResponse = (page: number) => ({
-  invoices: Array.from({ length: 20 }, (_, index) =>
-    invoice((page - 1) * 20 + index + 1)
+  invoices: Array.from({ length: 100 }, (_, index) =>
+    invoice((page - 1) * 100 + index + 1)
   ),
-  paginationDetails: { page, pages: 2, total: 40 },
+  paginationDetails: { page, pages: 2, total: 200 },
   summary: {
-    draftAmount: 4000,
+    draftAmount: 20000,
     openAmount: 0,
     outstandingAmount: 0,
     overdueAmount: 0,
-    draftCount: 40,
+    draftCount: 200,
     openCount: 0,
     outstandingCount: 0,
     overdueCount: 0,
     paidCount: 0,
-    totalCount: 40,
-    totalAmount: 4000,
+    totalCount: 200,
+    totalAmount: 20000,
     currency: "USD",
   },
   recentlyUpdatedInvoices: [],
-  recentlyUpdatedTotalCount: 40,
+  recentlyUpdatedTotalCount: 200,
   meta: {},
 });
 
@@ -86,12 +86,103 @@ test("invoice infinite scroll loads the next filtered page", async ({
 
   await page.goto(`${appUrl}/invoices`);
   await expect(page.getByText("INV-001")).toBeVisible();
-  await page.getByRole("button", { name: /Draft.*40 Invoices/ }).click();
+  await page.getByRole("button", { name: /Draft.*200 Invoices/ }).click();
   await expect(page.getByText("Scroll to load more invoices")).toBeVisible();
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   await expect
     .poll(() => requestedUrls.some(url => url.searchParams.get("page") === "2"))
     .toBe(true);
+  expect(consoleErrors).toEqual([]);
+});
+
+test("filtered invoice list keeps loading until matching invoices are found", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  const requestedUrls: URL[] = [];
+
+  page.on("console", message => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", error => consoleErrors.push(error.message));
+
+  await page.goto(`${appUrl}/user/sign_in`);
+  await page.getByRole("textbox", { name: "Email" }).fill("vipul@saeloun.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("password");
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.waitForURL("**/dashboard", { timeout: 10000 });
+
+  await page.route("**/api/v1/payments/settings", route =>
+    route.fulfill({
+      json: { providers: { stripe: {}, upi: {}, razorpay: {} } },
+    })
+  );
+  await page.route("**/api/v1/invoices/analytics/monthly_revenue", route =>
+    route.fulfill({
+      json: { chart_data: [], statistics: {} },
+    })
+  );
+  await page.route("**/api/v1/invoices/recently_updated?**", route =>
+    route.fulfill({
+      json: {
+        invoices: [],
+        meta: { has_more: false, total_count: 0 },
+      },
+    })
+  );
+  await page.route("**/api/v1/invoices**", route => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== "/api/v1/invoices") return route.fallback();
+
+    requestedUrls.push(url);
+    const pageNumber = Number(url.searchParams.get("page") || 1);
+    const invoices =
+      pageNumber === 1
+        ? Array.from({ length: 100 }, (_, index) =>
+            invoice(index + 1, "sent")
+          )
+        : Array.from({ length: 5 }, (_, index) =>
+            invoice(100 + index + 1, "draft")
+          );
+
+    return route.fulfill({
+      json: {
+        invoices,
+        paginationDetails: { page: pageNumber, pages: 2, total: 105 },
+        summary: {
+          draftAmount: 500,
+          openAmount: 10000,
+          outstandingAmount: 10000,
+          overdueAmount: 0,
+          draftCount: 5,
+          openCount: 100,
+          outstandingCount: 100,
+          overdueCount: 0,
+          paidCount: 0,
+          totalCount: 105,
+          totalAmount: 10500,
+          currency: "USD",
+        },
+        recentlyUpdatedInvoices: [],
+        recentlyUpdatedTotalCount: 105,
+        meta: {},
+      },
+    });
+  });
+
+  await page.goto(`${appUrl}/invoices`);
+  await expect(page.getByText("INV-001")).toBeVisible();
+  await expect
+    .poll(() => requestedUrls[0]?.searchParams.get("per"))
+    .toBe("100");
+
+  await page.getByRole("button", { name: /Draft.*5 Invoices/ }).click();
+
+  await expect
+    .poll(() => requestedUrls.some(url => url.searchParams.get("page") === "2"))
+    .toBe(true);
+  await expect(page.getByText("INV-101")).toBeVisible();
+  await expect(page.getByText(/Viewing 5 matching invoice/)).toBeVisible();
   expect(consoleErrors).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- Promote the filtered invoice infinite-scroll fix to production.
- Includes 100 invoices per page and filter-aware auto-loading while matching results are sparse.

## Verification
- rtk mise exec -- timeout 30 bin/vite build
- PR #2371 checks passed on develop
- Local browser verification on /invoices: initial per=100, Draft filter fetched page 2 and page 3, no console/page errors
