### PR TITLE
feat: enforceable workspace SSO and priority support

### DIFF
--- a/app/controllers/api/v1/mobile/otps_controller.rb
+++ b/app/controllers/api/v1/mobile/otps_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::Mobile::OtpsController < Api::V1::ApplicationController
   include AuthResponsePayload
+  include SsoEnforcementConcern
 
   skip_before_action :authenticate_user!
   skip_before_action :authenticate_user_using_x_auth_token
@@ -27,6 +28,8 @@ class Api::V1::Mobile::OtpsController < Api::V1::ApplicationController
     )
     user = result.user
     company = result.company
+    return unless sso_sign_in_allowed?(user)
+
     sign_in user, store: false
 
     render json: {

--- a/app/controllers/api/v1/sso_settings_controller.rb
+++ b/app/controllers/api/v1/sso_settings_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Api::V1::SsoSettingsController < Api::V1::ApplicationController
+  def show
+    authorize current_company, policy_class: SsoSettingPolicy
+
+    render json: settings_payload, status: 200
+  end
+
+  def update
+    authorize current_company, policy_class: SsoSettingPolicy
+
+    current_company.sso_settings_actor = current_user
+    current_company.update!(settings_params)
+
+    render json: settings_payload, status: 200
+  end
+
+  private
+
+    def settings_params
+      params.require(:company).permit(:sso_enforced, allowed_sso_domains: [])
+    end
+
+    def settings_payload
+      current_company.slice(:sso_enforced, :allowed_sso_domains)
+    end
+end

--- a/app/controllers/api/v1/support_requests_controller.rb
+++ b/app/controllers/api/v1/support_requests_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Api::V1::SupportRequestsController < Api::V1::ApplicationController
+  MAX_REQUESTS_PER_HOUR = 5
+
+  def create
+    authorize current_company, :support_request?
+
+    subject = support_request_params[:subject].to_s.delete("\r\n").strip
+    message = support_request_params[:message].to_s.delete("\r\n").strip
+    return render_validation_error if subject.blank? || message.blank? || subject.length > 200 || message.length > 5000
+    return render_throttled if throttle_count > MAX_REQUESTS_PER_HOUR
+
+    SupportRequestMailer.with(
+      user_id: current_user.id,
+      workspace_name: current_company.name,
+      plan_label: current_company.current_plan_label,
+      seat_count: current_company.used_team_seats,
+      role: current_user.roles.find_by(resource: current_company)&.name || "member",
+      subject:,
+      message:,
+      priority: current_company.pro_access?
+    ).request.deliver_later
+    Analytics::TrackingService.new(user: current_user).track_support_request(current_company)
+
+    head 201
+  end
+
+  private
+
+    def support_request_params
+      params.require(:support_request).permit(:subject, :message)
+    end
+
+    def throttle_count
+      Rails.cache.increment("support_requests:user:#{current_user.id}", 1, expires_in: 1.hour).to_i
+    end
+
+    def render_validation_error
+      render json: { errors: "Subject and message are required and must fit the allowed lengths." }, status: 422
+    end
+
+    def render_throttled
+      render json: { errors: "You can send up to 5 support requests per hour." }, status: 429
+    end
+end

--- a/app/controllers/api/v1/users/otps_controller.rb
+++ b/app/controllers/api/v1/users/otps_controller.rb
@@ -3,6 +3,7 @@
 class Api::V1::Users::OtpsController < Api::V1::ApplicationController
   include AuthResponsePayload
   include SameOriginAuthentication
+  include SsoEnforcementConcern
 
   skip_before_action :authenticate_user!
   skip_before_action :authenticate_user_using_x_auth_token
@@ -27,6 +28,8 @@ class Api::V1::Users::OtpsController < Api::V1::ApplicationController
       pending_token: otp_params[:pending_token],
       code: otp_params[:code]
     )
+    return unless sso_sign_in_allowed?(result.user)
+
     sign_in(result.user)
 
     render json: signed_in_payload(

--- a/app/controllers/api/v1/users/passkeys_controller.rb
+++ b/app/controllers/api/v1/users/passkeys_controller.rb
@@ -3,6 +3,7 @@
 class Api::V1::Users::PasskeysController < Api::V1::ApplicationController
   include AuthResponsePayload
   include SameOriginAuthentication
+  include SsoEnforcementConcern
 
   skip_before_action :authenticate_user!, only: :authenticate
   skip_before_action :authenticate_user_using_x_auth_token, only: :authenticate
@@ -86,6 +87,9 @@ class Api::V1::Users::PasskeysController < Api::V1::ApplicationController
     end
 
     passkey.update!(sign_count: credential.sign_count, last_used_at: Time.current)
+    # Passkeys do not satisfy workspace SSO; enforced workspaces require Google or GitHub sign-in.
+    return unless sso_sign_in_allowed?(user)
+
     sign_in(user)
 
     render json: signed_in_payload(

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::Users::PasswordsController < Devise::PasswordsController
+  include SsoEnforcementConcern
+
   respond_to :json
 
   def create
@@ -22,7 +24,7 @@ class Api::V1::Users::PasswordsController < Devise::PasswordsController
         }, status: 422
       end
 
-      sign_in(user) if Devise.sign_in_after_reset_password
+      sign_in(user) if Devise.sign_in_after_reset_password && sso_sign_in_error(user).nil?
       safe_user = user.as_json(only: %i[id email first_name last_name current_workspace_id])
       render json: { notice: I18n.t("password.update.success"), user: safe_user }, status: 200
     else

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
   include AuthResponsePayload
   include CurrentCompanyConcern
   include SameOriginAuthentication
+  include SsoEnforcementConcern
 
   before_action :authenticate_user_using_x_auth_token, only: :me
   before_action :reject_cross_origin_authentication!, only: :create
@@ -21,6 +22,8 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
       render_invalid_password_error
     elsif !user.confirmed?
       render_unconfirmed_user_error(user)
+    elsif (error = sso_sign_in_error(user))
+      render_sso_sign_in_error(error)
     elsif passkey_login_unsupported?(user)
       render_passkey_unsupported_error
     elsif passkey_login_required?(user)

--- a/app/controllers/api/v1/users/totp_controller.rb
+++ b/app/controllers/api/v1/users/totp_controller.rb
@@ -3,8 +3,11 @@
 class Api::V1::Users::TotpController < Api::V1::ApplicationController
   include AuthResponsePayload
   include SameOriginAuthentication
+  include SsoEnforcementConcern
 
   skip_before_action :authenticate_user!, only: :authenticate
+  skip_before_action :authenticate_user_using_x_auth_token, only: :authenticate
+  skip_before_action :set_virtual_verified_invitations_allowed, only: :authenticate
   before_action :reject_cross_origin_authentication!, only: :authenticate
   before_action :require_current_password!, only: [:setup, :regenerate_recovery_codes, :destroy]
 
@@ -83,6 +86,8 @@ class Api::V1::Users::TotpController < Api::V1::ApplicationController
       render json: { error: I18n.t("totp.invalid_verification") }, status: 422
       return
     end
+
+    return unless sso_sign_in_allowed?(user)
 
     sign_in(user)
 

--- a/app/controllers/concerns/sso_enforcement_concern.rb
+++ b/app/controllers/concerns/sso_enforcement_concern.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SsoEnforcementConcern
+  extend ActiveSupport::Concern
+
+  private
+
+    def sso_sign_in_error(user)
+      return if user.nil?
+
+      SsoEnforcement.new(user).password_error
+    end
+
+    def sso_sign_in_allowed?(user)
+      error = sso_sign_in_error(user)
+      return true unless error
+
+      render_sso_sign_in_error(error)
+      false
+    end
+
+    def render_sso_sign_in_error(error)
+      render json: { error: }, status: 403
+    end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -31,6 +31,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       user = provider.new(request.env["omniauth.auth"]).user!
 
       if user&.persisted?
+        if (error = SsoEnforcement.new(user).oauth_error)
+          flash[:error] = error
+          redirect_to root_path
+          return
+        end
+
         sign_in_and_redirect user
         set_flash_message(:notice, :success, kind:) if is_navigational_format?
       else

--- a/app/javascript/src/apis/api.ts
+++ b/app/javascript/src/apis/api.ts
@@ -656,6 +656,23 @@ export const auditLogsApi = {
   index: (params = {}) => http.get(`/audit_logs`, { params }),
 };
 
+export const ssoSettingsApi = {
+  show: () => http.get(`/sso_setting`, { skipErrorToast: true }),
+  update: (payload: any) =>
+    http.put(`/sso_setting`, payload, {
+      skipErrorToast: true,
+      skipSuccessToast: true,
+    }),
+};
+
+export const supportRequestsApi = {
+  create: (payload: any) =>
+    http.post(`/support_requests`, payload, {
+      skipErrorToast: true,
+      skipSuccessToast: true,
+    }),
+};
+
 // Teams
 export const teamsApi = {
   get: (id: any) => http.get(`/team/${id}/details`),

--- a/app/javascript/src/components/Navbar/Sidebar.tsx
+++ b/app/javascript/src/components/Navbar/Sidebar.tsx
@@ -23,6 +23,8 @@ import {
   Palmtree,
   UsersRound,
   ClockCounterClockwise,
+  Lifebuoy,
+  ShieldCheck,
 } from "phosphor-react";
 
 import { cn } from "../../lib/utils";
@@ -219,6 +221,24 @@ const Sidebar: React.FC = () => {
       label: i18n.t("navbar.auditLog"),
       path: "/settings/audit-log",
       allowedRoles: [Roles.ADMIN, Roles.OWNER],
+    },
+    {
+      icon: <ShieldCheck className="h-5 w-5" />,
+      label: i18n.t("navbar.securitySso"),
+      path: "/settings/sso",
+      allowedRoles: [Roles.ADMIN, Roles.OWNER],
+    },
+    {
+      icon: <Lifebuoy className="h-5 w-5" />,
+      label: i18n.t("navbar.support"),
+      path: "/settings/support",
+      allowedRoles: [
+        Roles.ADMIN,
+        Roles.OWNER,
+        Roles.BOOK_KEEPER,
+        Roles.EMPLOYEE,
+        Roles.CLIENT,
+      ],
     },
     {
       icon: <Wallet className="h-5 w-5" />,

--- a/app/javascript/src/components/Profile/Layout/Navigation/List.tsx
+++ b/app/javascript/src/components/Profile/Layout/Navigation/List.tsx
@@ -40,6 +40,10 @@ const labelForSetting = path => {
 
   if (path.startsWith("audit-log")) return t("settings.labels.auditLog");
 
+  if (path.startsWith("sso")) return t("settings.labels.securitySso");
+
+  if (path.startsWith("support")) return t("settings.labels.support");
+
   return path;
 };
 

--- a/app/javascript/src/components/Profile/Layout/routes.tsx
+++ b/app/javascript/src/components/Profile/Layout/routes.tsx
@@ -8,6 +8,8 @@ import OrgEdit from "components/Profile/Organization/Edit";
 import Holidays from "components/Profile/Organization/Holidays";
 import Billing from "components/Profile/Organization/Billing";
 import AuditLog from "components/Profile/Organization/AuditLog";
+import SsoSettings from "components/Profile/Organization/Sso";
+import Support from "components/Profile/Organization/Support";
 import PaymentSettings from "components/Profile/Organization/Payment";
 import TaxConfigurationSettings from "components/Profile/Organization/TaxConfiguration";
 import AllocatedDevicesDetails from "components/Profile/Personal/Devices";
@@ -212,6 +214,24 @@ export const SETTINGS = [
     icon: <ReminderIcon className="mr-2" size={20} weight="bold" />,
     authorisedRoles: [ADMIN, OWNER],
     Component: AuditLog,
+    category: "organization",
+    isTab: true,
+  },
+  {
+    label: "SECURITY & SSO",
+    path: "sso",
+    icon: <ReminderIcon className="mr-2" size={20} weight="bold" />,
+    authorisedRoles: [ADMIN, OWNER],
+    Component: SsoSettings,
+    category: "organization",
+    isTab: true,
+  },
+  {
+    label: "SUPPORT",
+    path: "support",
+    icon: <ReminderIcon className="mr-2" size={20} weight="bold" />,
+    authorisedRoles: [ADMIN, OWNER, BOOK_KEEPER, EMPLOYEE, CLIENT],
+    Component: Support,
     category: "organization",
     isTab: true,
   },

--- a/app/javascript/src/components/Profile/Organization/Billing/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Billing/index.tsx
@@ -462,6 +462,17 @@ const Billing = () => {
         </Alert>
       )}
 
+      {featureGate === "sso" && summary && !summary.pro_access && (
+        <Alert>
+          <AlertTitle>
+            {i18n.t("billingSettings.featureGate.ssoTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {i18n.t("billingSettings.featureGate.ssoDescription")}
+          </AlertDescription>
+        </Alert>
+      )}
+
       {featureGate === "seats" && summary && !summary.pro_access && (
         <Alert>
           <AlertTitle>

--- a/app/javascript/src/components/Profile/Organization/Sso/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Sso/index.tsx
@@ -1,0 +1,198 @@
+import React, { FormEvent, KeyboardEvent, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { ssoSettingsApi } from "apis/api";
+import PlanAccessGate from "components/PlanAccessGate";
+import { Badge } from "components/ui/badge";
+import { Button } from "components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "components/ui/card";
+import { Input } from "components/ui/input";
+import { Label } from "components/ui/label";
+import { Switch } from "components/ui/switch";
+import { i18n } from "../../../../i18n";
+
+const validDomain = (domain: string) =>
+  domain.length > 0 && !domain.includes("@") && domain.includes(".");
+
+const SsoSettingsForm = () => {
+  const [ssoEnforced, setSsoEnforced] = useState(false);
+  const [domains, setDomains] = useState<string[]>([]);
+  const [domainInput, setDomainInput] = useState("");
+  const [domainError, setDomainError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const response = await ssoSettingsApi.show();
+        setSsoEnforced(response.data.sso_enforced);
+        setDomains(response.data.allowed_sso_domains || []);
+      } catch (error: any) {
+        toast.error(
+          error?.response?.data?.errors || i18n.t("ssoSettings.loadError")
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadSettings();
+  }, []);
+
+  const addDomain = () => {
+    const domain = domainInput.trim().toLowerCase().replace(/,$/, "");
+    if (!domain) return true;
+
+    if (!validDomain(domain)) {
+      setDomainError(i18n.t("ssoSettings.invalidDomain"));
+
+      return false;
+    }
+
+    setDomains(current =>
+      current.includes(domain) ? current : [...current, domain]
+    );
+    setDomainInput("");
+    setDomainError("");
+
+    return true;
+  };
+
+  const handleDomainKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addDomain();
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const pendingDomain = domainInput.trim().toLowerCase();
+    if (pendingDomain && !validDomain(pendingDomain)) {
+      setDomainError(i18n.t("ssoSettings.invalidDomain"));
+
+      return;
+    }
+
+    const allowedSsoDomains = pendingDomain
+      ? Array.from(new Set([...domains, pendingDomain]))
+      : domains;
+
+    try {
+      setSaving(true);
+      const response = await ssoSettingsApi.update({
+        company: {
+          sso_enforced: ssoEnforced,
+          allowed_sso_domains: allowedSsoDomains,
+        },
+      });
+      setDomains(response.data.allowed_sso_domains);
+      setDomainInput("");
+      setDomainError("");
+      toast.success(i18n.t("ssoSettings.saved"));
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.errors || i18n.t("ssoSettings.saveError")
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="border-border bg-card shadow-sm">
+      <CardHeader>
+        <CardTitle>{i18n.t("ssoSettings.title")}</CardTitle>
+        <CardDescription>{i18n.t("ssoSettings.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="max-w-3xl space-y-8" onSubmit={handleSubmit}>
+          <div className="flex items-start justify-between gap-6 rounded-lg border border-border p-4">
+            <div className="space-y-1">
+              <Label htmlFor="sso-enforced">
+                {i18n.t("ssoSettings.requireSso")}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {i18n.t("ssoSettings.requireSsoWarning")}
+              </p>
+            </div>
+            <Switch
+              checked={ssoEnforced}
+              disabled={loading}
+              id="sso-enforced"
+              onCheckedChange={setSsoEnforced}
+            />
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="allowed-sso-domain">
+                {i18n.t("ssoSettings.allowedDomains")}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {i18n.t("ssoSettings.allowedDomainsDescription")}
+              </p>
+            </div>
+            <div className="flex min-h-12 flex-wrap items-center gap-2 rounded-md border border-input bg-background p-2 focus-within:ring-2 focus-within:ring-ring">
+              {domains.map(domain => (
+                <Badge className="gap-2" key={domain} variant="secondary">
+                  {domain}
+                  <button
+                    aria-label={i18n.t("ssoSettings.removeDomain", { domain })}
+                    className="rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() =>
+                      setDomains(current =>
+                        current.filter(item => item !== domain)
+                      )
+                    }
+                    type="button"
+                  >
+                    ×
+                  </button>
+                </Badge>
+              ))}
+              <Input
+                className="h-8 min-w-48 flex-1 border-0 p-1 shadow-none focus-visible:ring-0"
+                id="allowed-sso-domain"
+                onBlur={addDomain}
+                onChange={event =>
+                  setDomainInput(event.target.value.toLowerCase())
+                }
+                onKeyDown={handleDomainKeyDown}
+                placeholder={i18n.t("ssoSettings.domainPlaceholder")}
+                value={domainInput}
+              />
+            </div>
+            {domainError && (
+              <p className="text-sm text-destructive" role="alert">
+                {domainError}
+              </p>
+            )}
+            <p className="text-sm text-muted-foreground">
+              {i18n.t("ssoSettings.membersDomainNote")}
+            </p>
+          </div>
+
+          <Button disabled={loading || saving} type="submit">
+            {saving ? i18n.t("ssoSettings.saving") : i18n.t("ssoSettings.save")}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+const SsoSettings = () => (
+  <PlanAccessGate feature="sso">
+    <SsoSettingsForm />
+  </PlanAccessGate>
+);
+
+export default SsoSettings;

--- a/app/javascript/src/components/Profile/Organization/Support/index.tsx
+++ b/app/javascript/src/components/Profile/Organization/Support/index.tsx
@@ -1,0 +1,104 @@
+import React, { FormEvent, useState } from "react";
+import { toast } from "sonner";
+
+import { supportRequestsApi } from "apis/api";
+import { Badge } from "components/ui/badge";
+import { Button } from "components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "components/ui/card";
+import { Input } from "components/ui/input";
+import { Label } from "components/ui/label";
+import { Textarea } from "components/ui/textarea";
+import { useUserContext } from "context/UserContext";
+import { i18n } from "../../../../i18n";
+
+const Support = () => {
+  const { company } = useUserContext();
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const priority = Boolean(company?.pro_access);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    try {
+      setSending(true);
+      await supportRequestsApi.create({
+        support_request: { subject, message },
+      });
+      setSubject("");
+      setMessage("");
+      toast.success(i18n.t("supportSettings.sent"));
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.errors || i18n.t("supportSettings.sendError")
+      );
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Card className="border-border bg-card shadow-sm">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <CardTitle>{i18n.t("supportSettings.title")}</CardTitle>
+          <Badge variant={priority ? "default" : "secondary"}>
+            {priority
+              ? i18n.t("supportSettings.priorityBadge")
+              : i18n.t("supportSettings.standardBadge")}
+          </Badge>
+        </div>
+        <CardDescription>
+          {priority
+            ? i18n.t("supportSettings.priorityDescription")
+            : i18n.t("supportSettings.standardDescription")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="max-w-3xl space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="support-subject">
+              {i18n.t("supportSettings.subject")}
+            </Label>
+            <Input
+              id="support-subject"
+              maxLength={200}
+              onChange={event => setSubject(event.target.value)}
+              placeholder={i18n.t("supportSettings.subjectPlaceholder")}
+              required
+              value={subject}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="support-message">
+              {i18n.t("supportSettings.message")}
+            </Label>
+            <Textarea
+              className="min-h-40"
+              id="support-message"
+              maxLength={5000}
+              onChange={event => setMessage(event.target.value)}
+              placeholder={i18n.t("supportSettings.messagePlaceholder")}
+              required
+              value={message}
+            />
+          </div>
+          <Button disabled={sending} type="submit">
+            {sending
+              ? i18n.t("supportSettings.sending")
+              : i18n.t("supportSettings.send")}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default Support;

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1359,6 +1359,8 @@ const en = {
     leavesDescription: "Manage time off requests",
     expensesDescription: "Track business expenses",
     auditLog: "Audit Log",
+    securitySso: "Security & SSO",
+    support: "Support",
   },
 
   // Passkeys
@@ -1949,6 +1951,44 @@ const en = {
     },
   },
 
+  ssoSettings: {
+    title: "Security & SSO",
+    description: "Control how members sign in to this workspace.",
+    requireSso: "Require SSO sign-in",
+    requireSsoWarning:
+      "Members will need to use Google or GitHub. Workspace owners keep password access to prevent lockout.",
+    allowedDomains: "Allowed SSO domains",
+    allowedDomainsDescription:
+      "Press Enter or type a comma after each domain. Domains are saved in lowercase without @.",
+    domainPlaceholder: "saeloun.com",
+    membersDomainNote: "Members must sign in with an email on these domains.",
+    invalidDomain: "Enter a domain with a dot and without @.",
+    removeDomain: "Remove %{domain}",
+    save: "Save SSO settings",
+    saving: "Saving...",
+    saved: "SSO settings updated.",
+    loadError: "Could not load SSO settings.",
+    saveError: "Could not save SSO settings.",
+  },
+
+  supportSettings: {
+    title: "Support",
+    priorityBadge: "Priority support",
+    standardBadge: "Standard support",
+    priorityDescription:
+      "Priority support -- we respond within 1 business day.",
+    standardDescription:
+      "Send our team a support request and we will respond as soon as we can.",
+    subject: "Subject",
+    subjectPlaceholder: "What do you need help with?",
+    message: "Message",
+    messagePlaceholder: "Share the details our team needs to help.",
+    send: "Send support request",
+    sending: "Sending...",
+    sent: "Support request sent.",
+    sendError: "Could not send your support request.",
+  },
+
   billingSettings: {
     membership: "Membership",
     currentPlan: "Current plan",
@@ -2005,6 +2045,9 @@ const en = {
       auditTitle: "Audit Log is a Pro feature",
       auditDescription:
         "Upgrade to Pro to review administrative and record changes.",
+      ssoTitle: "Security & SSO is a Pro feature",
+      ssoDescription:
+        "Upgrade to Pro to enforce SSO and restrict workspace email domains.",
       seatsTitle: "You've reached your free plan's team limit",
       seatsDescription:
         "Upgrade to Pro to add unlimited team members to this workspace.",
@@ -2605,6 +2648,8 @@ const en = {
       organization: "Organization",
       billing: "Billing",
       auditLog: "Audit Log",
+      securitySso: "Security & SSO",
+      support: "Support",
       payment: "Payment",
       holidays: "Holidays",
       leaves: "Leaves",

--- a/app/mailers/support_request_mailer.rb
+++ b/app/mailers/support_request_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SupportRequestMailer < ApplicationMailer
+  def request
+    @user = User.find(params[:user_id])
+    @workspace_name = params[:workspace_name]
+    @plan_label = params[:plan_label]
+    @seat_count = params[:seat_count]
+    @role = params[:role]
+    prefix = params[:priority] ? "[Priority]" : "[Support]"
+    subject = params[:subject].to_s.delete("\r\n")
+    message = params[:message].to_s.delete("\r\n")
+    body = <<~BODY
+      Workspace: #{@workspace_name}
+      Plan: #{@plan_label}
+      Seats: #{@seat_count}
+      Requester: #{@user.full_name} (#{@user.email})
+      Role: #{@role}
+
+      #{message}
+    BODY
+    mail(
+      to: "hello@saeloun.com",
+      reply_to: @user.email,
+      subject: "#{prefix} #{subject}",
+      body:
+    )
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,6 +4,8 @@ class Company < ApplicationRecord
   include MetricsTracking
   include PhoneNumberValidatable
 
+  attr_accessor :sso_settings_actor
+
   audited except: [
     :updated_at,
     :trial_email_last_sent_on,
@@ -74,8 +76,12 @@ class Company < ApplicationRecord
   validates :name, length: { maximum: 30 }
   validate :business_phone_must_be_valid
   validate :validate_attachment_constraints
+  validate :allowed_sso_domains_are_valid
+  validate :sso_settings_do_not_lock_out_actor
   validates :standard_price, numericality: { greater_than_or_equal_to: 0 }
   validates :timesheet_edit_days, numericality: { only_integer: true, in: 1..365 }
+
+  before_validation :normalize_allowed_sso_domains
 
   # scopes
   scope :with_kept_employments, -> { merge(Employment.kept) }
@@ -266,6 +272,34 @@ class Company < ApplicationRecord
   end
 
   private
+
+    def normalize_allowed_sso_domains
+      self.allowed_sso_domains = Array(allowed_sso_domains).filter_map do |domain|
+        domain.to_s.strip.downcase.presence
+      end.uniq
+    end
+
+    def allowed_sso_domains_are_valid
+      invalid_domains = allowed_sso_domains.reject { |domain| domain.exclude?("@") && domain.include?(".") }
+      errors.add(:allowed_sso_domains, "must be valid domains without @") if invalid_domains.any?
+    end
+
+    def sso_settings_do_not_lock_out_actor
+      return unless sso_enforced? && sso_settings_actor.present?
+
+      if will_save_change_to_sso_enforced?(from: false, to: true) &&
+          !sso_settings_actor.has_role?(:owner, self) &&
+          !sso_settings_actor.identities.where(provider: %w[google_oauth2 github]).exists?
+        errors.add(:sso_enforced, "requires you to connect Google or GitHub first")
+      end
+
+      return if allowed_sso_domains.blank?
+
+      actor_domain = sso_settings_actor.email.to_s.downcase.split("@", 2).last
+      return if allowed_sso_domains.include?(actor_domain)
+
+      errors.add(:allowed_sso_domains, "must include your own email domain when SSO is required")
+    end
 
     def validate_attachment_constraints
       ATTACHMENT_CONTENT_TYPES.each do |name, allowed_content_types|

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -34,6 +34,10 @@ class CompanyPolicy < ApplicationPolicy
     user_owner_role? || user_admin_role?
   end
 
+  def support_request?
+    user.present? && record.present?
+  end
+
   def company_present?
     if user.present? && user.current_workspace.nil?
       @error_message_key = :company_not_present

--- a/app/policies/sso_setting_policy.rb
+++ b/app/policies/sso_setting_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SsoSettingPolicy < ApplicationPolicy
+  def show?
+    update?
+  end
+
+  def update?
+    has_owner_or_admin_role? && record.pro_access?
+  end
+end

--- a/app/services/analytics/tracking_service.rb
+++ b/app/services/analytics/tracking_service.rb
@@ -233,6 +233,15 @@ module Analytics
       ))
     end
 
+    def track_support_request(company, metadata = {})
+      track_event("support_request", metadata.merge(
+        company_id: company.id,
+        user_id: user&.id,
+        priority: company.pro_access?,
+        requested_at: Time.current
+      ))
+    end
+
     # Analytics Dashboard Events
     def track_analytics_viewed(section, metadata = {})
       track_event("analytics_viewed", metadata.merge(

--- a/app/services/sso_enforcement.rb
+++ b/app/services/sso_enforcement.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class SsoEnforcement
+  SSO_REQUIRED_MESSAGE = "Your workspace requires SSO sign-in. Use Google or GitHub."
+  DOMAIN_NOT_ALLOWED_MESSAGE = "Your email domain is not allowed by your workspace."
+
+  def initialize(user)
+    @user = user
+  end
+
+  def password_error
+    domain_error || sso_required_error
+  end
+
+  def oauth_error
+    domain_error
+  end
+
+  private
+
+    attr_reader :user
+
+    def domain_error
+      restricted = companies.select do |company|
+        company.allowed_sso_domains.present? && !company.allowed_sso_domains.include?(email_domain)
+      end
+
+      DOMAIN_NOT_ALLOWED_MESSAGE if restricted.any? && !owner_of_every?(restricted)
+    end
+
+    def sso_required_error
+      enforced = companies.select(&:sso_enforced?)
+      SSO_REQUIRED_MESSAGE if enforced.any? && !owner_of_every?(enforced)
+    end
+
+    def companies
+      @companies ||= user.companies.merge(Employment.kept).distinct.to_a
+    end
+
+    def email_domain
+      user.email.to_s.downcase.split("@", 2).last
+    end
+
+    def owner_of_every?(workspaces)
+      workspaces.all? { |workspace| user.has_role?(:owner, workspace) }
+    end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -135,6 +135,8 @@ namespace :api, defaults: { format: "json" } do
       post :trial
     end
     resources :audit_logs, only: [:index]
+    resource :sso_setting, only: [:show, :update]
+    resources :support_requests, only: [:create]
     namespace :invoices do
       resources :bulk_deletion, only: [:create]
       resources :bulk_download, only: [:index] do

--- a/db/migrate/20260815022000_add_sso_settings_to_companies.rb
+++ b/db/migrate/20260815022000_add_sso_settings_to_companies.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSsoSettingsToCompanies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :companies, :sso_enforced, :boolean, null: false, default: false
+    add_column :companies, :allowed_sso_domains, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_30_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_022000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -262,6 +262,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_000000) do
 
   create_table "companies", force: :cascade do |t|
     t.text "address"
+    t.string "allowed_sso_domains", default: [], null: false, array: true
     t.string "bank_account_number"
     t.string "bank_name"
     t.string "bank_routing_number"
@@ -279,6 +280,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_000000) do
     t.string "gst_number"
     t.string "name", null: false
     t.string "plan_tier", default: "free", null: false
+    t.boolean "sso_enforced", default: false, null: false
     t.decimal "standard_price", default: "0.0", null: false
     t.string "stripe_customer_id"
     t.string "stripe_subscription_id"

--- a/spec/mailers/support_request_mailer_spec.rb
+++ b/spec/mailers/support_request_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SupportRequestMailer do
+  let(:user) { create(:user, email: "member@saeloun.com") }
+
+  it "addresses and renders the workspace request" do
+    mail = described_class.with(
+      user_id: user.id,
+      workspace_name: "Saeloun",
+      plan_label: "paid",
+      seat_count: 8,
+      role: "admin",
+      subject: "Need help",
+      message: "Please help with billing.",
+      priority: true
+    ).request
+
+    expect(mail.to).to eq(["hello@saeloun.com"])
+    expect(mail.reply_to).to eq([user.email])
+    expect(mail.subject).to eq("[Priority] Need help")
+    expect(mail.body.encoded).to include(
+      "Workspace: Saeloun",
+      "Plan: paid",
+      "Seats: 8",
+      "Role: admin",
+      "Please help with billing."
+    )
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -529,5 +529,59 @@ RSpec.describe Company, type: :model do
         expect(company.subscription_interval).to be_nil
       end
     end
+
+    describe "SSO settings" do
+      let(:actor) { create(:user, email: "owner@saeloun.com") }
+
+      it "normalizes and validates allowed domains" do
+        company.allowed_sso_domains = [" Saeloun.COM ", "saeloun.com"]
+
+        expect(company).to be_valid
+        expect(company.allowed_sso_domains).to eq(["saeloun.com"])
+      end
+
+      it "rejects invalid domains" do
+        company.allowed_sso_domains = ["@saeloun"]
+
+        expect(company).not_to be_valid
+        expect(company.errors[:allowed_sso_domains]).to include("must be valid domains without @")
+      end
+
+      it "rejects SSO settings that exclude the acting user's domain" do
+        company.assign_attributes(sso_enforced: true, allowed_sso_domains: ["example.com"])
+        company.sso_settings_actor = actor
+
+        expect(company).not_to be_valid
+        expect(company.errors[:allowed_sso_domains]).to include(
+          "must include your own email domain when SSO is required"
+        )
+      end
+
+      it "requires a non-owner enabling SSO to have a connected OAuth identity" do
+        actor.add_role :admin, company
+        company.assign_attributes(sso_enforced: true, allowed_sso_domains: [])
+        company.sso_settings_actor = actor
+
+        expect(company).not_to be_valid
+        expect(company.errors[:sso_enforced]).to include("requires you to connect Google or GitHub first")
+      end
+
+      it "allows a non-owner with a connected OAuth identity to enable SSO" do
+        actor.add_role :admin, company
+        create(:identity, user: actor, provider: "google_oauth2")
+        company.assign_attributes(sso_enforced: true, allowed_sso_domains: [])
+        company.sso_settings_actor = actor
+
+        expect(company).to be_valid
+      end
+
+      it "allows an owner without an OAuth identity to enable SSO" do
+        actor.add_role :owner, company
+        company.assign_attributes(sso_enforced: true, allowed_sso_domains: [])
+        company.sso_settings_actor = actor
+
+        expect(company).to be_valid
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/mobile/otps_spec.rb
+++ b/spec/requests/api/v1/mobile/otps_spec.rb
@@ -77,6 +77,19 @@ RSpec.describe "Api::V1::Mobile::Otps", type: :request do
     expect(json_response["error"]).to eq("Invalid OTP")
   end
 
+  it "rejects OTP sign-in for a member of an SSO-enforced workspace" do
+    company.update!(sso_enforced: true)
+
+    post "/api/v1/mobile/otp/request", params: { phone: "9876543210" }
+    post "/api/v1/mobile/otp/verify", params: {
+      pending_token: json_response["pending_token"],
+      code: "123456"
+    }
+
+    expect(response).to have_http_status(:forbidden)
+    expect(json_response["error"]).to eq(SsoEnforcement::SSO_REQUIRED_MESSAGE)
+  end
+
   it "requests OTP through MSG91 when widget credentials are configured outside test" do
     allow(Rails.env).to receive(:test?).and_return(false)
     send_stub = stub_request(:post, "https://control.msg91.com/api/v5/widget/sendOtp")

--- a/spec/requests/api/v1/sso_settings_spec.rb
+++ b/spec/requests/api/v1/sso_settings_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::SsoSettings", type: :request do
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:user) { create(:user, email: "admin@saeloun.com", current_workspace_id: company.id) }
+
+  before do
+    create(:employment, company:, user:)
+    create(:identity, user:)
+    user.add_role :admin, company
+    sign_in user
+  end
+
+  it "updates normalized SSO settings" do
+    put api_v1_sso_setting_path, params: {
+      company: { sso_enforced: true, allowed_sso_domains: [" SAeloun.com "] }
+    }
+
+    expect(response).to have_http_status(:ok)
+    expect(company.reload).to have_attributes(sso_enforced: true, allowed_sso_domains: ["saeloun.com"])
+  end
+
+  it "denies workspaces without Pro access" do
+    company.update!(plan_tier: "free")
+
+    put api_v1_sso_setting_path, params: { company: { sso_enforced: true } }
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "denies users who are not admins or owners" do
+    user.remove_role :admin, company
+    user.add_role :employee, company
+
+    put api_v1_sso_setting_path, params: { company: { sso_enforced: true } }
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "returns a validation error when the change would lock out the actor" do
+    put api_v1_sso_setting_path, params: {
+      company: { sso_enforced: true, allowed_sso_domains: ["example.com"] }
+    }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(json_response["errors"]).to eq("Allowed sso domains must include your own email domain when SSO is required")
+  end
+end

--- a/spec/requests/api/v1/support_requests_spec.rb
+++ b/spec/requests/api/v1/support_requests_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::SupportRequests", type: :request do
+  let(:company) { create(:company, plan_tier: "paid") }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:params) { { support_request: { subject: "Need help", message: "Please help with billing." } } }
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :employee, company
+    sign_in user
+    allow(Rails).to receive(:cache).and_return(cache)
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it "enqueues and sends a priority request for a Pro workspace" do
+    expect {
+      post api_v1_support_requests_path, params: params
+    }.to have_enqueued_mail(SupportRequestMailer, :request)
+
+    expect(response).to have_http_status(:created)
+
+    perform_enqueued_jobs
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("[Priority] Need help")
+  end
+
+  it "sends a standard request for a workspace without Pro access" do
+    company.update!(plan_tier: "free")
+
+    post api_v1_support_requests_path, params: params
+    perform_enqueued_jobs
+
+    expect(response).to have_http_status(:created)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("[Support] Need help")
+  end
+
+  it "removes injected mail headers from the subject" do
+    post api_v1_support_requests_path, params: {
+      support_request: {
+        subject: "evil\r\nBcc: attacker@example.com",
+        message: "Please help.\r\nBcc: attacker@example.com"
+      }
+    }
+    perform_enqueued_jobs
+    mail = ActionMailer::Base.deliveries.last
+
+    expect(mail.header.fields.count { |field| field.name == "Subject" }).to eq(1)
+    expect(mail.subject).to eq("[Priority] evilBcc: attacker@example.com")
+    expect(mail.bcc).to be_nil
+  end
+
+  it "returns 429 after five requests in an hour" do
+    5.times { post api_v1_support_requests_path, params: params }
+    post api_v1_support_requests_path, params: params
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(json_response["errors"]).to eq("You can send up to 5 support requests per hour.")
+  end
+end

--- a/spec/requests/api/v1/users/otps_spec.rb
+++ b/spec/requests/api/v1/users/otps_spec.rb
@@ -76,4 +76,17 @@ RSpec.describe "Api::V1::Users::Otps", type: :request do
     expect(response).to have_http_status(:unprocessable_content)
     expect(json_response["error"]).to eq("OTP expired or invalid. Request a new code.")
   end
+
+  it "rejects OTP sign-in for a member of an SSO-enforced workspace" do
+    company.update!(sso_enforced: true)
+
+    post "/api/v1/users/otp/request", params: { phone: "9876543210" }
+    post "/api/v1/users/otp/verify", params: {
+      pending_token: json_response["pending_token"],
+      code: "123456"
+    }
+
+    expect(response).to have_http_status(:forbidden)
+    expect(json_response["error"]).to eq(SsoEnforcement::SSO_REQUIRED_MESSAGE)
+  end
 end

--- a/spec/requests/api/v1/users/passkeys_spec.rb
+++ b/spec/requests/api/v1/users/passkeys_spec.rb
@@ -90,6 +90,34 @@ RSpec.describe "Api::V1::Users::Passkeys", type: :request do
     expect(json_response["error"]).to eq("Cross-origin authentication is not allowed")
   end
 
+  it "rejects passkey sign-in for a member of an SSO-enforced workspace" do
+    create(:employment, company:, user:)
+    user.add_role :employee, company
+    company.update!(sso_enforced: true)
+    passkey = user.passkeys.create!(external_id: "credential-id", public_key: "public-key", sign_count: 0)
+    credential = OpenStruct.new(sign_count: 1)
+    webauthn_credential = OpenStruct.new(id: passkey.external_id)
+    sign_out user
+    allow(Passkeys::ChallengeToken).to receive(:verify).and_return(
+      "type" => "authentication",
+      "user_id" => user.id,
+      "company_id" => company.id,
+      "challenge" => "challenge"
+    )
+    allow(::WebAuthn::RelyingParty).to receive(:new).and_return(relying_party)
+    allow(relying_party).to receive(:verify_authentication) do |_response, _challenge, **_options, &block|
+      [credential, block.call(webauthn_credential)]
+    end
+
+    post "/api/v1/users/passkeys/authenticate", params: {
+      pending_token: "pending-token",
+      credential: { id: passkey.external_id }
+    }
+
+    expect(response).to have_http_status(:forbidden)
+    expect(json_response["error"]).to eq(SsoEnforcement::SSO_REQUIRED_MESSAGE)
+  end
+
   it "requires the current password for passkey security changes" do
     post "/api/v1/users/passkeys/registration_options", params: { current_password: "wrong" }
 

--- a/spec/requests/api/v1/users/passwords/update_spec.rb
+++ b/spec/requests/api/v1/users/passwords/update_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe "Api::V1::Users::Passwords#update", type: :request do
         expect(response).to have_http_status(:ok)
         expect(cli_session.reload.revoked_at).to be_present
       end
+
+      it "resets the password without signing in a member of an SSO-enforced workspace" do
+        company = create(:company, sso_enforced: true)
+        create(:employment, company:, user:)
+        user.add_role :employee, company
+        token = user.send(:set_reset_password_token)
+
+        send_request :put, api_v1_users_reset_password_path, params: {
+          user: {
+            reset_password_token: token, password: "newpassword",
+            password_confirmation: "newpassword"
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.valid_password?("newpassword")).to eq(true)
+
+        get "/api/v1/users/_me"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context "with invalid token" do

--- a/spec/requests/api/v1/users/sessions/create_spec.rb
+++ b/spec/requests/api/v1/users/sessions/create_spec.rb
@@ -98,6 +98,55 @@ RSpec.describe "Api::V1::Users::Sessions#create", type: :request do
     end
   end
 
+  context "when a workspace requires SSO" do
+    before do
+      company.update!(sso_enforced: true)
+      user.add_role :employee, company
+    end
+
+    it "rejects password sign-in for a member" do
+      post api_v1_users_login_path, params: {
+        user: { email: user.email, password: user.password }
+      }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response["error"]).to eq(SsoEnforcement::SSO_REQUIRED_MESSAGE)
+    end
+
+    it "allows password sign-in for an owner of every enforced workspace" do
+      second_company = create(:company, sso_enforced: true)
+      create(:employment, company: second_company, user:)
+      user.add_role :owner, company
+      user.add_role :owner, second_company
+
+      post api_v1_users_login_path, params: {
+        user: { email: user.email, password: user.password }
+      }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when a workspace restricts SSO domains" do
+    let(:user) do
+      create(:user, email: "member@example.com", current_workspace_id: company.id, password: "welcome12")
+    end
+
+    before do
+      company.update!(allowed_sso_domains: ["saeloun.com"])
+      user.add_role :employee, company
+    end
+
+    it "rejects password sign-in outside the allowed domains" do
+      post api_v1_users_login_path, params: {
+        user: { email: user.email, password: user.password }
+      }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response["error"]).to eq(SsoEnforcement::DOMAIN_NOT_ALLOWED_MESSAGE)
+    end
+  end
+
   context "when logged in on miru mobile app with valid email and password" do
     it "logs the user successfully" do
       send_request :post, api_v1_users_login_path(app: "miru-mobile"), params: {

--- a/spec/requests/api/v1/users/totp_spec.rb
+++ b/spec/requests/api/v1/users/totp_spec.rb
@@ -84,6 +84,25 @@ RSpec.describe "Api::V1::Users::Totp", type: :request do
     expect(json_response["error"]).to eq("Cross-origin authentication is not allowed")
   end
 
+  it "rejects TOTP sign-in for a member of an SSO-enforced workspace" do
+    create(:employment, company:, user:)
+    user.add_role :employee, company
+    company.update!(sso_enforced: true)
+    user.reset_totp_setup!
+    code = ROTP::TOTP.new(user.reload.otp_secret, issuer: User::TOTP_ISSUER).now
+    sign_out user
+    allow(Passkeys::ChallengeToken).to receive(:verify).and_return(
+      "type" => "totp_authentication",
+      "user_id" => user.id,
+      "company_id" => company.id
+    )
+
+    post "/api/v1/users/totp/authenticate", params: { pending_token: "pending-token", code: }
+
+    expect(response).to have_http_status(:forbidden)
+    expect(json_response["error"]).to eq(SsoEnforcement::SSO_REQUIRED_MESSAGE)
+  end
+
   it "requires the current password for TOTP security changes" do
     post "/api/v1/users/totp/setup", params: { current_password: "wrong" }
 

--- a/spec/requests/users/omniauth_callbacks/google_oauth2_spec.rb
+++ b/spec/requests/users/omniauth_callbacks/google_oauth2_spec.rb
@@ -66,6 +66,24 @@ RSpec.describe "Users::OmniauthCallbacks#google_oauth2", type: :request do
     end
   end
 
+  context "when the user's email domain is not allowed" do
+    let(:user) { create(:user, email: "john@example.com", current_workspace_id: company.id) }
+
+    before do
+      company.update!(allowed_sso_domains: ["saeloun.com"])
+      create(:employment, company:, user:)
+      user.add_role :employee, company
+      OmniAuth.config.mock_auth[:google_oauth2] = build(:google_user_data)
+
+      post user_google_oauth2_omniauth_callback_path
+    end
+
+    it "denies OAuth sign-in" do
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq(SsoEnforcement::DOMAIN_NOT_ALLOWED_MESSAGE)
+    end
+  end
+
   describe "oauth initiation host" do
     around do |example|
       original_app_base_url = ENV["APP_BASE_URL"]

--- a/spec/services/sso_enforcement_spec.rb
+++ b/spec/services/sso_enforcement_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SsoEnforcement do
+  let(:company) { create(:company, allowed_sso_domains: ["saeloun.com"]) }
+  let(:user) { create(:user, email: "member@example.com", current_workspace_id: company.id) }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :employee, company
+  end
+
+  it "uses the same domain restriction for OAuth sign-in" do
+    expect(described_class.new(user).oauth_error).to eq(described_class::DOMAIN_NOT_ALLOWED_MESSAGE)
+  end
+
+  it "exempts an owner from the domain restriction" do
+    user.remove_role :employee, company
+    user.add_role :owner, company
+
+    expect(described_class.new(user).oauth_error).to be_nil
+  end
+end


### PR DESCRIPTION
## What

Two more billing-page promises made real (continuing the plan-integrity work from #2418):

**Workspace SSO enforcement (Pro).** `sso_enforced` + `allowed_sso_domains` on companies, enforced by a shared `SsoEnforcement` service across **every** session-establishment path — password, OAuth callbacks, phone OTP (both controllers), TOTP, passkeys, and the post-password-reset auto sign-in. Semantics: members of an enforcing workspace must sign in with Google/GitHub; owners are always exempt (lockout protection); non-owner admins must have a connected OAuth identity before they can enable enforcement, and cannot save a domain list that excludes themselves; enforcement survives plan expiry (security is never silently dropped) while the settings page shows the Pro upsell. Settings live at /settings/sso behind the shared PlanAccessGate, and every change lands in the Pro audit log automatically.

**Priority support (Pro).** In-app support form at /settings/support for all roles; requests route to hello@saeloun.com with `[Priority]` subject + workspace/plan/seat metadata for Pro workspaces, `[Support]` otherwise; 5/user/hour throttle; CR/LF stripped from subject and message at both the controller and mailer boundaries (header-injection proof, spec included). Pro users see the "we respond within 1 business day" commitment.

## Review

Cross-model pipeline: Codex implemented; Kimi's first review **blocked** with four P1 findings — SSO enforcement was bypassable via OTP, TOTP, passkey, and password-reset sign-in — plus mail header injection. All were fixed (shared `SsoEnforcementConcern`, passkeys deliberately blocked to match the shipped policy copy) and Kimi's confirmation pass verified every finding closed at each call site, including a sweep of all remaining `sign_in` call sites (token/agent paths, correctly out of scope).

## Tests

163 examples green across enforcement service, all six auth paths, settings authorization (non-pro 403, non-admin 403, self-lockout validation), support throttling and header-injection, mailer content, and model validations. Browser-verified in dev: enforcement toggled via the real UI, member password login rejected with the right message, owner exempt, priority badge + submission working.

## Ops

- Migration adds two columns with safe defaults; no backfill needed
- No new env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Security & SSO settings for configuring enforcement and approved email domains.
  * Added support request form with priority handling, confirmation feedback, and request throttling.
  * Added navigation links and plan-based access messaging for these settings.
* **Bug Fixes**
  * Sign-in methods now respect required SSO policies, including password, OTP, passkey, TOTP, and OAuth authentication.
  * Added domain validation to prevent unauthorized access and accidental administrator lockouts.
* **Tests**
  * Added coverage for SSO enforcement, settings permissions, domain validation, and support request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->