### PR TITLE
fix: resolve Stripe price/secret env under production's variable names (unblock checkout)

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -142,14 +142,15 @@ class Api::V1::SubscriptionsController < Api::V1::ApplicationController
     end
 
     def checkout_price_id
-      interval_key =
+      candidates =
         if billing_interval == "yearly"
-          "STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY"
+          %w[STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY STRIPE_YEARLY_PRICE_ID]
         else
-          "STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY"
+          %w[STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY STRIPE_MONTHLY_PRICE_ID]
         end
+      candidates << "STRIPE_SUBSCRIPTION_PRICE_ID"
 
-      ENV[interval_key].presence || ENV["STRIPE_SUBSCRIPTION_PRICE_ID"].to_s
+      candidates.filter_map { |name| ENV[name].presence }.first.to_s
     end
 
     def ensure_stripe_customer_id

--- a/app/jobs/trial_emails_job.rb
+++ b/app/jobs/trial_emails_job.rb
@@ -9,10 +9,14 @@ class TrialEmailsJob < ApplicationJob
   # Self-hosted instances without Stripe pricing have no upgrade path, so
   # trial emails would only nag admins about a checkout that cannot succeed.
   def self.billing_configured?
-    ENV["STRIPE_PLAN_PAGE_URL"].present? ||
-      ENV["STRIPE_SUBSCRIPTION_PRICE_ID"].present? ||
-      ENV["STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY"].present? ||
-      ENV["STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY"].present?
+    %w[
+      STRIPE_PLAN_PAGE_URL
+      STRIPE_SUBSCRIPTION_PRICE_ID
+      STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY
+      STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY
+      STRIPE_MONTHLY_PRICE_ID
+      STRIPE_YEARLY_PRICE_ID
+    ].any? { |name| ENV[name].present? }
   end
 
   def perform

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-Stripe.api_key = ENV["STRIPE_SECRET_KEY"].presence || (Rails.env.test? ? "sk_test_dummy" : nil)
+Stripe.api_key =
+  ENV["STRIPE_SECRET_KEY"].presence ||
+  ENV["STRIPE_API_KEY"].presence ||
+  (Rails.env.test? ? "sk_test_dummy" : nil)

--- a/spec/jobs/trial_emails_job_spec.rb
+++ b/spec/jobs/trial_emails_job_spec.rb
@@ -25,12 +25,24 @@ RSpec.describe TrialEmailsJob do
 
   it "sends nothing when Stripe billing is not configured" do
     %w[STRIPE_PLAN_PAGE_URL STRIPE_SUBSCRIPTION_PRICE_ID STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY
-       STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY].each do |key|
+       STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY STRIPE_MONTHLY_PRICE_ID STRIPE_YEARLY_PRICE_ID].each do |key|
       allow(ENV).to receive(:[]).with(key).and_return(nil)
     end
     start_trial(days_ago: 2)
 
     expect { described_class.perform_now }.not_to have_enqueued_mail(SubscriptionMailer)
+  end
+
+  it "sends the getting started email when only the Render monthly price is configured" do
+    %w[STRIPE_PLAN_PAGE_URL STRIPE_SUBSCRIPTION_PRICE_ID STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY
+       STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY STRIPE_YEARLY_PRICE_ID].each do |key|
+      allow(ENV).to receive(:[]).with(key).and_return(nil)
+    end
+    allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return("price_monthly")
+    start_trial(days_ago: 2)
+
+    expect { described_class.perform_now }.to have_enqueued_mail(SubscriptionMailer, :trial_getting_started)
+      .with(params: { company_id: company.id, recipient_id: owner.id }, args: [])
   end
 
   it "sends the getting started email on day two of the trial" do
@@ -142,7 +154,7 @@ RSpec.describe TrialEmailsJob do
 
   it "does not send the expired email when Stripe billing is not configured" do
     %w[STRIPE_PLAN_PAGE_URL STRIPE_SUBSCRIPTION_PRICE_ID STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY
-       STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY].each do |key|
+       STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY STRIPE_MONTHLY_PRICE_ID STRIPE_YEARLY_PRICE_ID].each do |key|
       allow(ENV).to receive(:[]).with(key).and_return(nil)
     end
     start_trial(days_ago: 15)

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -204,6 +204,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY").and_return(nil)
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_YEARLY_PRICE_ID").and_return(nil)
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return(nil)
 
       post "/api/v1/subscription/checkout", headers: headers
@@ -211,10 +213,74 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(response).to have_http_status(:unprocessable_content)
     end
 
+    it "uses the Render monthly price when the existing monthly price is not configured" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return("price_render_monthly")
+      allow(ENV).to receive(:[]).with("STRIPE_YEARLY_PRICE_ID").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return(nil)
+
+      allow(Stripe::Customer).to receive(:create).and_return(OpenStruct.new(id: "cus_monthly"))
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return(OpenStruct.new(url: "https://checkout.stripe.com/monthly"))
+
+      post "/api/v1/subscription/checkout", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Stripe::Checkout::Session).to have_received(:create).with(
+        hash_including(line_items: [{ price: "price_render_monthly", quantity: 1 }])
+      )
+    end
+
+    it "uses the Render yearly price when the existing yearly price is not configured" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_YEARLY_PRICE_ID").and_return("price_render_yearly")
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return(nil)
+
+      allow(Stripe::Customer).to receive(:create).and_return(OpenStruct.new(id: "cus_yearly"))
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return(OpenStruct.new(url: "https://checkout.stripe.com/yearly"))
+
+      post "/api/v1/subscription/checkout", params: { interval: "yearly" }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Stripe::Checkout::Session).to have_received(:create).with(
+        hash_including(line_items: [{ price: "price_render_yearly", quantity: 1 }])
+      )
+    end
+
+    it "falls back to the shared subscription price" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_YEARLY_PRICE_ID").and_return(nil)
+      allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return("price_shared")
+
+      allow(Stripe::Customer).to receive(:create).and_return(OpenStruct.new(id: "cus_shared"))
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return(OpenStruct.new(url: "https://checkout.stripe.com/shared"))
+
+      post "/api/v1/subscription/checkout", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Stripe::Checkout::Session).to have_received(:create).with(
+        hash_including(line_items: [{ price: "price_shared", quantity: 1 }])
+      )
+    end
+
     it "creates a monthly checkout session when configured" do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY").and_return("price_monthly")
+      allow(ENV).to receive(:[]).with("STRIPE_MONTHLY_PRICE_ID").and_return("price_render_monthly")
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return(nil)
 
       stripe_customer = OpenStruct.new(id: "cus_123")
@@ -250,6 +316,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("STRIPE_PLAN_PAGE_URL").and_return(nil)
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY").and_return("price_yearly")
+      allow(ENV).to receive(:[]).with("STRIPE_YEARLY_PRICE_ID").and_return("price_render_yearly")
       allow(ENV).to receive(:[]).with("STRIPE_SUBSCRIPTION_PRICE_ID").and_return(nil)
       extra_user = create(:user, current_workspace_id: company.id)
       create(:employment, company:, user: extra_user)


### PR DESCRIPTION
P0 money-path fix (plan 027 in `plans/`). Found while verifying the live Stripe path — the precondition for any MRR.

## The bug

Production runs on **Render** (`render.yaml`), whose `miru-shared` env group provisions the per-interval Stripe price IDs as:

```
STRIPE_MONTHLY_PRICE_ID
STRIPE_YEARLY_PRICE_ID
STRIPE_SUBSCRIPTION_PRICE_ID
```

But `checkout_price_id` only read `STRIPE_SUBSCRIPTION_PRICE_ID_MONTHLY` / `STRIPE_SUBSCRIPTION_PRICE_ID_YEARLY` — names **never set in prod**. So the interval lookup always missed and fell back to the shared `STRIPE_SUBSCRIPTION_PRICE_ID`. Two bad outcomes depending on which dashboard vars were populated:
- Only the Render-named vars set, shared one blank → `checkout_price_id` returns "" → **422 `pricing_not_configured` → nobody can pay.**
- Shared var set → checkout works but **monthly and yearly bill the same price** (yearly subscribers charged wrong; the two provisioned interval prices are dead config).

Same class of latent trap on the secret key: the code reads `STRIPE_SECRET_KEY` (correct on Render) while the Kamal deploy configs declare `STRIPE_API_KEY`.

## The fix (config resolution only — no pricing/checkout logic change)

- `checkout_price_id` now tries, in order: the existing interval name → the Render name → the shared fallback, returning the first present (blank → 422 unchanged). **Precedence preserves today's behavior**: the existing name still wins when set.
- `TrialEmailsJob.billing_configured?` recognizes the Render price names too, so trial nurture emails gate on whether a customer could actually check out.
- `Stripe.api_key` falls back to `STRIPE_API_KEY` when `STRIPE_SECRET_KEY` is blank.

## Verification

- **42 specs green**, rubocop clean. Specs assert the important invariants: the existing interval name **wins** when both it and the Render name are set; checkout **422s** when no price name is set; the Render names are used when the old ones are absent; `billing_configured?` is true iff a real price/plan var is set.
- **Independent adversarial review: APPROVE** — purely additive, precedence-preserving, 422 safety net intact, no cross-interval or false-positive risk, no misconfig masking.

## Go-live (operator actions this fix enables but can't perform)

The code can now read prod's config, but live revenue still needs the dashboard set up (full checklist in `plans/027-*.md`): create the live Stripe products/prices (monthly + yearly, per-unit), set `STRIPE_SECRET_KEY` (live), `STRIPE_MONTHLY_PRICE_ID`, `STRIPE_YEARLY_PRICE_ID`, and the webhook signing secret in the Render `miru-shared` group, add the Stripe webhook endpoint, redeploy, and run one end-to-end checkout.

Optional future follow-up (pre-existing, out of scope): make the shared-`STRIPE_SUBSCRIPTION_PRICE_ID` fallback interval-aware so a single-var setup can't mis-bill annual subscribers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional Stripe price configuration keys for monthly and yearly checkout plans.
  - Checkout now selects the first available applicable price, with a shared fallback option.
  - Stripe API configuration supports an alternate API key setting.

- **Bug Fixes**
  - Improved handling of incomplete Stripe billing configuration.
  - Prevented trial emails from being sent when required billing settings are missing.

- **Tests**
  - Added coverage for alternate monthly and yearly checkout price settings and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->