### PR TITLE
fix: make quickbooks index migration re-runnable and strong_migrations safe

### DIFF
--- a/db/migrate/20260715000000_fix_quickbooks_export_indexes.rb
+++ b/db/migrate/20260715000000_fix_quickbooks_export_indexes.rb
@@ -3,29 +3,48 @@
 class FixQuickbooksExportIndexes < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
+  REFERENCE_COLUMNS = [:quickbooks_connection_id, :miru_record_type, :miru_record_id, :quickbooks_entity_type].freeze
   REFERENCE_INDEX_NAME = "idx_qbo_refs_miru_record_entity"
   REFERENCE_TMP_INDEX_NAME = "tmp_idx_qbo_refs_miru_record_entity"
+  EVENTS_COLUMNS = [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id, :payload_digest].freeze
   EVENTS_INDEX_NAME = "idx_qbo_events_idempotency"
   EVENTS_TMP_INDEX_NAME = "tmp_idx_qbo_events_idempotency"
 
+  # This migration is non-transactional (concurrent indexes) and previously
+  # failed partway in production, so every step must be safe to re-run.
   def up
-    add_index :quickbooks_references,
-      [:quickbooks_connection_id, :miru_record_type, :miru_record_id, :quickbooks_entity_type],
-      unique: true,
-      name: REFERENCE_TMP_INDEX_NAME,
-      algorithm: :concurrently
-    remove_index :quickbooks_references, name: REFERENCE_INDEX_NAME, algorithm: :concurrently
-    rename_index :quickbooks_references, REFERENCE_TMP_INDEX_NAME, REFERENCE_INDEX_NAME
+    unless index_exists?(:quickbooks_references, REFERENCE_COLUMNS, unique: true, name: REFERENCE_INDEX_NAME)
+      add_index :quickbooks_references, REFERENCE_COLUMNS,
+        unique: true,
+        name: REFERENCE_TMP_INDEX_NAME,
+        algorithm: :concurrently,
+        if_not_exists: true
+      remove_index :quickbooks_references, name: REFERENCE_INDEX_NAME, algorithm: :concurrently, if_exists: true
+      rename_index :quickbooks_references, REFERENCE_TMP_INDEX_NAME, REFERENCE_INDEX_NAME
+    end
 
-    change_column_null :quickbooks_sync_events, :payload_digest, false
-    add_index :quickbooks_sync_events,
-      [:quickbooks_connection_id, :quickbooks_entity_type, :quickbooks_entity_id, :payload_digest],
-      unique: true,
-      where: "status = 1",
-      name: EVENTS_TMP_INDEX_NAME,
-      algorithm: :concurrently
-    remove_index :quickbooks_sync_events, name: EVENTS_INDEX_NAME, algorithm: :concurrently
-    rename_index :quickbooks_sync_events, EVENTS_TMP_INDEX_NAME, EVENTS_INDEX_NAME
+    # payload_digest has been NOT NULL since create_quickbooks_sync_events;
+    # tightening here again blocked the deploy under strong_migrations. Only
+    # environments that somehow relaxed it need action, done via a constraint
+    # that is validated without locking the table.
+    if connection.columns(:quickbooks_sync_events).find { |c| c.name == "payload_digest" }&.null
+      safety_assured do
+        add_check_constraint :quickbooks_sync_events, "payload_digest IS NOT NULL",
+          name: "quickbooks_sync_events_payload_digest_null", validate: false
+      end
+      validate_check_constraint :quickbooks_sync_events, name: "quickbooks_sync_events_payload_digest_null"
+    end
+
+    unless index_exists?(:quickbooks_sync_events, EVENTS_COLUMNS, unique: true, name: EVENTS_INDEX_NAME)
+      add_index :quickbooks_sync_events, EVENTS_COLUMNS,
+        unique: true,
+        where: "status = 1",
+        name: EVENTS_TMP_INDEX_NAME,
+        algorithm: :concurrently,
+        if_not_exists: true
+      remove_index :quickbooks_sync_events, name: EVENTS_INDEX_NAME, algorithm: :concurrently, if_exists: true
+      rename_index :quickbooks_sync_events, EVENTS_TMP_INDEX_NAME, EVENTS_INDEX_NAME
+    end
   end
 
   def down


### PR DESCRIPTION
Production pre-deploy for #2390 failed: `change_column_null` in `20260715000000_fix_quickbooks_export_indexes.rb` is blocked by strong_migrations (locks the table), and the non-transactional migration had already half-applied its index swap in production.

**Fix**
- `payload_digest` has been NOT NULL since the create-table migration, so the tighten now only runs where the column is actually nullable — via a check constraint validated without locking (the exact strong_migrations recipe).
- All index steps guarded (`index_exists?`, `if_not_exists`/`if_exists`) so the re-run in production converges from the partially-applied state.

**Verified**
- Fresh test-env `db:drop db:create db:migrate` passes the full chain under strong_migrations.
- Deleting the schema_migrations row and re-running against an applied DB exits 0; both new unique indexes present, digest NOT NULL, version recorded.

Unblocks the production deploy of #2390.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of QuickBooks export database updates.
  * Export index and data-integrity updates can now be safely rerun without unnecessary locking or failures.
  * Preserved existing uniqueness and event-status validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->