### PR TITLE
feat: bill per team member and keep the Stripe quantity in sync

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -93,6 +93,7 @@ class Api::V1::SubscriptionsController < Api::V1::ApplicationController
         has_stripe_customer: current_company.stripe_customer_id.present?,
         team_member_limit: current_company.team_member_limit,
         used_team_seats: current_company.used_team_seats,
+        billable_team_seats: current_company.billable_team_seats,
         client_portal_users_count: current_company.client_portal_users_count,
         team_member_limit_reached: current_company.team_member_limit_reached?,
         trial_active: current_company.trial_active?,

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -48,6 +48,7 @@ type BillingSummary = {
   has_stripe_customer: boolean;
   team_member_limit: number;
   used_team_seats: number;
+  billable_team_seats: number;
   client_portal_users_count: number;
   team_member_limit_reached: boolean;
   trial_active: boolean;
@@ -76,7 +77,7 @@ const Billing = () => {
       setStatus(ApiStatus.LOADING);
       const response = await subscriptionsApi.show();
       setSummary(response.data);
-      setSeatEstimate(Math.max(response.data.used_team_seats || 3, 3));
+      setSeatEstimate(Math.max(response.data.billable_team_seats || 3, 3));
       setStatus(ApiStatus.SUCCESS);
     } catch {
       setStatus(ApiStatus.ERROR);
@@ -169,7 +170,7 @@ const Billing = () => {
 
         loadedSummary = true;
         setSummary(response.data);
-        setSeatEstimate(Math.max(response.data.used_team_seats || 3, 3));
+        setSeatEstimate(Math.max(response.data.billable_team_seats || 3, 3));
         setStatus(ApiStatus.SUCCESS);
         attempts += 1;
 

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1991,7 +1991,7 @@ const en = {
         "Upgrade in Stripe to add more than 3 members to this workspace.",
       clientPortalUsersTitle: "Client portal users included in seat count",
       clientPortalUsersDescription:
-        "Your seat count includes %{count} client portal user(s) who have login access. These users can view their invoices, projects, and time entries. Team members are managed on the Team page.",
+        "%{count} client portal user(s) have login access and count toward your workspace's seat usage, but they are not billed — only team members are charged. Team members are managed on the Team page.",
     },
     errors: {
       unableToOpenStripeCheckout: "Unable to open Stripe checkout",

--- a/app/jobs/sync_stripe_subscription_company_job.rb
+++ b/app/jobs/sync_stripe_subscription_company_job.rb
@@ -8,5 +8,6 @@ class SyncStripeSubscriptionCompanyJob < ApplicationJob
     return if company.blank?
 
     Subscriptions::StripeSyncService.process(company:)
+    Subscriptions::SeatReconciliationService.process(company: company.reload)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -118,7 +118,7 @@ class Company < ApplicationRecord
   end
 
   def billable_team_seats
-    [used_team_seats, 1].max
+    [employees_without_client_role.count, 1].max
   end
 
   def client_portal_users_count

--- a/app/services/subscriptions/seat_reconciliation_service.rb
+++ b/app/services/subscriptions/seat_reconciliation_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class SeatReconciliationService
+    ALLOWED_PRORATION_BEHAVIORS = %w[none create_prorations always_invoice].freeze
+    DEFAULT_PRORATION_BEHAVIOR = "none"
+
+    def self.process(...)
+      new(...).process
+    end
+
+    def initialize(company:)
+      @company = company
+    end
+
+    def process
+      return :skipped unless reconcilable?
+
+      subscription = Stripe::Subscription.retrieve(company.stripe_subscription_id)
+      item = single_seat_item(subscription)
+      return :skipped if item.nil?
+
+      if item.quantity.nil?
+        Rails.logger.warn(
+          "SeatReconciliation: company=#{company.id} skipped — item has no quantity (metered price?)"
+        )
+        return :skipped
+      end
+
+      desired = company.billable_team_seats
+      current = item.quantity.to_i
+      return :in_sync if current == desired
+
+      Stripe::Subscription.update(
+        subscription.id,
+        items: [{ id: item.id, quantity: desired }],
+        proration_behavior: proration_behavior
+      )
+
+      Rails.logger.info(
+        "SeatReconciliation: company=#{company.id} #{current}->#{desired} " \
+        "proration=#{proration_behavior}"
+      )
+      :updated
+    rescue Stripe::StripeError => e
+      Rails.logger.error("SeatReconciliation: company=#{company.id} failed: #{e.class}: #{e.message}")
+      false
+    end
+
+    private
+
+      attr_reader :company
+
+      def reconcilable?
+        company.present? &&
+          company.plan_tier == "paid" &&
+          company.stripe_subscription_id.present? &&
+          company.stripe_subscription_active?
+      end
+
+      # Only reconcile a subscription with exactly one line item (the seat price).
+      # If Stripe ever returns multiple items we do not guess which one is seats.
+      def single_seat_item(subscription)
+        items = subscription.items&.data
+        return nil if items.blank?
+
+        if items.length != 1
+          Rails.logger.warn(
+            "SeatReconciliation: company=#{company.id} skipped — subscription has #{items.length} line items"
+          )
+          return nil
+        end
+
+        items.first
+      end
+
+      def proration_behavior
+        value = ENV.fetch("STRIPE_SEAT_PRORATION_BEHAVIOR", DEFAULT_PRORATION_BEHAVIOR)
+        ALLOWED_PRORATION_BEHAVIORS.include?(value) ? value : DEFAULT_PRORATION_BEHAVIOR
+      end
+  end
+end

--- a/spec/jobs/sync_stripe_subscription_company_job_spec.rb
+++ b/spec/jobs/sync_stripe_subscription_company_job_spec.rb
@@ -17,9 +17,22 @@ RSpec.describe SyncStripeSubscriptionCompanyJob, type: :job do
     company = create(:company, stripe_customer_id: nil)
 
     allow(Subscriptions::StripeSyncService).to receive(:process)
+    allow(Subscriptions::SeatReconciliationService).to receive(:process)
 
     described_class.perform_now(company.id)
 
     expect(Subscriptions::StripeSyncService).not_to have_received(:process)
+    expect(Subscriptions::SeatReconciliationService).not_to have_received(:process)
+  end
+
+  it "reconciles seats after syncing the company" do
+    company = create(:company, stripe_customer_id: "cus_1")
+
+    allow(Subscriptions::StripeSyncService).to receive(:process).and_return(true)
+    allow(Subscriptions::SeatReconciliationService).to receive(:process)
+
+    described_class.perform_now(company.id)
+
+    expect(Subscriptions::SeatReconciliationService).to have_received(:process).with(company:)
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -386,15 +386,23 @@ RSpec.describe Company, type: :model do
 
     describe "#billable_team_seats" do
       it "returns at least one seat for billing" do
-        expect(company.billable_team_seats).to eq([company.used_team_seats, 1].max)
+        expect(create(:company).billable_team_seats).to eq(1)
       end
 
-      it "matches the kept employment count when the team grows" do
-        baseline = company.used_team_seats
+      it "matches the non-client kept employment count when the team grows" do
         second_user = create(:user)
         create(:employment, company:, user: second_user)
 
-        expect(company.billable_team_seats).to eq(baseline + 1)
+        expect(company.billable_team_seats).to eq(3)
+      end
+
+      it "excludes client-only users from billing but counts them as used seats" do
+        client_portal_user = create(:user)
+        create(:employment, company:, user: client_portal_user)
+        client_portal_user.add_role(:client, company)
+
+        expect(company.billable_team_seats).to eq(2)
+        expect(company.used_team_seats).to eq(3)
       end
     end
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
       expect(body["used_team_seats"]).to eq(2)
+      expect(body["billable_team_seats"]).to eq(1)
       expect(body["client_portal_users_count"]).to eq(1)
     end
 

--- a/spec/services/subscriptions/seat_reconciliation_service_spec.rb
+++ b/spec/services/subscriptions/seat_reconciliation_service_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::SeatReconciliationService do
+  describe ".process" do
+    let(:company) do
+      create(
+        :company,
+        plan_tier: "paid",
+        stripe_subscription_id: "sub_123",
+        subscription_status: "active"
+      )
+    end
+    let(:current_qty) { 5 }
+    let(:subscription) do
+      OpenStruct.new(
+        id: "sub_123",
+        items: OpenStruct.new(data: [OpenStruct.new(id: "si_1", quantity: current_qty)])
+      )
+    end
+
+    before do
+      allow(company).to receive(:billable_team_seats).and_return(8)
+      allow(Stripe::Subscription).to receive(:retrieve).and_return(subscription)
+      allow(Stripe::Subscription).to receive(:update)
+    end
+
+    it "updates an under-billed subscription" do
+      result = described_class.process(company:)
+
+      expect(result).to eq(:updated)
+      expect(Stripe::Subscription).to have_received(:update).once.with(
+        "sub_123",
+        items: [{ id: "si_1", quantity: 8 }],
+        proration_behavior: "none"
+      )
+    end
+
+    it "updates an over-billed subscription" do
+      allow(company).to receive(:billable_team_seats).and_return(2)
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:updated)
+      expect(Stripe::Subscription).to have_received(:update).once.with(
+        "sub_123",
+        items: [{ id: "si_1", quantity: 2 }],
+        proration_behavior: "none"
+      )
+    end
+
+    it "does not update an in-sync subscription" do
+      allow(company).to receive(:billable_team_seats).and_return(5)
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:in_sync)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "skips a company that is not paid" do
+      company.update!(plan_tier: "free")
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:skipped)
+      expect(Stripe::Subscription).not_to have_received(:retrieve)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "skips a company without a subscription id" do
+      company.update!(stripe_subscription_id: nil)
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:skipped)
+      expect(Stripe::Subscription).not_to have_received(:retrieve)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "skips a company with an inactive subscription" do
+      company.update!(subscription_status: "canceled")
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:skipped)
+      expect(Stripe::Subscription).not_to have_received(:retrieve)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "skips a subscription with multiple items" do
+      subscription.items.data << OpenStruct.new(id: "si_2", quantity: 1)
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:skipped)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "skips a subscription item without a quantity" do
+      subscription.items.data.first.quantity = nil
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:skipped)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "returns false when Stripe raises an error" do
+      allow(Stripe::Subscription).to receive(:retrieve)
+        .and_raise(Stripe::InvalidRequestError.new("boom", "id"))
+
+      expect(described_class.process(company:)).to eq(false)
+      expect(Stripe::Subscription).not_to have_received(:update)
+    end
+
+    it "uses a valid proration override and falls back to none for an invalid value" do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch)
+        .with("STRIPE_SEAT_PRORATION_BEHAVIOR", "none")
+        .and_return("create_prorations")
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:updated)
+      expect(Stripe::Subscription).to have_received(:update).with(
+        "sub_123",
+        items: [{ id: "si_1", quantity: 8 }],
+        proration_behavior: "create_prorations"
+      )
+
+      allow(ENV).to receive(:fetch)
+        .with("STRIPE_SEAT_PRORATION_BEHAVIOR", "none")
+        .and_return("invalid")
+
+      result = described_class.process(company:)
+
+      expect(result).to eq(:updated)
+      expect(Stripe::Subscription).to have_received(:update).with(
+        "sub_123",
+        items: [{ id: "si_1", quantity: 8 }],
+        proration_behavior: "none"
+      )
+    end
+  end
+
+  it "does not bill a client-portal user when reconciling the actual billable seat count" do
+    company = create(
+      :company,
+      plan_tier: "paid",
+      stripe_subscription_id: "sub_123",
+      subscription_status: "active"
+    )
+    team_members = create_list(:user, 2, current_workspace_id: company.id)
+    client_portal_user = create(:user, current_workspace_id: company.id)
+
+    team_members.each do |user|
+      create(:employment, company:, user:)
+      user.add_role(:employee, company)
+    end
+    create(:employment, company:, user: client_portal_user)
+    client_portal_user.add_role(:client, company)
+
+    subscription = OpenStruct.new(
+      id: "sub_123",
+      items: OpenStruct.new(data: [OpenStruct.new(id: "si_1", quantity: 1)])
+    )
+    allow(Stripe::Subscription).to receive(:retrieve).and_return(subscription)
+    allow(Stripe::Subscription).to receive(:update)
+
+    result = described_class.process(company:)
+
+    expect(company.billable_team_seats).to eq(2)
+    expect(Stripe::Subscription).to have_received(:update).once.with(
+      "sub_123",
+      items: [{ id: "si_1", quantity: 2 }],
+      proration_behavior: "none"
+    )
+    expect(result).to eq(:updated)
+  end
+end


### PR DESCRIPTION
Revenue-correctness work (plans 025 + 026 in `plans/`) on the per-seat billing path. Two changes that ship together.

## 1. Reconcile Stripe quantity to actual seats (025)

Checkout set the initial Stripe subscription quantity to the seat count, but **nothing updated it afterward** — `StripeSyncService` only reads from Stripe. A Pro workspace that grew from 5→20 seats kept paying for 5 indefinitely (lost MRR); a shrinking one kept over-paying.

A new `Subscriptions::SeatReconciliationService` runs inside the **existing daily** `SyncStripeSubscriptionCompanyJob` — deliberately **not** the webhook path, so our own `Stripe::Subscription.update` can't trigger an update→webhook→update loop. It is strictly **idempotent** (skips the update when quantity already matches) and defaults to **`proration_behavior: "none"`** (overridable via `STRIPE_SEAT_PRORATION_BEHAVIOR`) so the first true-up bills correctly from the next invoice **without surprise mid-cycle charges**. Guards: paid + active subscription, exactly one line item, non-nil quantity — otherwise it logs and skips.

## 2. Bill only true team members (026)

`billable_team_seats` counted **every** kept employment, including client-portal login users — so client contacts were billed as seats (checkout already did this; the billing page even disclosed it). Per maintainer decision, it now counts `employees_without_client_role`, so checkout, reconciliation, and the plan-purchased alert all charge **team members only**. Mixed-role users (client **and** team) are still billed. The billing page's spend estimate is reseeded from the billed count, and the client-portal note now says those users aren't billed.

The **free-plan seat limit is intentionally left counting all logins** (a gating policy, not billing) — see the follow-up note below.

## Verification

- **98 specs green**, rubocop clean, `bin/vite build` exit 0. Specs prove the real split (a fixture with `billable_team_seats == 2` while `used_team_seats == 3`) and that a mixed-role user is still billed — not rebalanced constants.
- **Browser-verified** the billing page (Playwright, zero console errors): with a workspace of 51 logins incl. 16 client-portal users, the spend estimate now shows **$35/mo** (team-only) instead of $51, yearly savings **$70** (consistent), and the usage row still correctly shows 51/3.
- **Independent adversarial review** (separate model, ran the specs): **no billing-correctness defect** — mixed-role billed, floor of 1 safe, retroactive decrease sane under `proration: none`, every Stripe-quantity path uses the team-only count, estimator is display-only and never affects the real charge.

## Follow-up for the maintainer (non-blocking)

Because billing now excludes client-portal users but the **free-plan 3-seat limit still counts them**, a free workspace can be gated at its cap by client logins it would never be billed for. That's an intended, scoped-out divergence — flagging it for conscious acceptance. Happy to align the limit with billing in a follow-up if you want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing seat estimates now reflect billable team members, excluding client portal users.
  * Subscription billing quantities are automatically reconciled when seat counts change.
  * Billing summaries now include billable seat counts.

* **Updates**
  * Clarified that client portal users count toward usage but are not billed.
  * Improved handling of subscription seat updates and proration settings.

* **Tests**
  * Added coverage for seat calculations, billing synchronization, exclusions, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->