### PR TITLE
fix: billing page confirms real paid state after checkout (no stale success banner)

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -64,6 +64,7 @@ const Billing = () => {
   const [processingPortal, setProcessingPortal] = useState(false);
   const [processingTrial, setProcessingTrial] = useState(false);
   const [billingResult, setBillingResult] = useState<string | null>(null);
+  const [finalizing, setFinalizing] = useState(false);
   const [billingInterval, setBillingInterval] = useState<"monthly" | "yearly">(
     "monthly"
   );
@@ -137,10 +138,59 @@ const Billing = () => {
 
   useEffect(() => {
     sendGAPageView();
-    fetchSummary();
     const query = new URLSearchParams(window.location.search);
     const billing = query.get("billing");
     if (billing) setBillingResult(billing);
+
+    if (billing !== "success") {
+      fetchSummary();
+
+      return;
+    }
+
+    let isMounted = true;
+    let attempts = 0;
+    let timer = 0;
+
+    setFinalizing(true);
+    setStatus(ApiStatus.LOADING);
+
+    const pollSummary = async () => {
+      try {
+        const response = await subscriptionsApi.show();
+        if (!isMounted) return;
+
+        setSummary(response.data);
+        setSeatEstimate(Math.max(response.data.used_team_seats || 3, 3));
+        setStatus(ApiStatus.SUCCESS);
+        attempts += 1;
+
+        if (response.data.plan_tier === "paid") {
+          setFinalizing(false);
+
+          return;
+        }
+      } catch {
+        if (!isMounted) return;
+        attempts += 1;
+      }
+
+      if (attempts >= 10) {
+        setFinalizing(false);
+        setBillingResult("delayed");
+
+        return;
+      }
+
+      timer = window.setTimeout(pollSummary, 2000);
+    };
+
+    pollSummary();
+
+    return () => {
+      isMounted = false;
+      window.clearTimeout(timer);
+    };
   }, []);
 
   const planLabel = () => {
@@ -333,10 +383,24 @@ const Billing = () => {
       {billingResult === "success" && (
         <Alert>
           <AlertTitle>
-            {i18n.t("billingSettings.alerts.subscriptionUpdatedTitle")}
+            {i18n.t(
+              finalizing
+                ? "billingSettings.alerts.finalizing"
+                : "billingSettings.alerts.subscriptionUpdatedTitle"
+            )}
           </AlertTitle>
+          {!finalizing && (
+            <AlertDescription>
+              {i18n.t("billingSettings.alerts.subscriptionUpdated")}
+            </AlertDescription>
+          )}
+        </Alert>
+      )}
+
+      {billingResult === "delayed" && (
+        <Alert>
           <AlertDescription>
-            {i18n.t("billingSettings.alerts.subscriptionUpdated")}
+            {i18n.t("billingSettings.alerts.finalizingDelayed")}
           </AlertDescription>
         </Alert>
       )}
@@ -526,13 +590,18 @@ const Billing = () => {
                   </Button>
                 )}
 
-                {!summary.billing_exempt && summary.plan_tier !== "paid" && (
-                  <Button onClick={startCheckout} disabled={processingCheckout}>
-                    {processingCheckout
-                      ? i18n.t("billingSettings.openingStripe")
-                      : i18n.t("billingSettings.upgradeWithStripe")}
-                  </Button>
-                )}
+                {!finalizing &&
+                  !summary.billing_exempt &&
+                  summary.plan_tier !== "paid" && (
+                    <Button
+                      onClick={startCheckout}
+                      disabled={processingCheckout}
+                    >
+                      {processingCheckout
+                        ? i18n.t("billingSettings.openingStripe")
+                        : i18n.t("billingSettings.upgradeWithStripe")}
+                    </Button>
+                  )}
 
                 {(summary.plan_tier === "paid" ||
                   summary.has_stripe_customer) && (
@@ -729,7 +798,8 @@ const Billing = () => {
                       : i18n.t("billingSettings.startTrial")}
                   </Button>
                 )}
-                {summary &&
+                {!finalizing &&
+                  summary &&
                   !summary.billing_exempt &&
                   summary.plan_tier !== "paid" && (
                     <Button

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -140,7 +140,10 @@ const Billing = () => {
     sendGAPageView();
     const query = new URLSearchParams(window.location.search);
     const billing = query.get("billing");
-    if (billing) setBillingResult(billing);
+    if (billing) {
+      setBillingResult(billing);
+      window.history.replaceState({}, "", window.location.pathname);
+    }
 
     if (billing !== "success") {
       fetchSummary();
@@ -150,6 +153,7 @@ const Billing = () => {
 
     let isMounted = true;
     let attempts = 0;
+    let loadedSummary = false;
     let timer = 0;
 
     setFinalizing(true);
@@ -160,6 +164,7 @@ const Billing = () => {
         const response = await subscriptionsApi.show();
         if (!isMounted) return;
 
+        loadedSummary = true;
         setSummary(response.data);
         setSeatEstimate(Math.max(response.data.used_team_seats || 3, 3));
         setStatus(ApiStatus.SUCCESS);
@@ -177,7 +182,11 @@ const Billing = () => {
 
       if (attempts >= 10) {
         setFinalizing(false);
-        setBillingResult("delayed");
+        if (loadedSummary) {
+          setBillingResult("delayed");
+        } else {
+          setStatus(ApiStatus.ERROR);
+        }
 
         return;
       }

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1955,6 +1955,9 @@ const en = {
     alerts: {
       subscriptionUpdatedTitle: "Subscription updated",
       subscriptionUpdated: "Your plan was updated in Stripe successfully.",
+      finalizing: "Finalizing your subscription…",
+      finalizingDelayed:
+        "Payment received — your Pro access will appear shortly. Refresh in a minute.",
       checkoutCancelled: "Checkout cancelled",
       noSubscriptionChanges: "No changes were made to your subscription.",
       unableToLoad: "Unable to load billing details",


### PR DESCRIPTION
Conversion-funnel audit, plan 020 (see `plans/`). Depends on #2397 (merged).

## Problem

Stripe redirects the buyer back to `/settings/billing?billing=success` the instant checkout completes — usually **before** the `checkout.session.completed` webhook is processed. The page fetched its summary once on mount and unconditionally showed a green "subscription updated" banner, while the plan card still read "Pro Trial"/"No plan" and **both** "Upgrade with Stripe" buttons stayed visible — inviting a second purchase (the double-charge #2397 guards server-side). It only self-healed on manual refresh or the daily 01:00 reconcile job.

## Fix

On `?billing=success`, poll the subscription summary every 2s up to ~20s:
- Show a **"Finalizing your subscription…"** state and hide **both** upgrade buttons until `plan_tier` flips to `paid`.
- When paid → the real success banner.
- On timeout **with** a loaded summary → a softer "Payment received — your Pro access will appear shortly" message.
- On all-poll-failure (no summary ever loaded) → the error state ("Unable to load billing details"), not an endless skeleton.
- Strip the `?billing=success` query param on read so a refresh doesn't re-run the cycle.
- Poll timer cleared on unmount; every setState guarded against setState-after-unmount.

## Verification

Browser-verified end to end with Playwright (zero console errors):
- **Finalizing**: "Finalizing…" shows, both upgrade buttons hidden.
- **Paid**: flipping the company to paid mid-poll shows the real success banner, upgrade button hidden. Screenshot captured.
- **Delayed**: after the poll cap, the payment-received fallback appears.
- **Refresh**: URL is stripped to `/settings/billing`; a reload shows the normal page, no re-trigger.
- `bin/vite build` clean, ESLint clean.

Two defects were caught **only** because I verified in the browser + adversarial review, and fixed in this PR: a **second unguarded upgrade button** (the plan-table CTA), and a **stuck-loading-skeleton** when every poll fails during the webhook window. Dual-model adversarial review: **CONFIRMED clean**.

## Deferred (documented in plan 020)

The attempt cap only advances when the request settles; the repo's axios client has no default timeout, so a hung first request is a pre-existing low-probability edge — noted as a follow-up, not blocking (per review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a subscription finalization state after successful billing.
  * The billing page now checks for plan activation and updates the subscription status automatically.
  * Added messaging for delayed Pro access when payment has been received.

* **Bug Fixes**
  * Improved post-checkout handling to prevent premature billing status updates.
  * Upgrade actions are temporarily hidden while subscription changes are being finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->