### PR TITLE
Release: payments report download 406 fix

### DIFF
--- a/app/controllers/api/v1/reports/payments_controller.rb
+++ b/app/controllers/api/v1/reports/payments_controller.rb
@@ -28,9 +28,12 @@ module Api::V1
         payments = filter_payments
         report_data = generate_payment_report(payments)
 
-        respond_to do |format|
-          format.csv { send_data generate_csv(report_data), filename: "payment_report_#{Date.current}.csv" }
-          format.pdf { send_data generate_pdf(report_data), filename: "payment_report_#{Date.current}.pdf" }
+        if request.query_parameters[:format] == "pdf"
+          send_data generate_pdf(report_data),
+            filename: "payment_report_#{Date.current}.pdf", type: "application/pdf"
+        else
+          send_data generate_csv(report_data),
+            filename: "payment_report_#{Date.current}.csv", type: "text/csv"
         end
       end
 

--- a/app/controllers/api/v1/reports/payments_controller.rb
+++ b/app/controllers/api/v1/reports/payments_controller.rb
@@ -28,7 +28,7 @@ module Api::V1
         payments = filter_payments
         report_data = generate_payment_report(payments)
 
-        if request.query_parameters[:format] == "pdf"
+        if request.query_parameters[:format] == "pdf" || params[:format] == "pdf"
           send_data generate_pdf(report_data),
             filename: "payment_report_#{Date.current}.pdf", type: "application/pdf"
         else

--- a/spec/requests/api/v1/reports/payments/download_spec.rb
+++ b/spec/requests/api/v1/reports/payments/download_spec.rb
@@ -13,12 +13,20 @@ RSpec.describe "Api::V1::Reports::PaymentsController#download", type: :request d
     sign_in admin
   end
 
-  it "downloads a PDF report" do
-    send_request :get, "/api/v1/reports/payments/download.pdf", headers: auth_headers(admin)
+  it "downloads a PDF report when the frontend requests format=pdf as a query param" do
+    send_request :get, "/api/v1/reports/payments/download?format=pdf", headers: auth_headers(admin)
 
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq("application/pdf")
     expect(response.body[0, 4]).to eq("%PDF")
     expect(response.headers["Content-Disposition"]).to include("payment_report_#{Date.current}.pdf")
+  end
+
+  it "downloads a CSV report by default" do
+    send_request :get, "/api/v1/reports/payments/download?format=csv", headers: auth_headers(admin)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/csv")
+    expect(response.headers["Content-Disposition"]).to include("payment_report_#{Date.current}.csv")
   end
 end


### PR DESCRIPTION
Promotes develop to production. Adds PR #2387: fixes the payments report PDF/CSV export returning HTTP 406 (the api namespace's json format default made the frontend's ?format=pdf request unmatched by respond_to). Found via production smoke testing of the prior release.