### PR TITLE
feat: turn the team-seat limit into a targeted upgrade prompt

### DIFF
--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -439,6 +439,17 @@ const Billing = () => {
         </Alert>
       )}
 
+      {featureGate === "seats" && summary && !summary.pro_access && (
+        <Alert>
+          <AlertTitle>
+            {i18n.t("billingSettings.featureGate.seatsTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {i18n.t("billingSettings.featureGate.seatsDescription")}
+          </AlertDescription>
+        </Alert>
+      )}
+
       <Card className="border-border bg-card shadow-sm">
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>{i18n.t("billingSettings.membership")}</CardTitle>

--- a/app/javascript/src/components/Team/TeamTable.tsx
+++ b/app/javascript/src/components/Team/TeamTable.tsx
@@ -645,7 +645,7 @@ const TeamTable: React.FC = () => {
               <button
                 type="button"
                 className="text-sm font-medium text-primary hover:underline"
-                onClick={() => navigate("/settings/billing")}
+                onClick={() => navigate("/settings/billing?feature=seats")}
               >
                 {i18n.t("team.upgradePlan")}
               </button>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1965,6 +1965,9 @@ const en = {
       reportsTitle: "Reports is a Pro feature",
       reportsDescription:
         "Upgrade to Pro to unlock Reports, analytics, and exports.",
+      seatsTitle: "You've reached your free plan's team limit",
+      seatsDescription:
+        "Upgrade to Pro to add unlimited team members to this workspace.",
     },
     alerts: {
       subscriptionUpdatedTitle: "Subscription updated",


### PR DESCRIPTION
Follow-on conversion-funnel work (plan 024 in `plans/`), extending the `?feature=` upsell pattern shipped for Reports (#2405) to the **highest-intent gate in the app**: an admin trying to add a teammate past the free plan's 3-seat cap.

## Problem

When a free/expired workspace hits the seat limit, the Team page disables **Invite Member** and shows an **Upgrade to add more members** link — but that link pointed at a bare `/settings/billing` with no context. The billing page then told the user nothing about *why* they landed there. Adding a teammate is peak buy-intent (they're actively growing), and the moment was being wasted.

## What

Presentation only — the server-side seat gate (`Company#team_member_limit_reached?`, limit 3) is untouched:
- The Team page's seat-limit upgrade link now carries `/settings/billing?feature=seats`.
- The billing page shows a **"You've reached your free plan's team limit"** banner when `feature=seats` and the workspace lacks Pro access, then strips the param (reusing the generic `featureGate` mechanism from #2405 — gated on `!summary.pro_access` so it never mis-fires at a trial/paid workspace).

## Verification

Browser-verified with Playwright as a **non-pro (expired-trial)** admin over the 3-seat limit (zero console errors):
- Team page: Invite disabled, **Upgrade to add more members** visible → clicking navigates to billing, the seats banner renders, and the `?feature=seats` param is stripped from the URL. Confirmed on the running app.
- Billing page shows the contextual banner above the membership card.
- Backend gate confirmed unchanged (not in the diff).
- `bin/vite build` exit 0; ESLint clean.

Independent adversarial review (separate model from the implementer): **APPROVE** — traced the Router context (no `useNavigate` crash risk), confirmed the banner gates on `pro_access` (no trial mis-fire like the one caught on #2405), and verified the i18n nesting.

## Scope note

The plan originally also added a CTA to the `AddEditMember` modal, but verification found that modal's host view (`Team/List`) is **no longer mounted by any router** — `/team` renders `TeamTable`. That edit was dropped rather than ship dead code; the live seat surface is entirely on `TeamTable`, fully covered here. (Details in `plans/024-*.md`.)

One accepted cosmetic nit (per review): a non-pro at-limit admin arriving via the CTA sees this contextual banner plus the pre-existing membership-card seat-limit alert — redundant but reinforcing; left as a possible future single-message polish.