### PR TITLE
fix: promote canonical URL tracking cleanup

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
   <% page_title = content_for?(:title) ? yield(:title) : "#{t('app.name')} | Time tracking and invoicing" %>
   <% page_description = content_for?(:meta_description) ? yield(:meta_description) : "#{t('app.name')} is an open-source platform for time tracking, invoicing, payments, and operations for agencies and small companies." %>
-  <% canonical_url = content_for?(:canonical_url) ? yield(:canonical_url) : request.original_url %>
+  <% canonical_url = content_for?(:canonical_url) ? yield(:canonical_url) : "#{request.base_url}#{request.path}" %>
   <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="description" content="<%= page_description %>">

--- a/spec/requests/seo_metadata_spec.rb
+++ b/spec/requests/seo_metadata_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SEO metadata", type: :request do
+  it "excludes tracking parameters from canonical and Open Graph URLs" do
+    get "/signup", params: {
+      utm_source: "newsletter",
+      utm_medium: "email",
+      utm_campaign: "1k_mrr"
+    }
+    expect(response).to have_http_status(:ok)
+
+    document = Nokogiri::HTML(response.body)
+
+    expect(document.at_css('link[rel="canonical"]')["href"]).to eq("http://www.example.com/signup")
+    expect(document.at_css('meta[property="og:url"]')["content"]).to eq("http://www.example.com/signup")
+  end
+end


### PR DESCRIPTION
## Summary

- promote the reviewed SEO canonical fix from `develop`
- keep attribution parameters in the visible URL
- exclude query parameters from default canonical and Open Graph URLs

## Provenance

- develop PR: #2410
- develop merge: `1e440cf914358b8e4add7a1ee30d95e01971ad6c`
- production cherry-pick: `6512a98ed`

## Verification

- `bundle exec rspec spec/requests/seo_metadata_spec.rb` — 1 example, 0 failures
- `bundle exec rubocop spec/requests/seo_metadata_spec.rb` — no offenses
- test Vite build — passed
- develop CI, CodeQL, Socket, Snyk, Docker build, and CodeRabbit — passed
