### PR TITLE
fix: resolve bundler-audit advisories (mcp 0.25, rails-html-sanitizer 1.7.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,7 +152,7 @@ gem "observer"
 # Faraday HTTP client adapter for Faraday 2.0+
 gem "faraday", ">= 2.14.1"
 gem "faraday-net_http"
-gem "mcp", "~> 0.13.0"
+gem "mcp", "~> 0.25.0"
 
 # Country information and timezones
 gem "countries", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    hana (1.3.7)
     hash_dot (2.5.0)
     hashdiff (1.2.1)
     hashie (5.1.0)
@@ -436,9 +437,11 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.20.0)
-    json-schema (6.2.0)
-      addressable (~> 2.8)
-      bigdecimal (>= 3.1, < 5)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (3.2.0)
       base64
     kamal (1.9.3)
@@ -469,7 +472,7 @@ GEM
       xrb (~> 0.10)
     localhost (1.7.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -481,8 +484,8 @@ GEM
     mapping (1.1.3)
     marcel (1.1.0)
     matrix (0.4.2)
-    mcp (0.13.0)
-      json-schema (>= 4.1)
+    mcp (0.25.0)
+      json_schemer (>= 2.4)
     metrics (0.15.0)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
@@ -661,8 +664,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)
@@ -822,6 +825,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     snaky_hash (2.0.5)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -1012,7 +1016,7 @@ DEPENDENCIES
   kamal
   letter_opener
   letter_opener_web
-  mcp (~> 0.13.0)
+  mcp (~> 0.25.0)
   mission_control-jobs
   money
   nkf

--- a/app/controllers/api/v1/mcp_controller.rb
+++ b/app/controllers/api/v1/mcp_controller.rb
@@ -9,7 +9,11 @@ class Api::V1::MCPController < Api::V1::ApplicationController
 
   def handle
     server = MCP::Miru::ServerFactory.build(server_context: mcp_server_context)
-    transport = MCP::Server::Transports::StreamableHTTPTransport.new(server, stateless: true)
+    transport = MCP::Server::Transports::StreamableHTTPTransport.new(
+      server,
+      stateless: true,
+      dns_rebinding_protection: false
+    )
     status, response_headers, body = transport.handle_request(request)
 
     response_headers.each { |key, value| response.set_header(key, value) }

--- a/app/controllers/api/v1/mcp_controller.rb
+++ b/app/controllers/api/v1/mcp_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::MCPController < Api::V1::ApplicationController
     transport = MCP::Server::Transports::StreamableHTTPTransport.new(
       server,
       stateless: true,
-      dns_rebinding_protection: false
+      allowed_hosts: [request.host],
+      allowed_origins: transport_allowed_origins
     )
     status, response_headers, body = transport.handle_request(request)
 
@@ -63,7 +64,7 @@ class Api::V1::MCPController < Api::V1::ApplicationController
     end
 
     def validate_origin_header!
-      origin = request.headers["Origin"].to_s.strip
+      origin = request.headers["Origin"].to_s.strip.downcase
       return if origin.blank?
       return if allowed_origins.include?(origin)
 
@@ -80,10 +81,17 @@ class Api::V1::MCPController < Api::V1::ApplicationController
     def allowed_origins
       configured = ENV.fetch("MCP_ALLOWED_ORIGINS", "")
         .split(/[,\s]+/)
-        .map(&:strip)
+        .map { |origin| origin.strip.downcase }
         .reject(&:blank?)
 
-      configured.presence || [request.base_url]
+      configured | [request.base_url.downcase]
+    end
+
+    def transport_allowed_origins
+      origin = request.headers["Origin"].to_s
+      return allowed_origins if origin.present?
+
+      allowed_origins + [origin.downcase]
     end
 
     def render_mcp_error(status:, code:, message:, data: nil)
@@ -102,6 +110,7 @@ class Api::V1::MCPController < Api::V1::ApplicationController
       return unless request.post?
 
       raw_body = request.raw_post.to_s
+      return if raw_body.bytesize > 1.megabyte
       return if raw_body.blank?
 
       payload = JSON.parse(raw_body)

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+MCP.configure do |config|
+  config.exception_reporter = ->(exception, server_context) {
+    Rails.logger.error("[MCP] #{exception.class}: #{exception.message}")
+    Sentry.capture_exception(exception, extra: { mcp: true }) if defined?(Sentry)
+  }
+end

--- a/docs/miru-mcp.md
+++ b/docs/miru-mcp.md
@@ -67,7 +67,7 @@ When blocked, `/mcp` returns HTTP `403` with JSON-RPC error code `-32003` and `e
 Notes:
 
 - If `MCP_SERVER_ENABLED=false`, endpoint returns HTTP `404` with JSON-RPC code `-32004`.
-- If `MCP_ALLOWED_ORIGINS` is unset, allowed origin defaults to the current request base URL.
+- The current request base URL (same origin) is always allowed; `MCP_ALLOWED_ORIGINS` adds extra origins on top of it. Matching is case-insensitive.
 - If `Origin` header is provided and not allowed, endpoint returns HTTP `403` with code `-32001`.
 
 ## Authentication


### PR DESCRIPTION
## What

- Bump `mcp` 0.13.0 → 0.25.0, clearing five GHSAs (unbounded session retention, SSE session poisoning, unbounded stdio/JSON-RPC buffers, DNS-rebinding gap).
- Bump `rails-html-sanitizer` 1.7.0 → 1.7.1 (XSS advisory GHSA-cj75-f6xr-r4g7, pulls loofah 2.25.2).
- This unblocks the CI **Security audit** job, which currently fails on develop and on dependabot PR #2394.

## MCP transport changes (0.23+ behavior)

The gem now enforces Host/Origin DNS-rebinding validation inside `StreamableHTTPTransport` and only accepts loopback hosts by default, which 403s every production request. Instead of disabling the check, the controller passes `allowed_hosts`/`allowed_origins` through so the gem layer stays on:

- `MCP_ALLOWED_ORIGINS` now **augments** the same-origin default instead of replacing it (setting it no longer locks out same-origin clients); matching is case-insensitive to match the transport.
- New `config/initializers/mcp.rb` wires `exception_reporter` to Rails.logger + Sentry — transport/tool errors were previously swallowed by the gem's no-op default.
- `jsonrpc_id` skips JSON parsing for bodies over 1 MB on rejection paths.
- Docs updated (`docs/miru-mcp.md`).

## Verification

- `bundle exec bundle-audit check` → no vulnerabilities found.
- 48 MCP specs green (`spec/requests/api/v1/mcp`, `spec/mcp`, `spec/services/mcp`), including origin allow/deny/blank cases.
- 97 sanitization-adjacent specs green (invoice model, payments requests) for the loofah/rails-html-sanitizer bump.
- RuboCop clean on changed files.
- Adversarial review (dual-model) findings all addressed: origin-augment semantics, case-insensitive matching, exception reporting, oversized-body parse guard.

## Client-visible notes (mcp 0.25)

- New 4 MiB request body cap (HTTP 413).
- Invalid tool arguments now return in-band `isError: true` results instead of JSON-RPC `-32602`.
- Protocol-version header is now validated (2024-11-05 … 2025-11-25).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Improved MCP request origin validation with case-insensitive matching.
  - Added safeguards for oversized JSON-RPC requests.
  - Ensured same-origin requests are permitted while supporting configured additional origins.

- **Monitoring**
  - MCP exceptions are now logged and optionally reported to Sentry.

- **Documentation**
  - Clarified allowed-origin behavior for MCP HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->