### PR TITLE
fix: allow editing and deleting time off entries

### DIFF
--- a/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
+++ b/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
@@ -6,7 +6,7 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
-import { minToHHMM } from "../../helpers";
+import { buildDateParseFormats, minToHHMM } from "../../helpers";
 import { i18n } from "../../i18n";
 import { useUserContext } from "../../context/UserContext";
 import { Roles } from "../../constants";
@@ -53,20 +53,9 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   const [reviewMode, setReviewMode] = useState<"day" | "week">("day");
   const { companyRole, isDesktop, company } = useUserContext();
   const timesheetEditDays: number = company?.timesheet_edit_days ?? 30;
-  const companyDateFormat = company?.date_format || company?.dateFormat;
-  const dateFormats = [
-    ...(companyDateFormat
-      ? [companyDateFormat, companyDateFormat.replace(/-/g, ".")]
-      : []),
-    "YYYY-MM-DD",
-    "MM-DD-YYYY",
-    "DD-MM-YYYY",
-    "MM/DD/YYYY",
-    "DD/MM/YYYY",
-    "MM.DD.YYYY",
-    "DD.MM.YYYY",
-    "YYYY.MM.DD",
-  ];
+  const dateFormats = buildDateParseFormats(
+    company?.date_format || company?.dateFormat
+  );
   const parsedDate = dayjs(selectedFullDate, dateFormats, true);
   const isoDate = parsedDate.format("YYYY-MM-DD");
   const entryDateCandidates = [

--- a/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
+++ b/app/javascript/src/components/TimeTracking/TimeEntriesDisplay.tsx
@@ -53,12 +53,19 @@ const TimeEntriesDisplay: React.FC<TimeEntriesDisplayProps> = ({
   const [reviewMode, setReviewMode] = useState<"day" | "week">("day");
   const { companyRole, isDesktop, company } = useUserContext();
   const timesheetEditDays: number = company?.timesheet_edit_days ?? 30;
+  const companyDateFormat = company?.date_format || company?.dateFormat;
   const dateFormats = [
+    ...(companyDateFormat
+      ? [companyDateFormat, companyDateFormat.replace(/-/g, ".")]
+      : []),
     "YYYY-MM-DD",
     "MM-DD-YYYY",
     "DD-MM-YYYY",
     "MM/DD/YYYY",
     "DD/MM/YYYY",
+    "MM.DD.YYYY",
+    "DD.MM.YYYY",
+    "YYYY.MM.DD",
   ];
   const parsedDate = dayjs(selectedFullDate, dateFormats, true);
   const isoDate = parsedDate.format("YYYY-MM-DD");

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -14,7 +14,7 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import updateLocale from "dayjs/plugin/updateLocale";
 import weekday from "dayjs/plugin/weekday";
-import { minToHHMM } from "helpers";
+import { buildDateParseFormats, minToHHMM } from "helpers";
 import Logger from "js-logger";
 import { sendGAPageView } from "utils/googleAnalytics";
 import { Button } from "../ui/button";
@@ -91,18 +91,7 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   const [copyingLastWeek, setCopyingLastWeek] = useState<boolean>(false);
   const [timerSyncKey, setTimerSyncKey] = useState<number>(0);
   const [resumeTimerEntry, setResumeTimerEntry] = useState<any>(null);
-  const dateParseFormats = [
-    dateFormat,
-    dateFormat.replace(/-/g, "."),
-    "YYYY-MM-DD",
-    "MM-DD-YYYY",
-    "DD-MM-YYYY",
-    "MM/DD/YYYY",
-    "DD/MM/YYYY",
-    "MM.DD.YYYY",
-    "DD.MM.YYYY",
-    "YYYY.MM.DD",
-  ];
+  const dateParseFormats = buildDateParseFormats(dateFormat);
 
   const employeeOptions = employees.map(e => ({
     value: `${e["id"]}`,

--- a/app/javascript/src/components/TimeTracking/index.tsx
+++ b/app/javascript/src/components/TimeTracking/index.tsx
@@ -93,11 +93,15 @@ const TimeTracking: React.FC<Iprops> = ({ user, isAdminUser }) => {
   const [resumeTimerEntry, setResumeTimerEntry] = useState<any>(null);
   const dateParseFormats = [
     dateFormat,
+    dateFormat.replace(/-/g, "."),
     "YYYY-MM-DD",
     "MM-DD-YYYY",
     "DD-MM-YYYY",
     "MM/DD/YYYY",
     "DD/MM/YYYY",
+    "MM.DD.YYYY",
+    "DD.MM.YYYY",
+    "YYYY.MM.DD",
   ];
 
   const employeeOptions = employees.map(e => ({

--- a/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
+++ b/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
@@ -7,7 +7,7 @@ import { useTimesheetEntries } from "context/TimesheetEntries";
 import { useUserContext } from "context/UserContext";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import { minFromHHMM, minToHHMM } from "helpers";
+import { buildDateParseFormats, minFromHHMM, minToHHMM } from "helpers";
 
 import { i18n } from "../../../i18n";
 import DesktopTimeoffForm from "./DesktopTimeoffForm";
@@ -154,6 +154,18 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
     return allEntries.find(entry => entry.id === editTimeoffEntryId);
   };
 
+  const parseLeaveDate = (leaveDate?: string) => {
+    if (!leaveDate) return null;
+
+    const parsedDate = dayjs(
+      leaveDate,
+      buildDateParseFormats(company?.date_format || company?.dateFormat),
+      true
+    );
+
+    return parsedDate.isValid() ? parsedDate.format("YYYY-MM-DD") : null;
+  };
+
   const handleFillData = () => {
     const timeoffEntry = findEditableTimeoffEntry();
 
@@ -161,28 +173,8 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
       setDuration(minToHHMM(timeoffEntry?.duration || 0));
       setNote(timeoffEntry?.note || "");
       if (timeoffEntry?.leave_date) {
-        const companyDateFormat =
-          company?.date_format || company?.dateFormat || "YYYY-MM-DD";
-
-        const parsedDate = dayjs(
-          timeoffEntry.leave_date,
-          [
-            companyDateFormat,
-            companyDateFormat.replace(/-/g, "."),
-            "YYYY-MM-DD",
-            "DD-MM-YYYY",
-            "MM-DD-YYYY",
-            "MM.DD.YYYY",
-            "DD.MM.YYYY",
-            "YYYY.MM.DD",
-          ],
-          true
-        );
-
         setSelectedDate(
-          parsedDate.isValid()
-            ? parsedDate.format("YYYY-MM-DD")
-            : selectedFullDate
+          parseLeaveDate(timeoffEntry.leave_date) || selectedFullDate
         );
       }
 
@@ -249,9 +241,7 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
     if (isValidTimeEntry()) {
       const payload = {
         duration: timeoffEntry?.duration || minFromHHMM(duration),
-        leave_date: timeoffEntry?.leave_date
-          ? dayjs(timeoffEntry.leave_date).format("YYYY-MM-DD")
-          : selectedDate,
+        leave_date: parseLeaveDate(timeoffEntry?.leave_date) || selectedDate,
         user_id: selectedEmployeeId,
         note: timeoffEntry?.note || note,
       };
@@ -314,19 +304,15 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
       );
 
       if (updateRes.status >= 200 && updateRes.status < 300) {
-        const refreshed =
-          (await refreshVisibleEntries?.(selectedEmployeeId)) ||
+        (await refreshVisibleEntries?.(selectedEmployeeId)) ||
           (await fetchEntries(selectedDate, selectedDate));
-        fetchEntriesOfMonths();
 
-        if (refreshed) {
-          setEditTimeoffEntryId(0);
-          setNewTimeoffEntryView(false);
-          setUpdateView(true);
-          handleAddEntryDateChange(dayjs(selectedDate));
-          if (dayjs(selectedDate).isValid()) {
-            setSelectedFullDate(dayjs(selectedDate).format("YYYY-MM-DD"));
-          }
+        setEditTimeoffEntryId(0);
+        setNewTimeoffEntryView(false);
+        setUpdateView(true);
+        handleAddEntryDateChange(dayjs(selectedDate));
+        if (dayjs(selectedDate).isValid()) {
+          setSelectedFullDate(dayjs(selectedDate).format("YYYY-MM-DD"));
         }
       }
     }

--- a/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
+++ b/app/javascript/src/components/TimeoffEntries/TimeoffForm/index.tsx
@@ -6,14 +6,17 @@ import { timeoffEntriesApi } from "apis/api";
 import { useTimesheetEntries } from "context/TimesheetEntries";
 import { useUserContext } from "context/UserContext";
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
 import { minFromHHMM, minToHHMM } from "helpers";
 
 import { i18n } from "../../../i18n";
 import DesktopTimeoffForm from "./DesktopTimeoffForm";
 import MobileTimeoffForm from "./MobileTimeoffForm";
 
+dayjs.extend(customParseFormat);
+
 const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
-  const { isDesktop } = useUserContext();
+  const { company, isDesktop } = useUserContext();
 
   const {
     leaveTypes,
@@ -30,7 +33,6 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
     editTimeoffEntryId,
     setEditTimeoffEntryId,
     handleFilterEntry,
-    handleRelocateEntry,
     setSelectedFullDate,
     holidayList,
     holidaysHashObj,
@@ -159,7 +161,29 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
       setDuration(minToHHMM(timeoffEntry?.duration || 0));
       setNote(timeoffEntry?.note || "");
       if (timeoffEntry?.leave_date) {
-        setSelectedDate(dayjs(timeoffEntry.leave_date).format("YYYY-MM-DD"));
+        const companyDateFormat =
+          company?.date_format || company?.dateFormat || "YYYY-MM-DD";
+
+        const parsedDate = dayjs(
+          timeoffEntry.leave_date,
+          [
+            companyDateFormat,
+            companyDateFormat.replace(/-/g, "."),
+            "YYYY-MM-DD",
+            "DD-MM-YYYY",
+            "MM-DD-YYYY",
+            "MM.DD.YYYY",
+            "DD.MM.YYYY",
+            "YYYY.MM.DD",
+          ],
+          true
+        );
+
+        setSelectedDate(
+          parsedDate.isValid()
+            ? parsedDate.format("YYYY-MM-DD")
+            : selectedFullDate
+        );
       }
 
       if (timeoffEntry?.holiday_info_id) {
@@ -290,21 +314,20 @@ const TimeoffForm = ({ isDisplayEditTimeoffEntryForm = false }) => {
       );
 
       if (updateRes.status >= 200 && updateRes.status < 300) {
-        if (selectedDate !== selectedFullDate) {
-          await handleFilterEntry(selectedFullDate, editTimeoffEntryId);
-          await handleRelocateEntry(selectedDate, updateRes.data.timeoff_entry);
-          if (!isDesktop) {
-            fetchEntriesOfMonths();
+        const refreshed =
+          (await refreshVisibleEntries?.(selectedEmployeeId)) ||
+          (await fetchEntries(selectedDate, selectedDate));
+        fetchEntriesOfMonths();
+
+        if (refreshed) {
+          setEditTimeoffEntryId(0);
+          setNewTimeoffEntryView(false);
+          setUpdateView(true);
+          handleAddEntryDateChange(dayjs(selectedDate));
+          if (dayjs(selectedDate).isValid()) {
+            setSelectedFullDate(dayjs(selectedDate).format("YYYY-MM-DD"));
           }
-        } else {
-          await fetchEntries(selectedDate, selectedDate);
-          fetchEntriesOfMonths();
         }
-        setEditTimeoffEntryId(0);
-        setNewTimeoffEntryView(false);
-        setUpdateView(true);
-        handleAddEntryDateChange(dayjs(selectedDate));
-        setSelectedFullDate(dayjs(selectedDate).format("YYYY-MM-DD"));
       }
     }
   };

--- a/app/javascript/src/helpers/dateParseFormats.ts
+++ b/app/javascript/src/helpers/dateParseFormats.ts
@@ -1,0 +1,18 @@
+const FALLBACK_FORMATS = [
+  "YYYY-MM-DD",
+  "MM-DD-YYYY",
+  "DD-MM-YYYY",
+  "MM/DD/YYYY",
+  "DD/MM/YYYY",
+  "MM.DD.YYYY",
+  "DD.MM.YYYY",
+  "YYYY.MM.DD",
+];
+
+export const buildDateParseFormats = (companyDateFormat?: string): string[] => {
+  const companyFormats = companyDateFormat
+    ? [companyDateFormat, companyDateFormat.replace(/[-/]/g, ".")]
+    : [];
+
+  return Array.from(new Set([...companyFormats, ...FALLBACK_FORMATS]));
+};

--- a/app/javascript/src/helpers/index.ts
+++ b/app/javascript/src/helpers/index.ts
@@ -3,6 +3,7 @@ import { cashFormatter } from "./cashFormater";
 import { companyDateFormater } from "./companyDateFormater";
 import { currencyFormat } from "./currency";
 import { currencySymbol } from "./currencySymbol";
+import { buildDateParseFormats } from "./dateParseFormats";
 import { getMonthFromString } from "./dateParser";
 import { useDebounce } from "./debounce";
 import { getDisplayAvatarUrl, getGravatarUrl } from "./gravatar";
@@ -16,6 +17,7 @@ import useKeypress from "./useKeyPress";
 import { validateTimesheetEntry } from "./validateTimesheetEntry";
 
 export {
+  buildDateParseFormats,
   bytesToSize,
   cashFormatter,
   companyDateFormater,

--- a/app/services/timeoff_entries/balance_summary_service.rb
+++ b/app/services/timeoff_entries/balance_summary_service.rb
@@ -100,7 +100,7 @@ module TimeoffEntries
       end
 
       def user_joined_date
-        employee_id = admin? ? user_id : current_user.id
+        employee_id = admin? && user_id.present? ? user_id : current_user.id
         user = User.find(employee_id)
         user.employments.kept.find_by(company_id: current_company.id)&.joined_at
       end

--- a/app/services/timeoff_entries/balance_summary_service.rb
+++ b/app/services/timeoff_entries/balance_summary_service.rb
@@ -101,7 +101,7 @@ module TimeoffEntries
 
       def user_joined_date
         employee_id = admin? && user_id.present? ? user_id : current_user.id
-        user = User.find(employee_id)
+        user = current_company.users.find(employee_id)
         user.employments.kept.find_by(company_id: current_company.id)&.joined_at
       end
 

--- a/app/services/timeoff_entries/overview_service.rb
+++ b/app/services/timeoff_entries/overview_service.rb
@@ -17,7 +17,7 @@ module TimeoffEntries
       balance_summary = TimeoffEntries::BalanceSummaryService.process(
         current_user:,
         current_company:,
-        user_id:,
+        user_id: resolved_user_id,
         year:
       )
 
@@ -39,9 +39,18 @@ module TimeoffEntries
 
         @_timeoff_entries ||= TimeoffEntry.from_workspace(current_company.id)
           .includes(:leave_type, :holiday_info, :custom_leave)
-          .where(user_id:)
+          .where(user_id: resolved_user_id)
           .during(start_date, end_date)
           .distinct
+      end
+
+      def resolved_user_id
+        @_resolved_user_id ||=
+          if admin? && user_id.present?
+            current_company.users.find(user_id).id
+          else
+            current_user.id
+          end
       end
   end
 end

--- a/app/views/api/v1/time_tracking/index.json.jbuilder
+++ b/app/views/api/v1/time_tracking/index.json.jbuilder
@@ -34,6 +34,7 @@ json.entries do
             json.leave_date CompanyDateFormattingService.new(entry[:leave_date], company:).process
             json.holiday_info_id entry[:holiday_info_id]
             json.leave_type_id entry[:leave_type_id]
+            json.custom_leave_id entry[:custom_leave_id]
             json.user_id entry[:user_id]
           end
         end

--- a/app/views/api/v1/timesheet_entry/index.json.jbuilder
+++ b/app/views/api/v1/timesheet_entry/index.json.jbuilder
@@ -24,6 +24,7 @@ json.entries do
             json.leave_date CompanyDateFormattingService.new(entry[:leave_date], company:).process
             json.holiday_info_id entry[:holiday_info_id]
             json.leave_type_id entry[:leave_type_id]
+            json.custom_leave_id entry[:custom_leave_id]
             json.user_id entry[:user_id]
           end
         end

--- a/spec/requests/api/v1/timeoff_entries/index_spec.rb
+++ b/spec/requests/api/v1/timeoff_entries/index_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Api::V1::TimeoffEntries#index", type: :request do
 
     it "returns timeoff index response without a user id" do
       leave = create(:leave, company:, year: Date.current.year)
-      create(:leave_type, leave:)
+      leave_type = create(:leave_type, leave:)
 
       send_request :get,
         api_v1_timeoff_entries_path,
@@ -45,6 +45,21 @@ RSpec.describe "Api::V1::TimeoffEntries#index", type: :request do
         headers: auth_headers(admin)
 
       expect(response).to have_http_status(:ok)
+      expect(json_response).to have_key("leaveBalance")
+      expect(json_response["leaveBalance"].pluck("id")).to include(leave_type.id)
+    end
+
+    it "returns not found for a user id outside the company" do
+      leave = create(:leave, company:, year: Date.current.year)
+      create(:leave_type, leave:)
+      outside_user = create(:user)
+
+      send_request :get,
+        api_v1_timeoff_entries_path,
+        params: { user_id: outside_user.id, year: Date.current.year },
+        headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -61,6 +76,29 @@ RSpec.describe "Api::V1::TimeoffEntries#index", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(json_response).to have_key("timeoffEntries")
+    end
+
+    it "only returns the employee's own entries when another user's id is passed" do
+      leave = create(:leave, company:, year: Date.current.year)
+      leave_type = create(:leave_type, leave:)
+      own_entry = create(
+        :timeoff_entry,
+        user: employee, leave_type:, leave_date: Date.current, duration: 60
+      )
+      other_entry = create(
+        :timeoff_entry,
+        user: admin, leave_type:, leave_date: Date.current - 1.day, duration: 120
+      )
+
+      send_request :get,
+        api_v1_timeoff_entries_path,
+        params: { user_id: admin.id, year: Date.current.year },
+        headers: auth_headers(employee)
+
+      expect(response).to have_http_status(:ok)
+      returned_ids = json_response["timeoffEntries"].pluck("id")
+      expect(returned_ids).to include(own_entry.id)
+      expect(returned_ids).not_to include(other_entry.id)
     end
   end
 

--- a/spec/requests/api/v1/timeoff_entries/index_spec.rb
+++ b/spec/requests/api/v1/timeoff_entries/index_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe "Api::V1::TimeoffEntries#index", type: :request do
       expect(json_response).to have_key("timeoffEntries")
       expect(json_response).to have_key("employees")
     end
+
+    it "returns timeoff index response without a user id" do
+      leave = create(:leave, company:, year: Date.current.year)
+      create(:leave_type, leave:)
+
+      send_request :get,
+        api_v1_timeoff_entries_path,
+        params: { year: Date.current.year },
+        headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "when user is an employee" do


### PR DESCRIPTION
Fixes #2393.

## Root cause

`CompanyDateFormattingService` always serializes `leave_date` with **dot** separators (`%m.%d.%Y` / `%d.%m.%Y` / `%Y.%m.%d`), while every frontend strict `dayjs` parse only listed dash/slash formats. Editing a time off entry therefore:

- poisoned `selectedFullDate` with the raw dotted string (`handleEditTimeoff` fallback),
- sent `leave_date: "07.23.2026"` to the API → **422 "Leave date can't be blank"**,
- left the stale leave card in the list and injected the raw update response as a phantom *timesheet* card whose delete button hit the wrong API.

Reproduced end-to-end in the browser before fixing (8h PTO edited to 4h showed "12h, 2 entries").

## Fix

- New shared `buildDateParseFormats(companyDateFormat)` helper — company format and its dot variant first, then canonical fallbacks — used by TimeTracking, TimeEntriesDisplay, and TimeoffForm (previously three drifting inline lists; the duplicate-entry payload path also used a non-strict parse that produced literal `"Invalid Date"`).
- Timeoff update flow now always refetches (mirrors create) instead of filter+relocate of raw response JSON; form closes unconditionally on 2xx; removed a double `fetchEntriesOfMonths` fetch that could clobber the visible week.
- `custom_leave_id` exposed in the time-tracking / timesheet leave payloads so custom-leave entries are editable too.

## Security hardening (from adversarial review)

- **IDOR closed**: `OverviewService` now clamps `user_id` at entry — non-admins always get their own entries. Previously any employee could read a co-worker's leave dates, durations, and notes via `GET /api/v1/timeoff_entries?user_id=<victim>`.
- **Cross-tenant oracle closed**: admin lookups are company-scoped (`current_company.users.find`), so foreign-company ids 404 instead of returning fabricated balances; `BalanceSummaryService#user_joined_date` no longer raises on a blank `user_id` (`User.find(nil)` 404'd the whole index for admins, breaking Leave Management's first load).

## Verification

- 61 specs green across `spec/requests/api/v1/timeoff_entries`, `spec/services/timeoff_entries`, `spec/requests/api/v1/timesheet_entry`, including new regression specs: admin without `user_id` (200 + leave balance), employee passing another user's id (only own entries returned), admin passing foreign-company id (404).
- Verified in the browser with Playwright: create → edit (PUT sends ISO `leave_date`, single card updates in place, form closes) → delete (card removed, empty state) with zero console errors.
- Reviewed by testing/maintainability/performance specialist passes + adversarial review; all fixable findings addressed (two pre-existing items deferred: UserContext date-format key normalization, `company.date_format` whitelist validation).
- Vite build, ESLint, and RuboCop clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for company-specific date formats across time tracking and time-off workflows.
  * Time-off and timesheet API responses now include custom leave identifiers.

* **Bug Fixes**
  * Improved date handling when creating or editing time-off entries.
  * Edited time-off entries now refresh reliably and update displayed dates correctly.
  * Improved access scoping so time-off data is limited to the appropriate company and employee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->