### PR TITLE
fix: exclude tracking parameters from canonical URLs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
   <% page_title = content_for?(:title) ? yield(:title) : "#{t('app.name')} | Time tracking and invoicing" %>
   <% page_description = content_for?(:meta_description) ? yield(:meta_description) : "#{t('app.name')} is an open-source platform for time tracking, invoicing, payments, and operations for agencies and small companies." %>
-  <% canonical_url = content_for?(:canonical_url) ? yield(:canonical_url) : request.original_url %>
+  <% canonical_url = content_for?(:canonical_url) ? yield(:canonical_url) : "#{request.base_url}#{request.path}" %>
   <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="description" content="<%= page_description %>">

--- a/spec/requests/seo_metadata_spec.rb
+++ b/spec/requests/seo_metadata_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SEO metadata", type: :request do
+  it "excludes tracking parameters from canonical and Open Graph URLs" do
+    get "/signup", params: {
+      utm_source: "newsletter",
+      utm_medium: "email",
+      utm_campaign: "1k_mrr"
+    }
+
+    document = Nokogiri::HTML(response.body)
+
+    expect(document.at_css('link[rel="canonical"]')["href"]).to eq("http://www.example.com/signup")
+    expect(document.at_css('meta[property="og:url"]')["content"]).to eq("http://www.example.com/signup")
+  end
+end

--- a/spec/requests/seo_metadata_spec.rb
+++ b/spec/requests/seo_metadata_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "SEO metadata", type: :request do
       utm_medium: "email",
       utm_campaign: "1k_mrr"
     }
+    expect(response).to have_http_status(:ok)
 
     document = Nokogiri::HTML(response.body)
 


### PR DESCRIPTION
## Summary

- keep campaign parameters in the visible signup URL for attribution
- remove query parameters from default canonical and Open Graph URLs
- preserve explicit per-page canonical overrides

## Verification

- `bundle exec rspec spec/requests/seo_metadata_spec.rb` — 1 example, 0 failures
- `bundle exec rubocop spec/requests/seo_metadata_spec.rb` — no offenses
- test Vite build — passed
- browser: `/signup?utm_source=newsletter&utm_medium=email&utm_campaign=1k_mrr` rendered successfully
- browser canonical and `og:url`: `/signup` with all query parameters removed
- browser console: 0 errors, 0 warnings

## Coverage

```text
CODE PATHS                                  USER FLOWS
[+] application.html.erb                    [+] SEO/social crawler request
  ├── [TESTED] base URL + request path        ├── [TESTED] UTM query excluded
  ├── [TESTED] canonical link output          └── [TESTED] Open Graph URL matches
  └── explicit override branch unchanged

COVERAGE: 3/3 changed paths tested (100%) | GAPS: 0
```

## Evidence

Screenshot: `output/playwright/seo-canonical-utm.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated canonical and Open Graph URLs to exclude tracking query parameters while preserving the current page URL.
* **Tests**
  * Added request coverage to verify canonical and `og:url` metadata remain clean when pages are accessed with tracking parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->