### PR TITLE
feat: enforce Pro plan promises — analytics gating and audit trail

### DIFF
--- a/app/controllers/api/v1/audit_logs_controller.rb
+++ b/app/controllers/api/v1/audit_logs_controller.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class Api::V1::AuditLogsController < Api::V1::ApplicationController
+  SENSITIVE_KEY_PATTERN = %r{
+    password|token|secret|digest|credential|api[_-]?key|account_number|
+    routing_number|swift_code|taxpayer_id|tax_id|otp|recovery_code|ciphertext
+  }ix
+
+  def index
+    authorize :audit_log, :index?
+
+    invalid = [:from, :to].find { |name| params[name].present? && parsed_date(name).nil? }
+    return render json: { errors: "#{invalid} must be a valid ISO 8601 date" }, status: 400 if invalid
+
+    audits = company_audits
+    audits = audits.where(auditable_type: params[:auditable_type]) if params[:auditable_type].present?
+    audit_action = request.query_parameters["action"]
+    audits = audits.where(action: audit_action) if audit_action.present?
+    audits = audits.where(user_id: params[:user_id]) if params[:user_id].present?
+    audits = audits.where(created_at: parsed_date(:from).beginning_of_day..) if params[:from].present?
+    audits = audits.where(created_at: ..parsed_date(:to).end_of_day) if params[:to].present?
+
+    pagy, records = pagy(audits.preload(:auditable, :user).order(created_at: :desc), items: 25)
+
+    render json: {
+      audit_logs: records.map { |audit| serialize_audit(audit) },
+      pagy: pagy_metadata(pagy)
+    }
+  end
+
+  private
+
+    def company_audits
+      Audited::Audit.where(associated: current_company)
+        .or(Audited::Audit.where(auditable: current_company))
+    end
+
+    def parsed_date(name)
+      @parsed_dates ||= {}
+      return @parsed_dates[name] if @parsed_dates.key?(name)
+
+      @parsed_dates[name] = begin
+        Date.iso8601(params[name])
+      rescue Date::Error
+        nil
+      end
+    end
+
+    def serialize_audit(audit)
+      {
+        id: audit.id,
+        auditable_type: audit.auditable_type,
+        auditable_id: audit.auditable_id,
+        auditable_label: auditable_label(audit),
+        action: audit.action,
+        audited_changes: filter_sensitive_values(audit.audited_changes),
+        user: serialize_user(audit),
+        created_at: audit.created_at.iso8601
+      }
+    end
+
+    def serialize_user(audit)
+      return if audit.user.blank? && audit.username.blank?
+
+      {
+        name: audit.user&.full_name || audit.username,
+        email: audit.user&.email || audit.username
+      }
+    end
+
+    def auditable_label(audit)
+      record = audit.auditable
+      attribute = [:name, :full_name, :invoice_number, :recipient_email]
+        .find { |name| record&.respond_to?(name) }
+      label = record.public_send(attribute) if attribute
+
+      label.presence || "#{audit.auditable_type} ##{audit.auditable_id}"
+    end
+
+    def filter_sensitive_values(value)
+      case value
+      when Hash
+        value.each_with_object({}) do |(key, nested_value), filtered|
+          filtered[key] = filter_sensitive_values(nested_value) unless key.to_s.match?(SENSITIVE_KEY_PATTERN)
+        end
+      when Array
+        value.map { |nested_value| filter_sensitive_values(nested_value) }
+      else
+        value
+      end
+    end
+end

--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -652,6 +652,10 @@ export const subscriptionsApi = {
   portal: () => http.post(`/subscription/portal`),
 };
 
+export const auditLogsApi = {
+  index: (params = {}) => http.get(`/audit_logs`, { params }),
+};
+
 // Teams
 export const teamsApi = {
   get: (id: any) => http.get(`/team/${id}/details`),

--- a/app/javascript/src/components/Dashboard/DashboardLayout.tsx
+++ b/app/javascript/src/components/Dashboard/DashboardLayout.tsx
@@ -195,8 +195,11 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
     items: group.items
       .filter(item => !item.roles || item.roles.includes(companyRole))
       .map(item =>
-        item.href === "/reports" && !hasProAccess(company)
-          ? { ...item, href: "/settings/billing?feature=reports" }
+        ["/reports", "/analytics"].includes(item.href) && !hasProAccess(company)
+          ? {
+              ...item,
+              href: `/settings/billing?feature=${item.href.slice(1)}`,
+            }
           : item
       ),
   });

--- a/app/javascript/src/components/Navbar/Sidebar.tsx
+++ b/app/javascript/src/components/Navbar/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Wallet,
   Palmtree,
   UsersRound,
+  ClockCounterClockwise,
 } from "phosphor-react";
 
 import { cn } from "../../lib/utils";
@@ -211,6 +212,12 @@ const Sidebar: React.FC = () => {
       icon: <UsersRound className="h-5 w-5" />,
       label: i18n.t("navbar.team"),
       path: Paths.TEAM.replace("/*", ""),
+      allowedRoles: [Roles.ADMIN, Roles.OWNER],
+    },
+    {
+      icon: <ClockCounterClockwise className="h-5 w-5" />,
+      label: i18n.t("navbar.auditLog"),
+      path: "/settings/audit-log",
       allowedRoles: [Roles.ADMIN, Roles.OWNER],
     },
     {

--- a/app/javascript/src/components/PlanAccessGate.tsx
+++ b/app/javascript/src/components/PlanAccessGate.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import Loader from "common/Loader";
+import { useUserContext } from "context/UserContext";
+import { Navigate } from "react-router-dom";
+
+import { getStoredCompany, hasProAccess } from "../lib/planAccess";
+
+type PlanAccessGateProps = {
+  children: React.ReactNode;
+  feature: string;
+};
+
+const PlanAccessGate: React.FC<PlanAccessGateProps> = ({
+  children,
+  feature,
+}) => {
+  const { company, loading } = useUserContext();
+  const effectiveCompany = company || getStoredCompany();
+
+  if (loading && !effectiveCompany) {
+    return <Loader className="h-screen" />;
+  }
+
+  if (!hasProAccess(effectiveCompany)) {
+    return <Navigate replace to={`/settings/billing?feature=${feature}`} />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PlanAccessGate;

--- a/app/javascript/src/components/Profile/Layout/Navigation/List.tsx
+++ b/app/javascript/src/components/Profile/Layout/Navigation/List.tsx
@@ -38,6 +38,8 @@ const labelForSetting = path => {
 
   if (path.startsWith("billing")) return t("settings.labels.billing");
 
+  if (path.startsWith("audit-log")) return t("settings.labels.auditLog");
+
   return path;
 };
 

--- a/app/javascript/src/components/Profile/Layout/routes.tsx
+++ b/app/javascript/src/components/Profile/Layout/routes.tsx
@@ -7,6 +7,7 @@ import BankInfo from "components/Profile/Organization/BankInfo";
 import OrgEdit from "components/Profile/Organization/Edit";
 import Holidays from "components/Profile/Organization/Holidays";
 import Billing from "components/Profile/Organization/Billing";
+import AuditLog from "components/Profile/Organization/AuditLog";
 import PaymentSettings from "components/Profile/Organization/Payment";
 import TaxConfigurationSettings from "components/Profile/Organization/TaxConfiguration";
 import AllocatedDevicesDetails from "components/Profile/Personal/Devices";
@@ -202,6 +203,15 @@ export const SETTINGS = [
     icon: <PaymentsIcon className="mr-2" size={20} weight="bold" />,
     authorisedRoles: [ADMIN, OWNER],
     Component: Billing,
+    category: "organization",
+    isTab: true,
+  },
+  {
+    label: "AUDIT LOG",
+    path: "audit-log",
+    icon: <ReminderIcon className="mr-2" size={20} weight="bold" />,
+    authorisedRoles: [ADMIN, OWNER],
+    Component: AuditLog,
     category: "organization",
     isTab: true,
   },

--- a/app/javascript/src/components/Profile/Organization/AuditLog/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/AuditLog/index.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect, useState } from "react";
+
+import { auditLogsApi } from "apis/api";
+import Loader from "common/Loader";
+import PlanAccessGate from "components/PlanAccessGate";
+import { Badge } from "components/ui/badge";
+import { Button } from "components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "components/ui/card";
+import { Input } from "components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "components/ui/table";
+import { i18n } from "../../../../i18n";
+
+type AuditLogRecord = {
+  id: number;
+  auditable_type: string;
+  auditable_id: number;
+  auditable_label: string;
+  action: string;
+  audited_changes: Record<string, unknown>;
+  user: { name: string; email: string } | null;
+  created_at: string;
+};
+
+type Pagination = {
+  page: number;
+  pages: number;
+  prev: number | null;
+  next: number | null;
+};
+
+const RECORD_TYPES = [
+  "Client",
+  "Project",
+  "Company",
+  "Invitation",
+  "Expense",
+  "Invoice",
+  "Payment",
+  "TimesheetEntry",
+  "User",
+];
+
+const formatValue = (value: unknown) => {
+  if (value === null || value === undefined || value === "") return "—";
+
+  if (typeof value === "object") return JSON.stringify(value);
+
+  return String(value);
+};
+
+const changeSummary = (changes: Record<string, unknown>) =>
+  Object.entries(changes).map(([key, value]) => {
+    const [before, after] = Array.isArray(value) ? value : [null, value];
+
+    return (
+      <div className="text-xs" key={key}>
+        <span className="font-medium">{key.replaceAll("_", " ")}:</span>{" "}
+        {formatValue(before)} → {formatValue(after)}
+      </div>
+    );
+  });
+
+const AuditLog = () => {
+  const [records, setRecords] = useState<AuditLogRecord[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [page, setPage] = useState(1);
+  const [recordType, setRecordType] = useState("all");
+  const [action, setAction] = useState("all");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  useEffect(() => {
+    const fetchAuditLogs = async () => {
+      setLoading(true);
+
+      try {
+        const response = await auditLogsApi.index({
+          page,
+          auditable_type: recordType === "all" ? undefined : recordType,
+          action: action === "all" ? undefined : action,
+          from: from || undefined,
+          to: to || undefined,
+        });
+        setRecords(response.data.audit_logs);
+        setPagination(response.data.pagy);
+        setLoadError(false);
+      } catch {
+        setRecords([]);
+        setPagination(null);
+        setLoadError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAuditLogs();
+  }, [page, recordType, action, from, to]);
+
+  const updateFilter = (setter: (value: string) => void, value: string) => {
+    setPage(1);
+    setter(value);
+  };
+
+  return (
+    <PlanAccessGate feature="audit">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4 sm:p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{i18n.t("auditLog.title")}</CardTitle>
+            <CardDescription>{i18n.t("auditLog.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Select
+              value={recordType}
+              onValueChange={value => updateFilter(setRecordType, value)}
+            >
+              <SelectTrigger aria-label={i18n.t("auditLog.filters.recordType")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  {i18n.t("auditLog.filters.allRecordTypes")}
+                </SelectItem>
+                {RECORD_TYPES.map(type => (
+                  <SelectItem key={type} value={type}>
+                    {type.replace(/([a-z])([A-Z])/g, "$1 $2")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={action}
+              onValueChange={value => updateFilter(setAction, value)}
+            >
+              <SelectTrigger aria-label={i18n.t("auditLog.filters.action")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  {i18n.t("auditLog.filters.allActions")}
+                </SelectItem>
+                {["create", "update", "destroy"].map(value => (
+                  <SelectItem key={value} value={value}>
+                    {i18n.t(`auditLog.actions.${value}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              aria-label={i18n.t("auditLog.filters.from")}
+              type="date"
+              value={from}
+              onChange={event => updateFilter(setFrom, event.target.value)}
+            />
+            <Input
+              aria-label={i18n.t("auditLog.filters.to")}
+              type="date"
+              value={to}
+              onChange={event => updateFilter(setTo, event.target.value)}
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden">
+          {loading ? (
+            <Loader className="h-64" />
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{i18n.t("auditLog.columns.date")}</TableHead>
+                    <TableHead>{i18n.t("auditLog.columns.actor")}</TableHead>
+                    <TableHead>{i18n.t("auditLog.columns.action")}</TableHead>
+                    <TableHead>{i18n.t("auditLog.columns.record")}</TableHead>
+                    <TableHead>{i18n.t("auditLog.columns.changes")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {records.length ? (
+                    records.map(record => (
+                      <TableRow key={record.id}>
+                        <TableCell className="whitespace-nowrap">
+                          {new Date(record.created_at).toLocaleString()}
+                        </TableCell>
+                        <TableCell>
+                          <div>
+                            {record.user?.name || i18n.t("auditLog.system")}
+                          </div>
+                          {record.user?.email && (
+                            <div className="text-xs text-muted-foreground">
+                              {record.user.email}
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">
+                            {i18n.t(`auditLog.actions.${record.action}`)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div>{record.auditable_type}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {record.auditable_label}
+                          </div>
+                        </TableCell>
+                        <TableCell className="min-w-64 space-y-1">
+                          {changeSummary(record.audited_changes)}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell className="h-32 text-center" colSpan={5}>
+                        {loadError
+                          ? i18n.t("auditLog.loadError")
+                          : i18n.t("auditLog.empty")}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          {pagination && pagination.pages > 1 && (
+            <div className="flex items-center justify-between border-t p-4">
+              <Button
+                disabled={!pagination.prev}
+                variant="outline"
+                onClick={() => setPage(pagination.prev || 1)}
+              >
+                {i18n.t("auditLog.pagination.previous")}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {i18n.t("auditLog.pagination.page", {
+                  page: pagination.page,
+                  pages: pagination.pages,
+                })}
+              </span>
+              <Button
+                disabled={!pagination.next}
+                variant="outline"
+                onClick={() => setPage(pagination.next || pagination.page)}
+              >
+                {i18n.t("auditLog.pagination.next")}
+              </Button>
+            </div>
+          )}
+        </Card>
+      </div>
+    </PlanAccessGate>
+  );
+};
+
+export default AuditLog;

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -440,6 +440,28 @@ const Billing = () => {
         </Alert>
       )}
 
+      {featureGate === "analytics" && summary && !summary.pro_access && (
+        <Alert>
+          <AlertTitle>
+            {i18n.t("billingSettings.featureGate.analyticsTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {i18n.t("billingSettings.featureGate.analyticsDescription")}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {featureGate === "audit" && summary && !summary.pro_access && (
+        <Alert>
+          <AlertTitle>
+            {i18n.t("billingSettings.featureGate.auditTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {i18n.t("billingSettings.featureGate.auditDescription")}
+          </AlertDescription>
+        </Alert>
+      )}
+
       {featureGate === "seats" && summary && !summary.pro_access && (
         <Alert>
           <AlertTitle>

--- a/app/javascript/src/components/Reports/AccessGate.tsx
+++ b/app/javascript/src/components/Reports/AccessGate.tsx
@@ -1,27 +1,9 @@
 import React from "react";
 
-import { Navigate } from "react-router-dom";
-
-import { useUserContext } from "context/UserContext";
-import Loader from "common/Loader";
-
-import { getStoredCompany, hasProAccess } from "../../lib/planAccess";
+import PlanAccessGate from "components/PlanAccessGate";
 
 const ReportsAccessGate: React.FC<{ children: React.ReactNode }> = ({
   children,
-}) => {
-  const { company, loading } = useUserContext();
-  const effectiveCompany = company || getStoredCompany();
-
-  if (loading && !effectiveCompany) {
-    return <Loader className="h-screen" />;
-  }
-
-  if (!hasProAccess(effectiveCompany)) {
-    return <Navigate replace to="/settings/billing?feature=reports" />;
-  }
-
-  return <>{children}</>;
-};
+}) => <PlanAccessGate feature="reports">{children}</PlanAccessGate>;
 
 export default ReportsAccessGate;

--- a/app/javascript/src/constants/routes.ts
+++ b/app/javascript/src/constants/routes.ts
@@ -11,6 +11,7 @@ import SignUp from "components/Authentication/SignUp";
 import InvoiceEmail from "components/InvoiceEmail";
 import Success from "components/payments/Success";
 import InvalidLink from "components/Team/List/InvalidLink";
+import PlanAccessGate from "components/PlanAccessGate";
 import ReportsAccessGate from "../components/Reports/AccessGate";
 
 const DashboardHome = lazy(
@@ -84,6 +85,13 @@ const withReportsGate = Component => props =>
     React.createElement(Component, props)
   );
 
+const withPlanGate = (feature, Component) => props =>
+  React.createElement(
+    PlanAccessGate,
+    { feature },
+    React.createElement(Component, props)
+  );
+
 const DashboardRoutes = [
   { path: "", Component: DashboardHome },
   { path: "*", Component: ErrorPage },
@@ -115,11 +123,20 @@ const ReportsRoutes = [
 ];
 
 const AnalyticsRoutes = [
-  { path: "", Component: AnalyticsHome },
-  { path: "revenue-forecast", Component: RevenueForecastPage },
-  { path: "team", Component: TeamAnalyticsPage },
-  { path: "clients", Component: ClientInsightsPage },
-  { path: "expenses", Component: ExpenseTrendsPage },
+  { path: "", Component: withPlanGate("analytics", AnalyticsHome) },
+  {
+    path: "revenue-forecast",
+    Component: withPlanGate("analytics", RevenueForecastPage),
+  },
+  { path: "team", Component: withPlanGate("analytics", TeamAnalyticsPage) },
+  {
+    path: "clients",
+    Component: withPlanGate("analytics", ClientInsightsPage),
+  },
+  {
+    path: "expenses",
+    Component: withPlanGate("analytics", ExpenseTrendsPage),
+  },
   { path: "*", Component: ErrorPage },
 ];
 

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1358,6 +1358,7 @@ const en = {
     paymentsDescription: "Track payment history",
     leavesDescription: "Manage time off requests",
     expensesDescription: "Track business expenses",
+    auditLog: "Audit Log",
   },
 
   // Passkeys
@@ -1915,6 +1916,39 @@ const en = {
     ratePerHour: "/ hour",
   },
 
+  auditLog: {
+    title: "Audit Log",
+    description: "Review administrative and record changes in this workspace.",
+    system: "System",
+    empty: "No audit events match these filters.",
+    loadError: "Could not load audit events. Try again or adjust the filters.",
+    filters: {
+      recordType: "Record type",
+      allRecordTypes: "All record types",
+      action: "Action",
+      allActions: "All actions",
+      from: "From date",
+      to: "To date",
+    },
+    actions: {
+      create: "Created",
+      update: "Updated",
+      destroy: "Deleted",
+    },
+    columns: {
+      date: "Date",
+      actor: "Actor",
+      action: "Action",
+      record: "Record",
+      changes: "Changes",
+    },
+    pagination: {
+      previous: "Previous",
+      next: "Next",
+      page: "Page %{page} of %{pages}",
+    },
+  },
+
   billingSettings: {
     membership: "Membership",
     currentPlan: "Current plan",
@@ -1965,6 +1999,12 @@ const en = {
       reportsTitle: "Reports is a Pro feature",
       reportsDescription:
         "Upgrade to Pro to unlock Reports, analytics, and exports.",
+      analyticsTitle: "Analytics is a Pro feature",
+      analyticsDescription:
+        "Upgrade to Pro to unlock forecasts, performance insights, and exports.",
+      auditTitle: "Audit Log is a Pro feature",
+      auditDescription:
+        "Upgrade to Pro to review administrative and record changes.",
       seatsTitle: "You've reached your free plan's team limit",
       seatsDescription:
         "Upgrade to Pro to add unlimited team members to this workspace.",
@@ -2014,7 +2054,7 @@ const en = {
       ssoDescription: "Give growing teams secure access without extra tools.",
       financeTitle: "Finance visibility that stays calm",
       financeDescription:
-        "Know margin, billing cadence, and team usage without extra setup.",
+        "Know revenue, billing cadence, and team usage without extra setup.",
     },
     planDescriptions: {
       pro: "Pro adds reports, SSO, more seats, and calmer admin controls without enterprise overhead.",
@@ -2564,6 +2604,7 @@ const en = {
       preferences: "Preferences",
       organization: "Organization",
       billing: "Billing",
+      auditLog: "Audit Log",
       payment: "Payment",
       holidays: "Holidays",
       leaves: "Leaves",

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -6,6 +6,8 @@ class Client < ApplicationRecord
   include MetricsTracking
   include PhoneNumberValidatable
 
+  audited associated_with: :company, except: [:updated_at]
+
   EIN_FORMAT = /\A\d{2}-\d{7}\z/
   MAX_LOGO_SIZE_MB = 5
   ALLOWED_LOGO_CONTENT_TYPES = %w[image/png image/jpeg image/jpg].freeze

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,6 +4,26 @@ class Company < ApplicationRecord
   include MetricsTracking
   include PhoneNumberValidatable
 
+  audited except: [
+    :updated_at,
+    :trial_email_last_sent_on,
+    :trial_expired_email_sent_at,
+    :stripe_customer_id,
+    :stripe_subscription_id,
+    :subscription_status,
+    :subscription_ends_at,
+    :subscription_interval,
+    :cancel_at_period_end,
+    :bank_account_number,
+    :bank_routing_number,
+    :bank_swift_code,
+    :ein,
+    :gst_number,
+    :tax_id,
+    :us_taxpayer_id,
+    :vat_number
+  ]
+
   MAX_ATTACHMENT_SIZE_MB = 5
   TRIAL_LENGTH = 14.days
   ATTACHMENT_CONTENT_TYPES = {

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -4,7 +4,8 @@ class Expense < ApplicationRecord
   include Discardable
   include Searchable
 
-  audited only: [:amount, :base_currency_amount, :currency, :date, :expense_type, :status, :paid_at, :category_name]
+  audited associated_with: :company,
+    only: [:amount, :base_currency_amount, :currency, :date, :expense_type, :status, :paid_at, :category_name]
 
   MAX_RECEIPT_SIZE_MB = 10
   MAX_RECEIPTS = 10

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,6 +2,7 @@
 
 class Invitation < ApplicationRecord
   include Searchable
+  audited associated_with: :company, except: [:updated_at, :token]
   enum :role, [:owner, :admin, :employee, :book_keeper, :client]
 
   pg_search_scope :pg_search,

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,7 +7,8 @@ class Invoice < ApplicationRecord
   include Searchable
 
   # Audit currency conversions and amount changes
-  audited only: [:amount, :base_currency_amount, :exchange_rate, :exchange_rate_date, :currency, :status, :amount_paid, :amount_due]
+  audited associated_with: :company,
+    only: [:amount, :base_currency_amount, :exchange_rate, :exchange_rate_date, :currency, :status, :amount_paid, :amount_due]
 
   # Configure pg_search - use ILIKE for more precise matching
   scope :pg_search, ->(query) {

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -2,7 +2,8 @@
 
 class Payment < ApplicationRecord
   # Audit all payment and currency conversion details
-  audited only: [:amount, :base_currency_amount, :exchange_rate, :exchange_rate_date, :payment_currency, :transaction_date, :status]
+  audited associated_with: :company,
+    only: [:amount, :base_currency_amount, :exchange_rate, :exchange_rate_date, :payment_currency, :transaction_date, :status]
 
   scope :for_kept_invoices, -> { joins(:invoice).merge(Invoice.kept).distinct }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,8 @@ class Project < ApplicationRecord
   include Searchable
   include MetricsTracking
 
+  audited associated_with: :company, except: [:updated_at]
+
   # Configure pg_search
   pg_search_scope :pg_search,
     against: [:name, :description],
@@ -15,6 +17,7 @@ class Project < ApplicationRecord
 
   # Associations
   belongs_to :client
+  has_one :company, through: :client
   has_many :timesheet_entries, inverse_of: :project
   has_many :project_members, dependent: :destroy
   has_many :expenses, dependent: :nullify

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -3,7 +3,8 @@
 class TimesheetEntry < ApplicationRecord
   include Discardable
   include Searchable
-  audited only: [:duration, :work_date, :note, :bill_status, :review_status, :project_id, :user_id, :agent_id, :source, :source_metadata, :proof_url, :proof_metadata, :discarded_at]
+  audited associated_with: :company,
+    only: [:duration, :work_date, :note, :bill_status, :review_status, :project_id, :user_id, :agent_id, :source, :source_metadata, :proof_url, :proof_metadata, :discarded_at]
   attribute :agent_id, :integer
   attribute :proof_url, :string
   attribute :source, :string, default: "manual"

--- a/app/policies/analytics_policy.rb
+++ b/app/policies/analytics_policy.rb
@@ -32,10 +32,15 @@ class AnalyticsPolicy < ApplicationPolicy
     end
 
     def financial_analytics_access?
-      company_analytics_access? || user_book_keeper_role? || user_manager_role?
+      pro_analytics_enabled? &&
+        (company_analytics_access? || user_book_keeper_role? || user_manager_role?)
     end
 
     def self_analytics_access?
-      financial_analytics_access? || user_employee_role?
+      pro_analytics_enabled? && (financial_analytics_access? || user_employee_role?)
+    end
+
+    def pro_analytics_enabled?
+      user.current_workspace&.pro_access?
     end
 end

--- a/app/policies/audit_log_policy.rb
+++ b/app/policies/audit_log_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AuditLogPolicy < ApplicationPolicy
+  def index?
+    has_owner_or_admin_role? && pro_access?
+  end
+
+  private
+
+    def pro_access?
+      user.current_workspace&.pro_access?
+    end
+end

--- a/app/services/create_invited_user_service.rb
+++ b/app/services/create_invited_user_service.rb
@@ -16,6 +16,12 @@ class CreateInvitedUserService
     end
   end
 
+  class SeatLimitReached < StandardError
+    def message
+      "This workspace has reached its team member limit. Ask the workspace owner to upgrade before accepting this invitation."
+    end
+  end
+
   def initialize(token, current_user = nil)
     @token = token
     @success = true
@@ -31,6 +37,7 @@ class CreateInvitedUserService
     user_valid!
     ActiveRecord::Base.transaction do
       update_invitation!
+      ensure_seat_available!
       find_or_create_user!
       add_role_to_invited_user
       create_client_member
@@ -64,6 +71,10 @@ class CreateInvitedUserService
 
     def update_invitation!
       invitation.update!(accepted_at: Time.current)
+    end
+
+    def ensure_seat_available!
+      raise SeatLimitReached unless invitation.company.can_add_team_member_role?(invitation.role)
     end
 
     def find_or_create_user!

--- a/app/services/team/update_service.rb
+++ b/app/services/team/update_service.rb
@@ -51,6 +51,18 @@ module Team
         end
 
         user.add_role(new_role, current_company)
+        audit_role_change
+      end
+
+      def audit_role_change
+        Audited::Audit.create!(
+          auditable: user,
+          associated: current_company,
+          user: actor,
+          action: "update",
+          audited_changes: { "role" => [current_role.to_s, new_role.to_s] },
+          comment: "Workspace role changed"
+        )
       end
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -134,6 +134,7 @@ namespace :api, defaults: { format: "json" } do
       post :portal
       post :trial
     end
+    resources :audit_logs, only: [:index]
     namespace :invoices do
       resources :bulk_deletion, only: [:create]
       resources :bulk_download, only: [:index] do

--- a/db/data/20260815000000_backfill_audit_company_associations.rb
+++ b/db/data/20260815000000_backfill_audit_company_associations.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class BackfillAuditCompanyAssociations < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured { backfill_associations }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+    def backfill_associations
+      execute <<~SQL.squish
+      UPDATE audits SET associated_id = expenses.company_id, associated_type = 'Company'
+      FROM expenses
+      WHERE audits.auditable_type = 'Expense' AND audits.auditable_id = expenses.id
+        AND audits.associated_id IS NULL
+      SQL
+
+      execute <<~SQL.squish
+      UPDATE audits SET associated_id = invoices.company_id, associated_type = 'Company'
+      FROM invoices
+      WHERE audits.auditable_type = 'Invoice' AND audits.auditable_id = invoices.id
+        AND audits.associated_id IS NULL
+      SQL
+
+      execute <<~SQL.squish
+      UPDATE audits SET associated_id = invoices.company_id, associated_type = 'Company'
+      FROM payments
+      INNER JOIN invoices ON invoices.id = payments.invoice_id
+      WHERE audits.auditable_type = 'Payment' AND audits.auditable_id = payments.id
+        AND audits.associated_id IS NULL
+      SQL
+
+      execute <<~SQL.squish
+      UPDATE audits SET associated_id = clients.company_id, associated_type = 'Company'
+      FROM timesheet_entries
+      INNER JOIN projects ON projects.id = timesheet_entries.project_id
+      INNER JOIN clients ON clients.id = projects.client_id
+      WHERE audits.auditable_type = 'TimesheetEntry' AND audits.auditable_id = timesheet_entries.id
+        AND audits.associated_id IS NULL
+      SQL
+    end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe Invitation, type: :model do
     it { is_expected.to callback(:send_invitation_mail).after(:commit) }
   end
 
+  describe "auditing" do
+    it "records creation against the invitation's company without its token" do
+      invitation = create(:invitation, company:)
+      audit = invitation.audits.last
+
+      expect(audit).to have_attributes(action: "create", associated: company)
+      expect(audit.audited_changes).not_to have_key("token")
+    end
+  end
+
   describe "#send_invitation_mail" do
     let(:mailer_scope) { double(send_user_invitation: mail_delivery) }
     let(:mail_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }

--- a/spec/models/invoice_currency_conversion_spec.rb
+++ b/spec/models/invoice_currency_conversion_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Invoice Currency Conversion", type: :model do
       end
 
       it "creates an audit trail" do
-        expect { invoice.save! }.to change { Audited::Audit.count }.by(1)
+        expect { invoice.save! }.to change { Audited::Audit.where(auditable_type: "Invoice").count }.by(1)
 
         audit = invoice.audits.last
         expect(audit.audited_changes).to include("base_currency_amount", "exchange_rate", "exchange_rate_date")

--- a/spec/policies/analytics_policy_spec.rb
+++ b/spec/policies/analytics_policy_spec.rb
@@ -3,13 +3,19 @@
 require "rails_helper"
 
 RSpec.describe AnalyticsPolicy, type: :policy do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:free_company) { create(:company, plan_tier: "free") }
+  let(:trial_company) do
+    create(:company, plan_tier: "free", trial_started_at: Time.current, trial_ends_at: 1.day.from_now)
+  end
   let(:owner) { create(:user, current_workspace_id: company.id) }
   let(:admin) { create(:user, current_workspace_id: company.id) }
   let(:manager) { create(:user, current_workspace_id: company.id) }
   let(:book_keeper) { create(:user, current_workspace_id: company.id) }
   let(:employee) { create(:user, current_workspace_id: company.id) }
   let(:client_user) { create(:user, current_workspace_id: company.id) }
+  let(:free_owner) { create(:user, current_workspace_id: free_company.id) }
+  let(:trial_owner) { create(:user, current_workspace_id: trial_company.id) }
 
   before do
     owner.add_role :owner, company
@@ -18,6 +24,8 @@ RSpec.describe AnalyticsPolicy, type: :policy do
     book_keeper.add_role :book_keeper, company
     employee.add_role :employee, company
     client_user.add_role :client, company
+    free_owner.add_role :owner, free_company
+    trial_owner.add_role :owner, trial_company
   end
 
   permissions :index? do
@@ -28,6 +36,8 @@ RSpec.describe AnalyticsPolicy, type: :policy do
       expect(described_class).to permit(book_keeper, :analytics)
       expect(described_class).to permit(employee, :analytics)
       expect(described_class).not_to permit(client_user, :analytics)
+      expect(described_class).not_to permit(free_owner, :analytics)
+      expect(described_class).to permit(trial_owner, :analytics)
     end
   end
 

--- a/spec/policies/analytics_report_policy_spec.rb
+++ b/spec/policies/analytics_report_policy_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe AnalyticsReportPolicy, type: :policy do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, plan_tier: "paid") }
   let(:owner) { create(:user, current_workspace_id: company.id) }
   let(:admin) { create(:user, current_workspace_id: company.id) }
   let(:book_keeper) { create(:user, current_workspace_id: company.id) }

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AuditLogPolicy, type: :policy do
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:free_company) { create(:company, plan_tier: "free") }
+  let(:admin) { create(:user, current_workspace_id: company.id) }
+  let(:owner) { create(:user, current_workspace_id: company.id) }
+  let(:employee) { create(:user, current_workspace_id: company.id) }
+  let(:free_owner) { create(:user, current_workspace_id: free_company.id) }
+
+  before do
+    admin.add_role :admin, company
+    owner.add_role :owner, company
+    employee.add_role :employee, company
+    free_owner.add_role :owner, free_company
+  end
+
+  permissions :index? do
+    it "allows paid workspace admins and owners" do
+      expect(described_class).to permit(admin, :audit_log)
+      expect(described_class).to permit(owner, :audit_log)
+    end
+
+    it "denies non-admins and free workspaces" do
+      expect(described_class).not_to permit(employee, :audit_log)
+      expect(described_class).not_to permit(free_owner, :audit_log)
+    end
+  end
+end

--- a/spec/requests/api/v1/analytics/revenue_forecasts/index_spec.rb
+++ b/spec/requests/api/v1/analytics/revenue_forecasts/index_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Analytics::RevenueForecastsController#index", type: :request do
-  let(:company) { create(:company, base_currency: "USD") }
+  let(:company) { create(:company, base_currency: "USD", plan_tier: "paid") }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let(:client) { create(:client, company:) }
 
@@ -49,6 +49,33 @@ RSpec.describe "Api::V1::Analytics::RevenueForecastsController#index", type: :re
       send_request :get, api_v1_analytics_revenue_forecasts_path, headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when the workspace has an active trial" do
+    before do
+      company.update!(plan_tier: "free", trial_started_at: Time.current, trial_ends_at: 1.day.from_now)
+      user.add_role :owner, company
+    end
+
+    it "allows access" do
+      send_request :get, api_v1_analytics_revenue_forecasts_path, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when the workspace trial has expired" do
+    before do
+      company.update!(plan_tier: "free", trial_started_at: 15.days.ago, trial_ends_at: 1.day.ago)
+      user.add_role :owner, company
+    end
+
+    it "returns the standard structured authorization error" do
+      send_request :get, api_v1_analytics_revenue_forecasts_path, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response).to eq("errors" => "You are not authorized to perform this action.")
     end
   end
 

--- a/spec/requests/api/v1/audit_logs/index_spec.rb
+++ b/spec/requests/api/v1/audit_logs/index_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::AuditLogsController#index", type: :request do
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:other_company) { create(:company, plan_tier: "paid") }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:client) { create(:client, company:) }
+  let(:other_client) { create(:client, company: other_company) }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :admin, company
+    sign_in user
+  end
+
+  it "returns only audits associated with the current company" do
+    current_audit = create_audit(auditable: client, associated: company)
+    other_audit = create_audit(auditable: other_client, associated: other_company)
+
+    send_request :get, api_v1_audit_logs_path, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    ids = json_response.fetch("audit_logs").pluck("id")
+    expect(ids).to include(current_audit.id)
+    expect(ids).not_to include(other_audit.id)
+  end
+
+  it "filters by type, action, user, and date range" do
+    matching_audit = travel_to(Date.new(2026, 8, 10).noon) do
+      create_audit(auditable: client, associated: company, user:, action: "update")
+    end
+    create_audit(auditable: company, action: "create")
+
+    send_request :get, api_v1_audit_logs_path,
+      params: {
+        auditable_type: "Client",
+        action: "update",
+        user_id: user.id,
+        from: "2026-08-10",
+        to: "2026-08-10"
+      },
+      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response.fetch("audit_logs").pluck("id")).to eq([matching_audit.id])
+  end
+
+  it "strips sensitive keys recursively" do
+    audit = create_audit(
+      auditable: client,
+      associated: company,
+      audited_changes: {
+        "name" => ["Old", "New"],
+        "token" => ["old-token", "new-token"],
+        "bank_account_number" => ["old-account", "new-account"],
+        "metadata" => { "password_digest" => "digest", "safe" => "value" }
+      }
+    )
+
+    send_request :get, api_v1_audit_logs_path, headers: auth_headers(user)
+
+    serialized = json_response.fetch("audit_logs").find { |item| item["id"] == audit.id }
+    expect(serialized.fetch("audited_changes")).to eq(
+      "name" => ["Old", "New"],
+      "metadata" => { "safe" => "value" }
+    )
+  end
+
+  it "returns a structured 400 for malformed date filters" do
+    send_request :get, api_v1_audit_logs_path(from: "not-a-date"), headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(json_response["errors"]).to eq("from must be a valid ISO 8601 date")
+  end
+
+  it "associates project audits with the company through the client chain" do
+    project = create(:project, client:)
+    project.update!(name: "Renamed Project")
+
+    audit = Audited::Audit.where(auditable: project, action: "update").last
+    expect(audit.associated).to eq(company)
+
+    send_request :get, api_v1_audit_logs_path(auditable_type: "Project"), headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response["audit_logs"].pluck("auditable_id")).to include(project.id)
+  end
+
+  it "denies non-admins" do
+    user.remove_role :admin, company
+    user.add_role :employee, company
+
+    send_request :get, api_v1_audit_logs_path, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "denies workspaces without Pro access" do
+    company.update!(plan_tier: "free")
+
+    send_request :get, api_v1_audit_logs_path, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  private
+
+    def create_audit(auditable:, associated: nil, user: nil, action: "update", audited_changes: { "name" => ["Old", "New"] })
+      Audited::Audit.create!(auditable:, associated:, user:, action:, audited_changes:)
+    end
+end

--- a/spec/requests/internal_api/v1/analytics_controller_spec.rb
+++ b/spec/requests/internal_api/v1/analytics_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::AnalyticsController", type: :request do
-  let(:company) { create(:company, base_currency: "USD", working_days: "5", working_hours: "40") }
+  let(:company) { create(:company, base_currency: "USD", working_days: "5", working_hours: "40", plan_tier: "paid") }
   let(:user) { create(:user, current_workspace_id: company.id) }
   let(:client) { create(:client, company:) }
   let(:project) { create(:project, client:, billable: true) }

--- a/spec/requests/internal_api/v1/analytics_exports_controller_spec.rb
+++ b/spec/requests/internal_api/v1/analytics_exports_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::AnalyticsExportsController", type: :request do
-  let(:company) { create(:company, base_currency: "USD", working_days: "5", working_hours: "40") }
+  let(:company) { create(:company, base_currency: "USD", working_days: "5", working_hours: "40", plan_tier: "paid") }
   let(:admin) { create(:user, current_workspace_id: company.id) }
   let(:manager) { create(:user, current_workspace_id: company.id) }
   let(:employee) { create(:user, current_workspace_id: company.id) }

--- a/spec/requests/internal_api/v1/analytics_reports_controller_spec.rb
+++ b/spec/requests/internal_api/v1/analytics_reports_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "InternalApi::V1::AnalyticsReportsController", type: :request do
-  let(:company) { create(:company) }
+  let(:company) { create(:company, plan_tier: "paid") }
   let(:creator) { create(:user, current_workspace_id: company.id) }
   let(:viewer) { create(:user, current_workspace_id: company.id) }
   let(:client_user) { create(:user, current_workspace_id: company.id) }

--- a/spec/services/create_invited_user_service_spec.rb
+++ b/spec/services/create_invited_user_service_spec.rb
@@ -18,6 +18,46 @@ RSpec.describe CreateInvitedUserService do
   end
 
   describe "#process" do
+    context "when the free workspace's seats filled after the invitation was sent" do
+      before do
+        (3 - company.used_team_seats).times do
+          create(:employment, company:, user: create(:user, current_workspace_id: company.id))
+        end
+      end
+
+      it "rejects a team member invitation without accepting it" do
+        service = described_class.new(invitation.token)
+        service.process
+
+        expect(service.success).to be(false)
+        expect(service.error_message).to eq(
+          "This workspace has reached its team member limit. Ask the workspace owner to upgrade before accepting this invitation."
+        )
+        expect(invitation.reload.accepted_at).to be_nil
+        expect(User.exists?(email: invitation.recipient_email)).to be(false)
+      end
+
+      it "allows a client invitation" do
+        invitation.update!(role: :client, client: create(:client, company:))
+
+        service = described_class.new(invitation.token)
+        service.process
+
+        expect(service.success).to be(true)
+        expect(invitation.reload.accepted_at).to be_present
+      end
+
+      it "allows a team member invitation with Pro access" do
+        company.update!(plan_tier: "paid")
+
+        service = described_class.new(invitation.token)
+        service.process
+
+        expect(service.success).to be(true)
+        expect(invitation.reload.accepted_at).to be_present
+      end
+    end
+
     context "when invited user doesn't exists in application" do
       before do
         @service = CreateInvitedUserService.new(invitation.token)

--- a/spec/services/team/update_service_spec.rb
+++ b/spec/services/team/update_service_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe Team::UpdateService do
       }.from("employee").to("admin")
     end
 
+    it "audits a role change with the actor and workspace" do
+      expect { process }.to change { Audited::Audit.where(auditable: user, action: "update").count }.by(1)
+
+      audit = Audited::Audit.where(auditable: user, action: "update").last
+      expect(audit).to have_attributes(
+        associated: company,
+        user: actor,
+        audited_changes: { "role" => ["", "admin"] }
+      )
+    end
+
     context "with an unknown role" do
       let(:new_role) { "superhacker" }
 


### PR DESCRIPTION
## What

Makes the billing page's Pro promises true, closing the gaps found in a full plan-vs-product audit:

1. **Analytics is now actually Pro.** `AnalyticsPolicy` requires `pro_access?` (mirroring `ReportPolicy`); every surface is covered — dashboards, comparisons, revenue forecasts, cached `AnalyticsReport`s, and exports. Frontend routes are wrapped by a new shared `PlanAccessGate` (generalized from the reports gate), non-pro users land on `/settings/billing` with an analytics upsell banner. This creates the missing upgrade moment: previously the entire Pro-marketed analytics suite was free.
2. **Audit Trail ships.** The `audited` gem has been writing an `audits` table with no read surface. New Pro-gated `GET /api/v1/audit_logs` (admin/owner only) + `/settings/audit-log` page with type/action/date filters. Auditing extended to Client, Project, Company, Invitation, and team role changes. Tenant scoping via `associated: current_company OR auditable: current_company` — filters can only narrow, never widen. Sensitive keys (passwords, tokens, bank/tax identifiers) are stripped recursively from responses. A data migration backfills `associated` on legacy audit rows so history stays visible. Stripe-managed Company columns are excluded from auditing to keep signal high (plan_tier changes are kept — those are meaningful).
3. **Seat-limit bypass closed.** Invites issued while Pro/trialing were still redeemable after downgrade/expiry; `CreateInvitedUserService` now re-checks the seat limit at acceptance (client invites unaffected).
4. **Copy honesty.** Dropped the "margin" claim from billing finance copy (no cost basis is modelled, so margin isn't computable).

## Review

Cross-model pipeline: Codex implemented, Kimi reviewed (verdict: no cross-tenant leak, gating complete, seat re-check correct), Claude verified independently. All Kimi P2/P3 findings folded: structured 400 on malformed date filters, legacy-audit backfill, Company audit exclusions, audit-log UI error state, and explicit coverage for Project's has_one-through audit association.

## Tests

201 examples green across policies, requests, services, and models — including a cross-tenant negative test (another company's audits proven absent), sensitive-key stripping, seat-limit acceptance scenarios, and role-change audit rows. Browser-verified in dev: expired-trial workspace bounces from /analytics to the billing upsell; Pro workspace renders the audit log with real change rows.

## Ops

- `bin/rails data:migrate` runs the audit backfill automatically via the existing predeploy step
- No new env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization audit logs with filtering, pagination, actor details, and before/after changes.
  * Added audit tracking for key company, financial, project, invitation, and team-role changes.
  * Added administrator and owner navigation access for audit logs.
  * Added plan-based access controls and billing prompts for analytics, reports, and audit logs.
* **Bug Fixes**
  * Prevented invitations from exceeding free-plan seat limits while preserving client invitations.
  * Sensitive audit values are excluded from displayed changes.
* **Security**
  * Audit logs are restricted to authorized users and their company.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->