### PR TITLE
fix: payments report PDF/CSV download returns 406 (format query param ignored)

### DIFF
--- a/app/controllers/api/v1/reports/payments_controller.rb
+++ b/app/controllers/api/v1/reports/payments_controller.rb
@@ -28,9 +28,12 @@ module Api::V1
         payments = filter_payments
         report_data = generate_payment_report(payments)
 
-        respond_to do |format|
-          format.csv { send_data generate_csv(report_data), filename: "payment_report_#{Date.current}.csv" }
-          format.pdf { send_data generate_pdf(report_data), filename: "payment_report_#{Date.current}.pdf" }
+        if request.query_parameters[:format] == "pdf"
+          send_data generate_pdf(report_data),
+            filename: "payment_report_#{Date.current}.pdf", type: "application/pdf"
+        else
+          send_data generate_csv(report_data),
+            filename: "payment_report_#{Date.current}.csv", type: "text/csv"
         end
       end
 

--- a/app/controllers/api/v1/reports/payments_controller.rb
+++ b/app/controllers/api/v1/reports/payments_controller.rb
@@ -28,7 +28,7 @@ module Api::V1
         payments = filter_payments
         report_data = generate_payment_report(payments)
 
-        if request.query_parameters[:format] == "pdf"
+        if request.query_parameters[:format] == "pdf" || params[:format] == "pdf"
           send_data generate_pdf(report_data),
             filename: "payment_report_#{Date.current}.pdf", type: "application/pdf"
         else

--- a/spec/requests/api/v1/reports/payments/download_spec.rb
+++ b/spec/requests/api/v1/reports/payments/download_spec.rb
@@ -13,12 +13,20 @@ RSpec.describe "Api::V1::Reports::PaymentsController#download", type: :request d
     sign_in admin
   end
 
-  it "downloads a PDF report" do
-    send_request :get, "/api/v1/reports/payments/download.pdf", headers: auth_headers(admin)
+  it "downloads a PDF report when the frontend requests format=pdf as a query param" do
+    send_request :get, "/api/v1/reports/payments/download?format=pdf", headers: auth_headers(admin)
 
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq("application/pdf")
     expect(response.body[0, 4]).to eq("%PDF")
     expect(response.headers["Content-Disposition"]).to include("payment_report_#{Date.current}.pdf")
+  end
+
+  it "downloads a CSV report by default" do
+    send_request :get, "/api/v1/reports/payments/download?format=csv", headers: auth_headers(admin)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/csv")
+    expect(response.headers["Content-Disposition"]).to include("payment_report_#{Date.current}.csv")
   end
 end


### PR DESCRIPTION
## Problem

Production smoke testing surfaced that the **Payments report Export → PDF** (and CSV) returns **HTTP 406**. The download action used `respond_to` with `format.csv`/`format.pdf`, but the `api` namespace sets `defaults: { format: "json" }` (config/routes/api.rb:3). The frontend calls `/reports/payments/download?format=pdf` (format as a **query param**, not a `.pdf` extension), so `request.format` resolves to `:json` — no matching `respond_to` handler → 406.

This is why PR #2385's payments-PDF fix (which produced valid PDF bytes) still didn't work end-to-end: the request never reached the generator. The original spec used the `.pdf` URL extension, which set the format unambiguously and masked the real-world query-param behavior.

## Fix

Branch on `request.query_parameters[:format]` (unaffected by the route's json default) and `send_data` directly with explicit content types — matching the working report-download pattern (e.g. `Reports::AccountsAging::DownloadService`). The spec now exercises the query-param path the frontend actually uses, for both PDF and CSV.

## Note for follow-up

The shared `Reports::DownloadService` base class also keys off `params[:format]`, which the same route default clobbers to `json` — so other reports' PDF-via-query-param downloads may silently return CSV. Worth a broader check + fix in a follow-up (not included here to keep this change targeted and tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment report downloads by selecting PDF or CSV format using the `format` query parameter.
  * PDF and CSV downloads now return the correct file type, content type, and filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->