### PR TITLE
fix: paying customers see "Paid" and can't be double-charged

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -10,6 +10,11 @@ class Api::V1::SubscriptionsController < Api::V1::ApplicationController
   def checkout
     authorize current_company, policy_class: CompanyPolicy
 
+    if current_company.plan_tier == "paid"
+      render json: { errors: I18n.t("subscriptions.already_subscribed") }, status: 422
+      return
+    end
+
     plan_page_url = checkout_plan_page_url
     if plan_page_url.present?
       render json: checkout_payload(plan_page_url), status: 200

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -208,10 +208,7 @@ class Company < ApplicationRecord
 
     attrs[:stripe_subscription_id] = stripe_subscription_id if has_attribute?(:stripe_subscription_id)
     attrs[:subscription_interval] = subscription_interval if has_attribute?(:subscription_interval)
-    if attrs[:plan_tier] == "paid"
-      attrs[:trial_started_at] = nil
-      attrs[:trial_ends_at] = nil
-    end
+    attrs[:trial_ends_at] = nil if attrs[:plan_tier] == "paid"
 
     update!(attrs)
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -168,14 +168,14 @@ class Company < ApplicationRecord
 
   def current_plan_label
     return "free_pro" if billing_exempt?
-    return "pro_trial" if trial_active?
     return "paid" if plan_tier == "paid"
+    return "pro_trial" if trial_active?
 
     "free"
   end
 
   def current_subscription_status
-    return "trialing" if trial_active?
+    return "trialing" if trial_active? && plan_tier != "paid"
     return "trial_expired" if trial_expired? && plan_tier != "paid"
 
     subscription_status
@@ -208,6 +208,10 @@ class Company < ApplicationRecord
 
     attrs[:stripe_subscription_id] = stripe_subscription_id if has_attribute?(:stripe_subscription_id)
     attrs[:subscription_interval] = subscription_interval if has_attribute?(:subscription_interval)
+    if attrs[:plan_tier] == "paid"
+      attrs[:trial_started_at] = nil
+      attrs[:trial_ends_at] = nil
+    end
 
     update!(attrs)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,6 +811,7 @@ en:
     forgot_password: forgot password ?
     unlock_instruction: didn't receive unlock instructions?
   subscriptions:
+    already_subscribed: "Your workspace already has an active paid subscription. Use Manage billing to make changes."
     no_billing_customer: No billing customer exists for this company
     pricing_not_configured: Stripe subscription pricing is not configured
     trial_not_eligible: Your workspace is not eligible for a Pro trial

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -357,6 +357,18 @@ RSpec.describe Company, type: :model do
         expect(company.pro_access?).to eq(true)
         expect(company.stripe_subscription_active?).to eq(true)
       end
+
+      it "prefers the paid plan and Stripe status over an active trial" do
+        company.update!(
+          plan_tier: "paid",
+          subscription_status: "active",
+          trial_started_at: Time.current,
+          trial_ends_at: 1.day.from_now
+        )
+
+        expect(company.current_plan_label).to eq("paid")
+        expect(company.current_subscription_status).to eq("active")
+      end
     end
 
     describe "#team_member_limit_reached?" do
@@ -424,6 +436,8 @@ RSpec.describe Company, type: :model do
 
     describe "#apply_stripe_subscription!" do
       it "marks the company as paid for active subscriptions" do
+        company.update!(trial_started_at: Time.current, trial_ends_at: 1.day.from_now)
+
         company.apply_stripe_subscription!(
           stripe_customer_id: "cus_123",
           stripe_subscription_id: "sub_123",
@@ -439,9 +453,15 @@ RSpec.describe Company, type: :model do
         expect(company.stripe_subscription_id).to eq("sub_123")
         expect(company.subscription_status).to eq("active")
         expect(company.subscription_interval).to eq("month")
+        expect(company.trial_started_at).to be_nil
+        expect(company.trial_ends_at).to be_nil
       end
 
-      it "marks the company as free for canceled subscriptions" do
+      it "downgrades without changing trial timestamps" do
+        trial_started_at = Time.zone.local(2026, 3, 1, 12, 0, 0)
+        trial_ends_at = Time.zone.local(2026, 3, 15, 12, 0, 0)
+        company.update!(plan_tier: "paid", trial_started_at:, trial_ends_at:)
+
         company.apply_stripe_subscription!(
           stripe_customer_id: "cus_123",
           stripe_subscription_id: "sub_123",
@@ -449,7 +469,11 @@ RSpec.describe Company, type: :model do
           subscription_interval: "year"
         )
 
-        expect(company.reload.plan_tier).to eq("free")
+        company.reload
+
+        expect(company.plan_tier).to eq("free")
+        expect(company.trial_started_at).to eq(trial_started_at)
+        expect(company.trial_ends_at).to eq(trial_ends_at)
       end
     end
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -436,7 +436,8 @@ RSpec.describe Company, type: :model do
 
     describe "#apply_stripe_subscription!" do
       it "marks the company as paid for active subscriptions" do
-        company.update!(trial_started_at: Time.current, trial_ends_at: 1.day.from_now)
+        started_at = Time.current
+        company.update!(trial_started_at: started_at, trial_ends_at: 1.day.from_now)
 
         company.apply_stripe_subscription!(
           stripe_customer_id: "cus_123",
@@ -453,8 +454,31 @@ RSpec.describe Company, type: :model do
         expect(company.stripe_subscription_id).to eq("sub_123")
         expect(company.subscription_status).to eq("active")
         expect(company.subscription_interval).to eq("month")
-        expect(company.trial_started_at).to be_nil
         expect(company.trial_ends_at).to be_nil
+        expect(company.trial_started_at).to be_within(1.second).of(started_at)
+      end
+
+      it "does not let a subscribe then cancel cycle grant a second trial" do
+        company.update!(trial_started_at: 20.days.ago, trial_ends_at: 6.days.ago)
+
+        company.apply_stripe_subscription!(
+          stripe_customer_id: "cus_123",
+          stripe_subscription_id: "sub_123",
+          subscription_status: "active",
+          subscription_interval: "month"
+        )
+        company.apply_stripe_subscription!(
+          stripe_customer_id: "cus_123",
+          stripe_subscription_id: "sub_123",
+          subscription_status: "canceled",
+          subscription_interval: "month"
+        )
+
+        company.reload
+
+        expect(company.plan_tier).to eq("free")
+        expect(company.trial_available?).to eq(false)
+        expect(company.trial_active?).to eq(false)
       end
 
       it "downgrades without changing trial timestamps" do

--- a/spec/requests/api/v1/subscriptions/checkout_spec.rb
+++ b/spec/requests/api/v1/subscriptions/checkout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Api::V1::SubscriptionsController, type: :request do

--- a/spec/requests/api/v1/subscriptions/checkout_spec.rb
+++ b/spec/requests/api/v1/subscriptions/checkout_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::SubscriptionsController, type: :request do
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:headers) { auth_headers(user) }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role(:owner, company)
+  end
+
+  describe "POST /api/v1/subscription/checkout" do
+    it "rejects checkout for an existing paid subscription" do
+      allow(Stripe::Checkout::Session).to receive(:create)
+
+      post "/api/v1/subscription/checkout", headers: headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["errors"]).to eq(
+        "Your workspace already has an active paid subscription. Use Manage billing to make changes."
+      )
+      expect(Stripe::Checkout::Session).not_to have_received(:create)
+    end
+  end
+end


### PR DESCRIPTION
Part of the conversion-funnel audit (see `plans/` 018-023). First in the priority order — protects your earliest paying customers.

## Problems fixed

**1. A customer who upgrades during their trial was still shown "Pro Trial".**
`Company#current_plan_label` returned `"pro_trial"` before checking `"paid"`, `current_subscription_status` returned `"trialing"` before the real Stripe status, and `apply_stripe_subscription!` never cleared the trial's end date. A paying customer was told they were still on a free trial (billing page + subscription API), until `trial_ends_at` passed.

Fix: prefer the paid plan and the real Stripe status over an active trial, and null `trial_ends_at` when a paid subscription is applied so trial predicates stop firing for a paying company.

**2. No already-paid guard on `checkout` → double charge.**
A paid workspace that reached `POST /subscription/checkout` again (the billing UI still showed the Upgrade button during the post-checkout webhook race — fixed separately in plan 020 — and the raw API / agent path is always reachable) created a **second** active Stripe subscription on the same customer and was billed twice.

Fix: early-return `422 already_subscribed` when `plan_tier == "paid"` and point the customer at the billing portal.

## Adversarial-review catch (fixed in this PR)

The first cut nulled `trial_started_at` too. Because `trial_available?` keys on `trial_started_at.blank?`, that would have let a **subscribe → cancel** cycle grant a fresh 14-day trial every time (unbounded free-tier abuse). Corrected to null **only** `trial_ends_at` and keep `trial_started_at` (one trial per company), with a regression spec for the subscribe→cancel cycle. Re-review confirmed the asymmetric (present-start / nil-end) state is nil-guarded everywhere and `TrialEmailsJob` filters it out before any dereference.

## Verification

- 95 specs green across `spec/models/company_spec.rb`, `spec/requests/api/v1/subscriptions`, `spec/jobs/trial_emails_job_spec.rb`, `spec/services/subscriptions`, `spec/mailers/subscription_mailer_spec.rb`, including new examples for the paid-over-trial precedence, the downgrade-preserves-timestamps case, the subscribe→cancel re-trial guard, and the already-paid checkout 422 (asserts `Stripe::Checkout::Session.create` is not called).
- Behavior confirmed via rails runner: a paid mid-trial company reads `current_plan_label == "paid"` / status `active` (was `pro_trial`/`trialing`); a genuine trial still reads `pro_trial`/`trialing`.
- RuboCop clean. Dual-model adversarial review: CONFIRMED clean.

## Follow-ups (planned, not in this PR)

`plans/README.md` has the full funnel audit: 020 (post-checkout webhook-race polling), 019 (Stripe payment-link fulfillment), 021 (in-app trial countdown banner), 023 (trial-expired email), 022 (tease Reports). Plus three product decisions flagged for you: Analytics ungated while Reports is paywalled, per-seat billing never reconciled to Stripe, and the self-hosted trial dead-ending at day 14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection to block subscription checkout when a workspace already has an active paid subscription.
  * Users are shown an error with guidance to use **Manage billing** for changes.

* **Bug Fixes**
  * Paid subscription status now takes precedence over active trials.
  * Trial end dates are cleared when a subscription becomes paid.
  * Cancel/downgrade flows no longer incorrectly grant an additional trial; existing trial timestamps are preserved.

* **Tests**
  * Added/expanded request and model specs to cover the new checkout rule and trial/subscription precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->