### PR TITLE
build: update vulnerable gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       xpath (~> 3.2)
     cbor (0.5.10.1)
     chunky_png (1.4.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     console (1.34.3)
       fiber-annotation
@@ -211,7 +211,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     csv (3.3.5)
     cuprite (0.17)
       capybara (~> 3.0)
@@ -330,7 +330,7 @@ GEM
       falcon
       live
       rails (>= 8.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -435,7 +435,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.19.8)
+    json (2.20.0)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -501,7 +501,7 @@ GEM
       turbo-rails
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_json (1.15.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -525,11 +525,11 @@ GEM
     netrc (0.11.0)
     nio4r (2.7.5)
     nkf (0.2.0)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.22)
       auth-sanitizer (~> 0.2, >= 0.2.1)
@@ -952,7 +952,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     xrb (0.11.2)
-    yard (0.9.42)
+    yard (0.9.44)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard


### PR DESCRIPTION
## Summary
- Update vulnerable locked gems flagged by bundler-audit: concurrent-ruby, crass, faraday, msgpack, nokogiri, yard
- Accept json transitive patch update from the narrow bundle update

## Verification
- rtk mise exec -- timeout 180 bundle exec bundler-audit check --no-update
- rtk mise exec -- timeout 180 bundle exec brakeman -q -w2