### PR TITLE
feat: tease Reports as a Pro upsell instead of hiding it

### DIFF
--- a/app/javascript/src/components/Dashboard/DashboardLayout.tsx
+++ b/app/javascript/src/components/Dashboard/DashboardLayout.tsx
@@ -191,11 +191,13 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
 
   const filterNavigationGroup = group => ({
     ...group,
-    items: group.items.filter(
-      item =>
-        (!item.roles || item.roles.includes(companyRole)) &&
-        !(item.href === "/reports" && !hasProAccess(company))
-    ),
+    items: group.items
+      .filter(item => !item.roles || item.roles.includes(companyRole))
+      .map(item =>
+        item.href === "/reports" && !hasProAccess(company)
+          ? { ...item, href: "/settings/billing?feature=reports" }
+          : item
+      ),
   });
 
   // prettier-ignore

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -64,6 +64,7 @@ const Billing = () => {
   const [processingPortal, setProcessingPortal] = useState(false);
   const [processingTrial, setProcessingTrial] = useState(false);
   const [billingResult, setBillingResult] = useState<string | null>(null);
+  const [featureGate, setFeatureGate] = useState<string | null>(null);
   const [finalizing, setFinalizing] = useState(false);
   const [billingInterval, setBillingInterval] = useState<"monthly" | "yearly">(
     "monthly"
@@ -140,6 +141,8 @@ const Billing = () => {
     sendGAPageView();
     const query = new URLSearchParams(window.location.search);
     const billing = query.get("billing");
+    const feature = query.get("feature");
+    setFeatureGate(feature);
     if (billing) {
       setBillingResult(billing);
       window.history.replaceState({}, "", window.location.pathname);
@@ -421,6 +424,17 @@ const Billing = () => {
           </AlertTitle>
           <AlertDescription>
             {i18n.t("billingSettings.alerts.noSubscriptionChanges")}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {featureGate === "reports" && summary && summary.plan_tier !== "paid" && (
+        <Alert>
+          <AlertTitle>
+            {i18n.t("billingSettings.featureGate.reportsTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {i18n.t("billingSettings.featureGate.reportsDescription")}
           </AlertDescription>
         </Alert>
       )}

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -143,8 +143,8 @@ const Billing = () => {
     const billing = query.get("billing");
     const feature = query.get("feature");
     setFeatureGate(feature);
-    if (billing) {
-      setBillingResult(billing);
+    if (billing || feature) {
+      if (billing) setBillingResult(billing);
       window.history.replaceState({}, "", window.location.pathname);
     }
 
@@ -428,7 +428,7 @@ const Billing = () => {
         </Alert>
       )}
 
-      {featureGate === "reports" && summary && summary.plan_tier !== "paid" && (
+      {featureGate === "reports" && summary && !summary.pro_access && (
         <Alert>
           <AlertTitle>
             {i18n.t("billingSettings.featureGate.reportsTitle")}

--- a/app/javascript/src/components/Reports/AccessGate.tsx
+++ b/app/javascript/src/components/Reports/AccessGate.tsx
@@ -18,7 +18,7 @@ const ReportsAccessGate: React.FC<{ children: React.ReactNode }> = ({
   }
 
   if (!hasProAccess(effectiveCompany)) {
-    return <Navigate replace to="/settings/billing" />;
+    return <Navigate replace to="/settings/billing?feature=reports" />;
   }
 
   return <>{children}</>;

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1961,6 +1961,11 @@ const en = {
       monthly: "Billed month to month",
       yearlySavings: "Save 2 months per seat",
     },
+    featureGate: {
+      reportsTitle: "Reports is a Pro feature",
+      reportsDescription:
+        "Upgrade to Pro to unlock Reports, analytics, and exports.",
+    },
     alerts: {
       subscriptionUpdatedTitle: "Subscription updated",
       subscriptionUpdated: "Your plan was updated in Stripe successfully.",


### PR DESCRIPTION
Conversion-funnel audit, plan 022 (the last of six — see `plans/`). Turns the Reports Pro gate from *hidden* into an *upsell trigger*.

## Problem

Reports is the headline Pro feature the billing page markets, yet free/expired users never encountered it: the nav item was filtered out entirely, and deep-linking `/reports` silently redirected to a context-free billing page. The desire→upgrade moment never fired.

## What

Presentation-only (the server-side gate `report_policy` is untouched):
- Keep the Reports nav item **visible** for non-pro users, pointing at `/settings/billing?feature=reports`.
- The `AccessGate` redirect for `/reports` now carries the same `?feature=reports`.
- The billing page shows a **"Reports is a Pro feature"** upgrade banner when `feature=reports` and the workspace lacks Pro access, then strips the param.

## Verification

Browser-verified with Playwright (zero console errors):
- **Non-pro (expired trial)**: Reports appears in nav (→ billing?feature=reports); deep-linking /reports redirects to billing?feature=reports and shows the banner. Screenshot captured.
- **Pro (paid)**: Reports nav is `/reports`, deep-link works, no banner — no regression.
- **Trial (has access)**: no banner even at ?feature=reports.
- Backend gate confirmed intact: `report_policy` not in the diff; the report API still 403s non-pro and every route stays wrapped by `ReportsAccessGate`.
- `bin/vite build` + ESLint clean.

Adversarial review caught two banner mis-fires — it showed "Upgrade to unlock Reports" to a user who had **just started a trial** (plan_tier still "free" but pro_access true), and the `?feature` param wasn't cleared so a refresh re-showed it. Both fixed (gate on `!summary.pro_access`; strip the param) and browser-verified. Review verdict: **approve**, gate secure, nav/title correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer access guidance for Reports when Pro access is unavailable.
  * Reports links now direct users to billing settings with Reports-specific context.
  * Added a billing alert explaining the Reports Pro feature and upgrade option.
  * Added supporting copy for the Reports feature in English localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->