### PR TITLE
feat: growth analytics digest and super-admin dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,6 @@ CLOUDFLARE_ACCOUNT_ID="<Replace with Cloudflare account id>"
 SANITIZED_SUBSET_R2_PREFIX="miru/sanitized-subsets"
 SANITIZED_SUBSET_R2_BUCKET="miru-sanitized-subsets"
 SOURCE_DUMP="tmp/migration/miru_production_20260306_203652.dump"
+
+# Weekly founder growth digest (comma-separated recipients; falls back to super admins)
+FOUNDER_DIGEST_EMAILS=""

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)

--- a/app/controllers/admin/growth_controller.rb
+++ b/app/controllers/admin/growth_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Admin::GrowthController < ApplicationController
+  skip_after_action :verify_authorized
+
+  def show
+    @metrics = Analytics::GrowthMetricsService.process
+    render layout: false
+  end
+end

--- a/app/jobs/analytics/founder_digest_job.rb
+++ b/app/jobs/analytics/founder_digest_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Analytics::FounderDigestJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    recipients = founder_recipients
+
+    if recipients.empty?
+      Rails.logger.info("Analytics::FounderDigestJob skipped: no recipients")
+      return
+    end
+
+    metrics = Analytics::GrowthMetricsService.process
+    recipients.each do |recipient|
+      FounderDigestMailer.with(recipient:, metrics:, date: Date.current).weekly.deliver_later
+    end
+  end
+
+  private
+
+    def founder_recipients
+      configured = ENV["FOUNDER_DIGEST_EMAILS"]
+      return configured.split(",").map(&:strip).compact_blank.uniq if configured.present?
+
+      User.super_admins.pluck(:email)
+    end
+end

--- a/app/mailers/founder_digest_mailer.rb
+++ b/app/mailers/founder_digest_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FounderDigestMailer < ApplicationMailer
+  def weekly
+    @metrics = params[:metrics].deep_symbolize_keys
+    @digest_date = params[:date].presence&.to_date || Date.current
+
+    mail(
+      to: params[:recipient],
+      subject: "Miru growth digest — #{@digest_date.to_fs(:long)}",
+      reply_to: default_reply_to_address
+    )
+  end
+end

--- a/app/services/analytics/growth_metrics_service.rb
+++ b/app/services/analytics/growth_metrics_service.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+module Analytics
+  class GrowthMetricsService < ApplicationService
+    SIGNUP_WEEKS = 4
+    CHECKOUT_EVENTS = %w[subscription_checkout_started subscription_purchased].freeze
+
+    def process
+      {
+        signups:,
+        activation_funnel:,
+        weekly_active:,
+        trials:,
+        checkouts:,
+        top_workspaces:
+      }
+    end
+
+    private
+
+      def now
+        @now ||= Time.current
+      end
+
+      def signups
+        company_counts = signup_counts(Company)
+        user_counts = signup_counts(User)
+
+        {
+          weeks: signup_weeks.map do |week_start|
+            {
+              week_start:,
+              companies: company_counts.fetch(week_start, 0),
+              users: user_counts.fetch(week_start, 0)
+            }
+          end,
+          totals: {
+            companies: Company.count,
+            users: User.count
+          }
+        }
+      end
+
+      def signup_counts(model)
+        model
+          .where(created_at: signup_range)
+          .group(Arel.sql("DATE_TRUNC('week', created_at)"))
+          .count
+          .transform_keys(&:to_date)
+      end
+
+      def signup_weeks
+        @signup_weeks ||= SIGNUP_WEEKS.times.map { |index| now.utc.to_date.beginning_of_week - index.weeks }
+      end
+
+      # DATE_TRUNC buckets the bare timestamp column in UTC, so the Ruby side
+      # of the week math must stay in UTC even if config.time_zone changes.
+      def signup_range
+        signup_weeks.last.in_time_zone("UTC")...(signup_weeks.first + 1.week).in_time_zone("UTC")
+      end
+
+      def activation_funnel
+        {
+          total: Company.count,
+          with_client: companies_with_client,
+          with_activity: companies_with_activity,
+          with_invoice: companies_with_invoice,
+          with_payment: companies_with_payment
+        }
+      end
+
+      def companies_with_client
+        Company.where(<<~SQL.squish).count
+          EXISTS (
+            SELECT 1 FROM clients
+            WHERE clients.company_id = companies.id AND clients.discarded_at IS NULL
+          )
+        SQL
+      end
+
+      def companies_with_activity
+        Company.where(<<~SQL.squish).count
+          EXISTS (
+            SELECT 1
+            FROM timesheet_entries
+            INNER JOIN projects ON projects.id = timesheet_entries.project_id
+            INNER JOIN clients ON clients.id = projects.client_id
+            WHERE clients.company_id = companies.id
+              AND timesheet_entries.discarded_at IS NULL
+              AND projects.discarded_at IS NULL
+              AND clients.discarded_at IS NULL
+          ) OR EXISTS (
+            SELECT 1 FROM invoices
+            WHERE invoices.company_id = companies.id AND invoices.discarded_at IS NULL
+          )
+        SQL
+      end
+
+      def companies_with_invoice
+        Company.where(<<~SQL.squish).count
+          EXISTS (
+            SELECT 1 FROM invoices
+            WHERE invoices.company_id = companies.id AND invoices.discarded_at IS NULL
+          )
+        SQL
+      end
+
+      def companies_with_payment
+        Company.where(<<~SQL.squish).count
+          EXISTS (
+            SELECT 1
+            FROM payments
+            INNER JOIN invoices ON invoices.id = payments.invoice_id
+            WHERE invoices.company_id = companies.id AND invoices.discarded_at IS NULL
+          )
+        SQL
+      end
+
+      def weekly_active
+        {
+          companies: weekly_active_company_ids.size,
+          users: Ahoy::Event
+            .where(name: "user_login", time: seven_day_range)
+            .where.not(user_id: nil)
+            .distinct
+            .count(:user_id)
+        }
+      end
+
+      def weekly_active_company_ids
+        time_entry_company_ids | invoice_company_ids | payment_company_ids
+      end
+
+      def time_entry_company_ids
+        TimesheetEntry.kept
+          .joins(project: :client)
+          .merge(Project.kept)
+          .merge(Client.kept)
+          .where(timesheet_entries: { created_at: seven_day_range })
+          .distinct
+          .pluck("clients.company_id")
+      end
+
+      def invoice_company_ids
+        Invoice.kept
+          .where(created_at: seven_day_range)
+          .where.not(company_id: nil)
+          .distinct
+          .pluck(:company_id)
+      end
+
+      def payment_company_ids
+        Payment
+          .joins(:invoice)
+          .merge(Invoice.kept)
+          .where(payments: { created_at: seven_day_range })
+          .where.not(invoices: { company_id: nil })
+          .distinct
+          .pluck("invoices.company_id")
+      end
+
+      def trials
+        trial_companies = Company.where.not(trial_started_at: nil)
+
+        {
+          active: trial_companies.where("trial_ends_at > ?", now).count,
+          ending_within_7_days: trial_companies.where(trial_ends_at: now..(now + 7.days)).count,
+          expired: trial_companies.where(trial_ends_at: ..now).where.not(plan_tier: "paid").count,
+          converted: trial_companies.where(plan_tier: "paid").count
+        }
+      end
+
+      def checkouts
+        {
+          last_7_days: checkout_counts(seven_day_range),
+          last_30_days: checkout_counts(thirty_day_range)
+        }
+      end
+
+      def checkout_counts(range)
+        counts = Ahoy::Event.where(name: CHECKOUT_EVENTS, time: range).group(:name).count
+
+        {
+          started: counts.fetch("subscription_checkout_started", 0),
+          purchased: counts.fetch("subscription_purchased", 0)
+        }
+      end
+
+      def top_workspaces
+        activity = activity_by_company
+        user_counts = Employment.kept.group(:company_id).distinct.count(:user_id)
+
+        Company.pluck(:id, :name, :billing_exempt).map do |id, name, billing_exempt|
+          company_activity = activity.fetch(id, { activity_score: 0, last_activity_at: nil })
+
+          {
+            id:,
+            name:,
+            users_count: user_counts.fetch(id, 0),
+            activity_score: company_activity[:activity_score],
+            last_activity_at: company_activity[:last_activity_at],
+            billing_exempt:
+          }
+        end.sort_by { |workspace| [-workspace[:activity_score], workspace[:name].downcase, workspace[:id]] }.first(10)
+      end
+
+      def activity_by_company
+        [time_entry_activity, invoice_activity, payment_activity].each_with_object({}) do |rows, activity|
+          rows.each do |company_id, count, last_activity_at|
+            company_activity = activity[company_id] ||= { activity_score: 0, last_activity_at: nil }
+            company_activity[:activity_score] += count
+            company_activity[:last_activity_at] = [company_activity[:last_activity_at], last_activity_at].compact.max
+          end
+        end
+      end
+
+      def time_entry_activity
+        TimesheetEntry.kept
+          .joins(project: :client)
+          .merge(Project.kept)
+          .merge(Client.kept)
+          .where(timesheet_entries: { created_at: thirty_day_range })
+          .group("clients.company_id")
+          .pluck(
+            Arel.sql("clients.company_id"),
+            Arel.sql("COUNT(*)"),
+            Arel.sql("MAX(timesheet_entries.created_at)")
+          )
+      end
+
+      def invoice_activity
+        Invoice.kept
+          .where(created_at: thirty_day_range)
+          .where.not(company_id: nil)
+          .group(:company_id)
+          .pluck(:company_id, Arel.sql("COUNT(*)"), Arel.sql("MAX(invoices.created_at)"))
+      end
+
+      def payment_activity
+        Payment
+          .joins(:invoice)
+          .merge(Invoice.kept)
+          .where(payments: { created_at: thirty_day_range })
+          .where.not(invoices: { company_id: nil })
+          .group("invoices.company_id")
+          .pluck(
+            Arel.sql("invoices.company_id"),
+            Arel.sql("COUNT(*)"),
+            Arel.sql("MAX(payments.created_at)")
+          )
+      end
+
+      def seven_day_range
+        (now - 7.days)..now
+      end
+
+      def thirty_day_range
+        (now - 30.days)..now
+      end
+  end
+end

--- a/app/views/admin/growth/show.html.erb
+++ b/app/views/admin/growth/show.html.erb
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Miru growth analytics</title>
+    <style>
+      body { margin: 0; background: #fff; color: #333; font: 15px/1.5 system-ui, sans-serif; }
+      main { max-width: 1100px; margin: 0 auto; padding: 32px 20px 64px; }
+      h1 { margin: 0; font-size: 28px; }
+      h2 { margin: 30px 0 10px; font-size: 19px; }
+      .muted { color: #666; }
+      .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+      .card { padding: 14px; border: 1px solid #ddd; }
+      .card strong { display: block; font-size: 24px; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { padding: 9px 10px; border: 1px solid #ddd; text-align: left; }
+      th { background: #f7f7f7; font-weight: 600; }
+      .number { text-align: right; }
+      @media (max-width: 650px) { main { padding: 20px 12px; } th, td { padding: 7px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Miru growth analytics</h1>
+      <p class="muted">Updated <%= Time.current.to_fs(:long) %></p>
+
+      <h2>Signups · last 4 ISO weeks</h2>
+      <div class="cards">
+        <div class="card"><span>Total workspaces</span><strong><%= @metrics.dig(:signups, :totals, :companies) %></strong></div>
+        <div class="card"><span>Total users</span><strong><%= @metrics.dig(:signups, :totals, :users) %></strong></div>
+      </div>
+      <table>
+        <thead><tr><th>Week starting</th><th class="number">Workspaces</th><th class="number">Users</th></tr></thead>
+        <tbody>
+          <% @metrics.dig(:signups, :weeks).each do |week| %>
+            <tr>
+              <td><%= week[:week_start].to_date.to_fs(:long) %></td>
+              <td class="number"><%= week[:companies] %></td>
+              <td class="number"><%= week[:users] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <h2>Activation funnel</h2>
+      <% funnel = @metrics[:activation_funnel] %>
+      <% stages = [
+        ["All workspaces", funnel[:total]],
+        ["Added a client", funnel[:with_client]],
+        ["Logged time or invoiced", funnel[:with_activity]],
+        ["Created an invoice", funnel[:with_invoice]],
+        ["Recorded a payment", funnel[:with_payment]]
+      ] %>
+      <table>
+        <thead><tr><th>Stage</th><th class="number">Workspaces</th><th class="number">From prior stage</th></tr></thead>
+        <tbody>
+          <% stages.each_with_index do |(label, count), index| %>
+            <% previous_count = index.zero? ? nil : stages[index - 1].last %>
+            <% conversion = previous_count.to_i.positive? ? number_to_percentage(count * 100.0 / previous_count, precision: 1) : "—" %>
+            <tr><td><%= label %></td><td class="number"><%= count %></td><td class="number"><%= conversion %></td></tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <h2>Weekly active · last 7 days</h2>
+      <div class="cards">
+        <div class="card"><span>Active workspaces</span><strong><%= @metrics.dig(:weekly_active, :companies) %></strong></div>
+        <div class="card"><span>Users logged in</span><strong><%= @metrics.dig(:weekly_active, :users) %></strong></div>
+      </div>
+
+      <h2>Trial cohort</h2>
+      <div class="cards">
+        <div class="card"><span>Active</span><strong><%= @metrics.dig(:trials, :active) %></strong></div>
+        <div class="card"><span>Ending within 7 days</span><strong><%= @metrics.dig(:trials, :ending_within_7_days) %></strong></div>
+        <div class="card"><span>Expired</span><strong><%= @metrics.dig(:trials, :expired) %></strong></div>
+        <div class="card"><span>Converted to paid</span><strong><%= @metrics.dig(:trials, :converted) %></strong></div>
+      </div>
+
+      <h2>Subscription checkout</h2>
+      <table>
+        <thead><tr><th>Window</th><th class="number">Started</th><th class="number">Purchased</th></tr></thead>
+        <tbody>
+          <tr><td>Last 7 days</td><td class="number"><%= @metrics.dig(:checkouts, :last_7_days, :started) %></td><td class="number"><%= @metrics.dig(:checkouts, :last_7_days, :purchased) %></td></tr>
+          <tr><td>Last 30 days</td><td class="number"><%= @metrics.dig(:checkouts, :last_30_days, :started) %></td><td class="number"><%= @metrics.dig(:checkouts, :last_30_days, :purchased) %></td></tr>
+        </tbody>
+      </table>
+
+      <h2>Top workspaces · last 30 days</h2>
+      <table>
+        <thead><tr><th>Workspace</th><th class="number">Users</th><th class="number">Activity score</th><th>Last activity</th><th>Billing exempt</th></tr></thead>
+        <tbody>
+          <% @metrics[:top_workspaces].each do |workspace| %>
+            <tr>
+              <td><%= workspace[:name] %></td>
+              <td class="number"><%= workspace[:users_count] %></td>
+              <td class="number"><%= workspace[:activity_score] %></td>
+              <td><%= workspace[:last_activity_at]&.to_date&.to_fs(:long) || "Never" %></td>
+              <td><%= workspace[:billing_exempt] ? "Yes" : "No" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>

--- a/app/views/founder_digest_mailer/weekly.html.erb
+++ b/app/views/founder_digest_mailer/weekly.html.erb
@@ -1,0 +1,60 @@
+<% content_for :email_preheader, "Weekly signups, activation, trials, and workspace activity." %>
+<% content_for :email_eyebrow, "Growth analytics" %>
+<% content_for :email_title, "Miru growth digest" %>
+<% content_for :email_subtitle do %>
+  Week of <%= @digest_date.to_fs(:long) %>
+<% end %>
+
+<h2 style="margin: 0 0 12px; color: #020617; font-size: 18px;">Signups</h2>
+<%= render "shared/mailer/fact_rows", rows: [
+  { label: "Total workspaces", value: @metrics.dig(:signups, :totals, :companies) },
+  { label: "Total users", value: @metrics.dig(:signups, :totals, :users) }
+] %>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-fact-table">
+  <% @metrics.dig(:signups, :weeks).each do |week| %>
+    <tr>
+      <td class="email-fact-key">Week of <%= week[:week_start].to_date.to_fs(:long) %></td>
+      <td class="email-fact-value"><%= week[:companies] %> workspaces · <%= week[:users] %> users</td>
+    </tr>
+  <% end %>
+</table>
+
+<h2 style="margin: 30px 0 12px; color: #020617; font-size: 18px;">Activation funnel</h2>
+<%= render "shared/mailer/fact_rows", rows: [
+  { label: "All workspaces", value: @metrics.dig(:activation_funnel, :total) },
+  { label: "Added a client", value: @metrics.dig(:activation_funnel, :with_client) },
+  { label: "Logged time or invoiced", value: @metrics.dig(:activation_funnel, :with_activity) },
+  { label: "Created an invoice", value: @metrics.dig(:activation_funnel, :with_invoice) },
+  { label: "Recorded a payment", value: @metrics.dig(:activation_funnel, :with_payment) }
+] %>
+
+<h2 style="margin: 30px 0 12px; color: #020617; font-size: 18px;">Last 7 days</h2>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="detail-grid">
+  <tr>
+    <%= render "shared/mailer/detail_card", label: "Active workspaces", value: @metrics.dig(:weekly_active, :companies) %>
+    <%= render "shared/mailer/detail_card", label: "Users logged in", value: @metrics.dig(:weekly_active, :users) %>
+  </tr>
+</table>
+
+<h2 style="margin: 30px 0 12px; color: #020617; font-size: 18px;">Trials and checkout</h2>
+<%= render "shared/mailer/fact_rows", rows: [
+  { label: "Active trials", value: @metrics.dig(:trials, :active) },
+  { label: "Ending within 7 days", value: @metrics.dig(:trials, :ending_within_7_days) },
+  { label: "Expired trials", value: @metrics.dig(:trials, :expired) },
+  { label: "Converted trials", value: @metrics.dig(:trials, :converted) },
+  { label: "Checkout starts · 7 days", value: @metrics.dig(:checkouts, :last_7_days, :started) },
+  { label: "Purchases · 7 days", value: @metrics.dig(:checkouts, :last_7_days, :purchased) },
+  { label: "Checkout starts · 30 days", value: @metrics.dig(:checkouts, :last_30_days, :started) },
+  { label: "Purchases · 30 days", value: @metrics.dig(:checkouts, :last_30_days, :purchased) }
+] %>
+
+<h2 style="margin: 30px 0 12px; color: #020617; font-size: 18px;">Top workspaces · 30 days</h2>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-fact-table">
+  <% @metrics[:top_workspaces].each do |workspace| %>
+    <tr>
+      <td class="email-fact-key"><%= workspace[:name] %><%= " · billing exempt" if workspace[:billing_exempt] %></td>
+      <td class="email-fact-value"><%= workspace[:activity_score] %> actions · <%= workspace[:users_count] %> users</td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/founder_digest_mailer/weekly.text.erb
+++ b/app/views/founder_digest_mailer/weekly.text.erb
@@ -1,0 +1,34 @@
+Miru growth digest — <%= @digest_date.to_fs(:long) %>
+
+SIGNUPS
+Total workspaces: <%= @metrics.dig(:signups, :totals, :companies) %>
+Total users: <%= @metrics.dig(:signups, :totals, :users) %>
+<% @metrics.dig(:signups, :weeks).each do |week| %>
+Week of <%= week[:week_start].to_date.to_fs(:long) %>: <%= week[:companies] %> workspaces, <%= week[:users] %> users
+<% end %>
+
+ACTIVATION FUNNEL
+All workspaces: <%= @metrics.dig(:activation_funnel, :total) %>
+Added a client: <%= @metrics.dig(:activation_funnel, :with_client) %>
+Logged time or invoiced: <%= @metrics.dig(:activation_funnel, :with_activity) %>
+Created an invoice: <%= @metrics.dig(:activation_funnel, :with_invoice) %>
+Recorded a payment: <%= @metrics.dig(:activation_funnel, :with_payment) %>
+
+LAST 7 DAYS
+Active workspaces: <%= @metrics.dig(:weekly_active, :companies) %>
+Users logged in: <%= @metrics.dig(:weekly_active, :users) %>
+
+TRIALS
+Active: <%= @metrics.dig(:trials, :active) %>
+Ending within 7 days: <%= @metrics.dig(:trials, :ending_within_7_days) %>
+Expired: <%= @metrics.dig(:trials, :expired) %>
+Converted: <%= @metrics.dig(:trials, :converted) %>
+
+CHECKOUTS
+Last 7 days: <%= @metrics.dig(:checkouts, :last_7_days, :started) %> started, <%= @metrics.dig(:checkouts, :last_7_days, :purchased) %> purchased
+Last 30 days: <%= @metrics.dig(:checkouts, :last_30_days, :started) %> started, <%= @metrics.dig(:checkouts, :last_30_days, :purchased) %> purchased
+
+TOP WORKSPACES · 30 DAYS
+<% @metrics[:top_workspaces].each do |workspace| %>
+<%= workspace[:name] %>: <%= workspace[:activity_score] %> actions, <%= workspace[:users_count] %> users<%= ", billing exempt" if workspace[:billing_exempt] %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   # Mount PgHero for database monitoring (restricted to super admins)
   authenticate :user, lambda { |u| u.super_admin? } do
     mount PgHero::Engine, at: "/pghero"
+    get "/admin/growth", to: "admin/growth#show"
   end
 
   # Legacy server-rendered analytics dashboard for super admins. The product

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -18,6 +18,9 @@ default: &default
         trial_emails:
           class: TrialEmailsJob
           schedule: '0 9 * * *'
+        founder_digest:
+          class: Analytics::FounderDigestJob
+          schedule: '0 8 * * 1'
         refresh_cached_analytics_reports:
           class: Analytics::RefreshCachedReportsJob
           schedule: '0 * * * *'
@@ -63,6 +66,9 @@ production:
         trial_emails:
           class: TrialEmailsJob
           schedule: '<%= ENV.fetch("TRIAL_EMAILS_CRON", "0 9 * * *") %>'
+        founder_digest:
+          class: Analytics::FounderDigestJob
+          schedule: '<%= ENV.fetch("FOUNDER_DIGEST_CRON", "0 8 * * 1") %>'
         refresh_cached_analytics_reports:
           class: Analytics::RefreshCachedReportsJob
           schedule: '0 * * * *'

--- a/spec/jobs/analytics/founder_digest_job_spec.rb
+++ b/spec/jobs/analytics/founder_digest_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::FounderDigestJob do
+  let(:metrics) do
+    {
+      signups: { weeks: [], totals: { companies: 0, users: 0 } },
+      activation_funnel: { total: 0, with_client: 0, with_activity: 0, with_invoice: 0, with_payment: 0 },
+      weekly_active: { companies: 0, users: 0 },
+      trials: { active: 0, ending_within_7_days: 0, expired: 0, converted: 0 },
+      checkouts: {
+        last_7_days: { started: 0, purchased: 0 },
+        last_30_days: { started: 0, purchased: 0 }
+      },
+      top_workspaces: []
+    }
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(Analytics::GrowthMetricsService).to receive(:process).and_return(metrics)
+  end
+
+  it "sends one digest to each configured recipient" do
+    allow(ENV).to receive(:[]).with("FOUNDER_DIGEST_EMAILS").and_return("one@example.com, two@example.com")
+
+    expect {
+      described_class.perform_now
+    }.to have_enqueued_mail(FounderDigestMailer, :weekly).twice
+
+    recipients = enqueued_jobs.filter_map do |job|
+      next unless job[:job] == ActionMailer::MailDeliveryJob
+
+      params = job[:args].last.fetch("params")
+      params.fetch("recipient")
+    end
+    expect(recipients).to match_array(["one@example.com", "two@example.com"])
+    expect(Analytics::GrowthMetricsService).to have_received(:process).once
+  end
+
+  it "falls back to super admin emails when FOUNDER_DIGEST_EMAILS is unset" do
+    allow(ENV).to receive(:[]).with("FOUNDER_DIGEST_EMAILS").and_return(nil)
+    admin = create(:user, email: User.super_admin_emails.first)
+    admin.update!(confirmed_at: Time.current) unless admin.confirmed?
+
+    expect {
+      described_class.perform_now
+    }.to have_enqueued_mail(FounderDigestMailer, :weekly).once
+  end
+
+  it "skips when neither configuration nor super admins provide recipients" do
+    allow(ENV).to receive(:[]).with("FOUNDER_DIGEST_EMAILS").and_return(nil)
+    allow(User).to receive(:super_admins).and_return(User.none)
+    allow(Rails.logger).to receive(:info)
+
+    expect {
+      described_class.perform_now
+    }.not_to have_enqueued_mail(FounderDigestMailer)
+
+    expect(Rails.logger).to have_received(:info).with("Analytics::FounderDigestJob skipped: no recipients")
+    expect(Analytics::GrowthMetricsService).not_to have_received(:process)
+  end
+end

--- a/spec/mailers/founder_digest_mailer_spec.rb
+++ b/spec/mailers/founder_digest_mailer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FounderDigestMailer do
+  let(:metrics) do
+    {
+      signups: {
+        weeks: [{ week_start: Date.new(2026, 8, 10), companies: 3, users: 5 }],
+        totals: { companies: 20, users: 40 }
+      },
+      activation_funnel: { total: 20, with_client: 15, with_activity: 12, with_invoice: 8, with_payment: 5 },
+      weekly_active: { companies: 9, users: 11 },
+      trials: { active: 4, ending_within_7_days: 2, expired: 6, converted: 3 },
+      checkouts: {
+        last_7_days: { started: 7, purchased: 2 },
+        last_30_days: { started: 18, purchased: 6 }
+      },
+      top_workspaces: [{ name: "Acme", activity_score: 14, users_count: 3, billing_exempt: false }]
+    }
+  end
+
+  it "renders the weekly growth digest" do
+    mail = described_class.with(
+      recipient: "founder@example.com",
+      metrics:,
+      date: Date.new(2026, 8, 14)
+    ).weekly
+
+    expect(mail.subject).to eq("Miru growth digest — August 14, 2026")
+    expect(mail.to).to eq(["founder@example.com"])
+    expect(mail.html_part.body.encoded).to include("Activation funnel", "Active workspaces", "Acme")
+    expect(mail.text_part.body.encoded).to include("ACTIVATION FUNNEL", "Active workspaces: 9", "Acme: 14 actions")
+  end
+end

--- a/spec/requests/admin/growth_spec.rb
+++ b/spec/requests/admin/growth_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin growth analytics" do
+  let(:metrics) do
+    {
+      signups: {
+        weeks: [{ week_start: Date.new(2026, 8, 10), companies: 2, users: 4 }],
+        totals: { companies: 10, users: 20 }
+      },
+      activation_funnel: { total: 10, with_client: 8, with_activity: 6, with_invoice: 4, with_payment: 2 },
+      weekly_active: { companies: 5, users: 7 },
+      trials: { active: 3, ending_within_7_days: 1, expired: 4, converted: 2 },
+      checkouts: {
+        last_7_days: { started: 4, purchased: 1 },
+        last_30_days: { started: 12, purchased: 5 }
+      },
+      top_workspaces: [{
+        name: "Acme",
+        users_count: 3,
+        activity_score: 14,
+        last_activity_at: Time.zone.local(2026, 8, 13),
+        billing_exempt: false
+      }]
+    }
+  end
+
+  before do
+    allow(Analytics::GrowthMetricsService).to receive(:process).and_return(metrics)
+  end
+
+  it "renders the report for a super admin" do
+    sign_in create(:user, email: User.super_admin_emails.first, confirmed_at: Time.current)
+
+    get "/admin/growth"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Miru growth analytics", "Activation funnel", "Top workspaces", "Acme")
+  end
+
+  it "does not render the report for a regular user" do
+    sign_in create(:user)
+
+    get "/admin/growth", headers: { "ACCEPT" => "application/json" }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("Miru growth analytics")
+    expect(Analytics::GrowthMetricsService).not_to have_received(:process)
+  end
+end

--- a/spec/services/analytics/growth_metrics_service_spec.rb
+++ b/spec/services/analytics/growth_metrics_service_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::GrowthMetricsService do
+  around do |example|
+    travel_to(Time.zone.local(2026, 8, 12, 12)) { example.run }
+  end
+
+  let!(:inactive_company) { create(:company, name: "Inactive workspace") }
+  let!(:engaged_company) do
+    create(
+      :company,
+      name: "Engaged workspace",
+      trial_started_at: 2.days.ago,
+      trial_ends_at: 3.days.from_now
+    )
+  end
+  let!(:paid_company) do
+    create(
+      :company,
+      name: "Paid workspace",
+      plan_tier: "paid",
+      trial_started_at: 20.days.ago,
+      trial_ends_at: 2.days.ago,
+      billing_exempt: true
+    )
+  end
+
+  let!(:engaged_client) { create(:client, company: engaged_company) }
+  let!(:paid_client) { create(:client, company: paid_company) }
+  let!(:engaged_user) { create(:user, current_workspace: engaged_company) }
+  let!(:paid_users) { create_list(:user, 2, current_workspace: paid_company) }
+  let!(:paid_invoice) { create(:invoice, company: paid_company, client: paid_client) }
+
+  before do
+    create(:employment, company: engaged_company, user: engaged_user)
+    paid_users.each { |user| create(:employment, company: paid_company, user:) }
+    create(:timesheet_entry, project: create(:project, client: engaged_client), user: engaged_user)
+    create(:payment, invoice: paid_invoice)
+  end
+
+  it "reports funnel, trial, and workspace activity metrics" do
+    metrics = described_class.process
+
+    expect(metrics[:activation_funnel]).to eq(
+      total: 3,
+      with_client: 2,
+      with_activity: 2,
+      with_invoice: 1,
+      with_payment: 1
+    )
+    expect(metrics[:trials]).to eq(
+      active: 1,
+      ending_within_7_days: 1,
+      expired: 0,
+      converted: 1
+    )
+    expect(metrics[:top_workspaces].pluck(:name)).to eq([
+      "Paid workspace",
+      "Engaged workspace",
+      "Inactive workspace"
+    ])
+    expect(metrics[:top_workspaces].first).to include(
+      activity_score: 2,
+      users_count: 2,
+      billing_exempt: true
+    )
+  end
+
+  it "ignores discarded clients, invoices, and employments" do
+    discarded_only = create(:company, name: "Discarded only")
+    discarded_client = create(:client, company: discarded_only)
+    create(:invoice, company: discarded_only, client: discarded_client).discard!
+    discarded_client.discard!
+    ghost = create(:user, current_workspace: engaged_company)
+    create(:employment, company: engaged_company, user: ghost).discard!
+
+    metrics = described_class.process
+
+    expect(metrics[:activation_funnel]).to include(total: 4, with_client: 2, with_invoice: 1)
+    engaged_row = metrics[:top_workspaces].find { |workspace| workspace[:name] == "Engaged workspace" }
+    expect(engaged_row[:users_count]).to eq(1)
+  end
+
+  it "reports signup trend, weekly active usage, and checkout events" do
+    create(:company, name: "Last week signup", created_at: 8.days.ago)
+    Ahoy::Event.create!(
+      visit: Ahoy::Visit.create!(started_at: 1.day.ago),
+      user_id: engaged_user.id, name: "user_login", time: 1.day.ago, properties: {}
+    )
+    Ahoy::Event.create!(
+      visit: Ahoy::Visit.create!(started_at: 2.days.ago),
+      user_id: paid_users.first.id, name: "subscription_checkout_started", time: 2.days.ago, properties: {}
+    )
+    Ahoy::Event.create!(
+      visit: Ahoy::Visit.create!(started_at: 20.days.ago),
+      user_id: paid_users.first.id, name: "subscription_purchased", time: 20.days.ago, properties: {}
+    )
+
+    metrics = described_class.process
+
+    current_week = metrics[:signups][:weeks].first
+    previous_week = metrics[:signups][:weeks].second
+    expect(current_week[:companies]).to eq(3)
+    expect(previous_week[:companies]).to eq(1)
+    expect(metrics[:signups][:totals][:companies]).to eq(4)
+
+    expect(metrics[:weekly_active]).to eq(companies: 2, users: 1)
+
+    expect(metrics[:checkouts]).to eq(
+      last_7_days: { started: 1, purchased: 0 },
+      last_30_days: { started: 1, purchased: 1 }
+    )
+  end
+end


### PR DESCRIPTION
## What

Founder-level growth visibility, consumed two ways from one service:

- **`Analytics::GrowthMetricsService`** — signups per ISO week (last 4), activation funnel (workspace → client → activity → invoice → payment), weekly active workspaces/users, trial cohort (active / ending ≤7d / expired / converted, disjoint buckets), checkout events (7d/30d), and top-10 engaged workspaces. All queries filter discarded records (`.kept` / `discarded_at IS NULL`), matching the existing analytics convention. Week math is pinned to UTC to stay consistent with `DATE_TRUNC` regardless of `config.time_zone`.
- **Weekly founder digest email** — `FounderDigestMailer#weekly` + `Analytics::FounderDigestJob`, registered as the `founder_digest` Solid Queue recurring task (Mondays 08:00 UTC, override via `FOUNDER_DIGEST_CRON`). Recipients from `FOUNDER_DIGEST_EMAILS` (comma-separated), falling back to confirmed super admins; skips with a log line when neither resolves. Templates follow the subscription mailer house style.
- **Super-admin dashboard** at `/admin/growth` — server-rendered, no JS, gated by the same `super_admin` authenticate block as PgHero. Non-super-admins fall through to the SPA catch-all.

## Why

We have 686 workspaces and 1,192 users on app.miru.so but no aggregate view of activation or trial conversion. The raw Ahoy events already exist; this reads them plus DB state — no new instrumentation, no new gems.

## Tests

9 examples: funnel/trial/top-workspace counts, discarded-record exclusion, signup-trend + WAU + checkout counts, digest recipients (env, super-admin fallback, skip), mailer content, and request-level auth. Dashboard also verified rendering in a real browser against dev data.

## Ops

- New env (optional): `FOUNDER_DIGEST_EMAILS`, `FOUNDER_DIGEST_CRON` (documented in .env.example)
- Recurring task registers on worker restart after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a super-admin growth analytics dashboard covering signups, activation, activity, trials, checkout events, and top workspaces.
  - Added weekly founder growth digest emails in HTML and plain-text formats.
  - Added configurable digest recipients and weekly scheduling.

- **Bug Fixes**
  - Restricted growth analytics access to super administrators.

- **Tests**
  - Added coverage for dashboard access, metrics, digest delivery, recipient selection, and email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->