### PR TITLE
feat: mobile views for outstanding, aging, payment, and hours reports

### DIFF
--- a/app/javascript/src/components/Reports/AccountsAgingReport/MobileView.tsx
+++ b/app/javascript/src/components/Reports/AccountsAgingReport/MobileView.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import EmptyStates from "common/EmptyStates";
+import { i18n } from "../../../i18n";
+
+import ReportMobileRow, { ClientAgingMobileRow } from "./ReportMobileRow";
+
+interface MobileViewProps {
+  clients: ClientAgingMobileRow[];
+  currency: string;
+}
+
+const MobileView = ({ clients, currency }: MobileViewProps) =>
+  clients.length ? (
+    <div className="sm:hidden">
+      <div className="flex items-center justify-between border-b py-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+        <span>{i18n.t("reports.clientHeader")}</span>
+        <span>{i18n.t("reports.totalDue")}</span>
+      </div>
+      {clients.map(client => (
+        <ReportMobileRow client={client} currency={currency} key={client.id} />
+      ))}
+    </div>
+  ) : (
+    <div className="sm:hidden">
+      <EmptyStates
+        Message={i18n.t("reports.noClientsWithOutstandingBalances")}
+        showNoSearchResultState={false}
+      />
+    </div>
+  );
+
+export default MobileView;

--- a/app/javascript/src/components/Reports/AccountsAgingReport/ReportMobileRow.tsx
+++ b/app/javascript/src/components/Reports/AccountsAgingReport/ReportMobileRow.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+import { Divider } from "common/Divider";
+import { currencyFormat } from "helpers/currency";
+import { i18n } from "../../../i18n";
+
+export interface ClientAgingMobileRow {
+  id: number;
+  name: string;
+  amount_overdue: {
+    zero_to_thirty_days: number;
+    thirty_one_to_sixty_days: number;
+    sixty_one_to_ninety_days: number;
+    ninety_plus_days: number;
+    total: number;
+  };
+}
+
+interface ReportMobileRowProps {
+  client: ClientAgingMobileRow;
+  currency: string;
+}
+
+const BUCKETS = [
+  { key: "zero_to_thirty_days", label: "reports.zeroToThirtyDays" },
+  { key: "thirty_one_to_sixty_days", label: "reports.thirtyOneToSixtyDays" },
+  { key: "sixty_one_to_ninety_days", label: "reports.sixtyOneToNinetyDays" },
+  { key: "ninety_plus_days", label: "reports.ninetyPlusDays" },
+] as const;
+
+const ReportMobileRow = ({ client, currency }: ReportMobileRowProps) => (
+  <div>
+    <div className="min-h-20 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <p className="min-w-0 truncate text-sm font-semibold text-foreground">
+          {client.name}
+        </p>
+        <div className="shrink-0 text-right">
+          <p className="text-xs font-medium text-muted-foreground">
+            {i18n.t("reports.totalDue")}
+          </p>
+          <p className="mt-1 whitespace-nowrap text-base font-bold text-foreground">
+            {currencyFormat(currency, client.amount_overdue.total)}
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3">
+        {BUCKETS.map(bucket => (
+          <div className="flex items-baseline justify-between" key={bucket.key}>
+            <p className="text-xs font-medium text-muted-foreground">
+              {i18n.t(bucket.label)}
+            </p>
+            <p className="whitespace-nowrap text-sm font-semibold text-foreground">
+              {currencyFormat(currency, client.amount_overdue[bucket.key])}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+    <Divider />
+  </div>
+);
+
+export default ReportMobileRow;

--- a/app/javascript/src/components/Reports/AccountsAgingReport/index.tsx
+++ b/app/javascript/src/components/Reports/AccountsAgingReport/index.tsx
@@ -54,6 +54,7 @@ import {
   ChartTooltipContent,
 } from "../../ui/chart";
 import ShareReportButton from "../ShareReportButton";
+import MobileView from "./MobileView";
 import {
   buildSearchParams,
   formatReportApiDate,
@@ -395,14 +396,14 @@ const AccountsAgingReport: React.FC = () => {
           </p>
         </div>
 
-        <div className="flex items-center space-x-3">
+        <div className="flex flex-wrap items-center gap-3">
           {/* As of Date Picker */}
           <Popover>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
                 className={cn(
-                  "w-[200px] justify-start text-left font-normal",
+                  "w-full justify-start text-left font-normal sm:w-[200px]",
                   !asOfDate && "text-muted-foreground"
                 )}
               >
@@ -425,7 +426,7 @@ const AccountsAgingReport: React.FC = () => {
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline">
+              <Button className="w-full sm:w-auto" variant="outline">
                 {getMultiFilterLabel(
                   i18n.t("reports.clients"),
                   selectedClients.length,
@@ -466,7 +467,7 @@ const AccountsAgingReport: React.FC = () => {
           {/* Export Dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline">
+              <Button className="w-full sm:w-auto" variant="outline">
                 <Download className="mr-2 h-4 w-4" />
                 {i18n.t("reports.export")}
                 <ChevronDown className="ml-2 h-4 w-4" />
@@ -622,9 +623,13 @@ const AccountsAgingReport: React.FC = () => {
           <CardTitle>{i18n.t("reports.invoiceAgingDetails")}</CardTitle>
         </CardHeader>
         <CardContent>
+          <MobileView
+            clients={visibleClients}
+            currency={data?.report?.base_currency || ""}
+          />
           <div
             ref={tableRef}
-            className="rounded-md border max-h-[600px] overflow-y-auto"
+            className="hidden rounded-md border max-h-[600px] overflow-y-auto sm:block"
           >
             <Table>
               <TableHeader>
@@ -676,13 +681,24 @@ const AccountsAgingReport: React.FC = () => {
 
           {/* Loading indicator for infinite scroll */}
           {displayedItems < allClients.length && (
-            <div className="flex justify-center py-4">
+            <div className="flex flex-col items-center gap-2 py-4">
               <div className="text-sm text-muted-foreground">
                 {i18n.t("reports.showingOfClients", {
                   displayed: displayedItems,
                   total: allClients.length,
                 })}
               </div>
+              <Button
+                className="sm:hidden"
+                variant="outline"
+                onClick={() =>
+                  setDisplayedItems(prev =>
+                    Math.min(prev + 10, allClients.length)
+                  )
+                }
+              >
+                {i18n.t("reports.loadMore")}
+              </Button>
             </div>
           )}
         </CardContent>

--- a/app/javascript/src/components/Reports/OutstandingInvoiceReport/MobileView.tsx
+++ b/app/javascript/src/components/Reports/OutstandingInvoiceReport/MobileView.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+import EmptyStates from "common/EmptyStates";
+import { i18n } from "../../../i18n";
+
+import ReportMobileRow, {
+  OutstandingInvoiceMobileRow,
+} from "./ReportMobileRow";
+
+interface MobileViewProps {
+  baseCurrency: string;
+  onSelectClient: (clientId: string) => void;
+  rows: OutstandingInvoiceMobileRow[];
+}
+
+const MobileView = ({ baseCurrency, onSelectClient, rows }: MobileViewProps) =>
+  rows.length ? (
+    <div className="sm:hidden">
+      <div className="flex items-center justify-between border-b py-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+        <span>{i18n.t("reports.clientHeader")}</span>
+        <span>{i18n.t("amount")}</span>
+      </div>
+      {rows.map(row => (
+        <ReportMobileRow
+          baseCurrency={baseCurrency}
+          key={row.invoice.id || row.invoice.invoice_number}
+          onSelectClient={onSelectClient}
+          row={row}
+        />
+      ))}
+    </div>
+  ) : (
+    <div className="sm:hidden">
+      <EmptyStates
+        Message={i18n.t("reports.noOutstandingOrOverdueInvoices")}
+        showNoSearchResultState={false}
+      />
+    </div>
+  );
+
+export default MobileView;

--- a/app/javascript/src/components/Reports/OutstandingInvoiceReport/ReportMobileRow.tsx
+++ b/app/javascript/src/components/Reports/OutstandingInvoiceReport/ReportMobileRow.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+import { Divider } from "common/Divider";
+import { currencyFormat } from "helpers/currency";
+import { i18n } from "../../../i18n";
+import type { Invoice } from "../../../types/invoice";
+import { StatusBadge } from "../../ui/status-badge";
+
+export interface OutstandingInvoiceMobileRow {
+  invoice: Invoice;
+  originalAmount: number;
+  baseAmount: number;
+}
+
+interface ReportMobileRowProps {
+  baseCurrency: string;
+  onSelectClient: (clientId: string) => void;
+  row: OutstandingInvoiceMobileRow;
+}
+
+const ReportMobileRow = ({
+  baseCurrency,
+  onSelectClient,
+  row,
+}: ReportMobileRowProps) => {
+  const { invoice, originalAmount, baseAmount } = row;
+
+  return (
+    <div>
+      <div className="min-h-20 w-full py-4 text-left">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            {invoice.client_id ? (
+              <button
+                className="block max-w-full truncate text-left text-sm font-semibold text-foreground underline-offset-2 hover:underline"
+                type="button"
+                onClick={() => onSelectClient(invoice.client_id)}
+              >
+                {invoice.client_name || invoice.client?.name}
+              </button>
+            ) : (
+              <p className="truncate text-sm font-semibold text-foreground">
+                {invoice.client_name || invoice.client?.name}
+              </p>
+            )}
+            <p className="mt-1 text-xs text-muted-foreground">
+              {invoice.invoice_number}
+            </p>
+          </div>
+          <StatusBadge
+            className="shrink-0 capitalize"
+            status={invoice.status}
+          />
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-4">
+          <p className="text-xs font-medium text-muted-foreground">
+            {i18n.t("reports.originalAmount")}
+          </p>
+          <p className="shrink-0 text-right text-sm font-semibold text-foreground">
+            {currencyFormat(invoice.currency || baseCurrency, originalAmount)}
+          </p>
+        </div>
+        <div className="mt-2 flex items-center justify-between gap-4">
+          <p className="text-xs font-medium text-muted-foreground">
+            {i18n.t("reports.baseAmount")}
+          </p>
+          <p className="shrink-0 text-right text-sm font-bold text-foreground">
+            {currencyFormat(baseCurrency, baseAmount)}
+          </p>
+        </div>
+      </div>
+      <Divider />
+    </div>
+  );
+};
+
+export default ReportMobileRow;

--- a/app/javascript/src/components/Reports/OutstandingInvoiceReport/WorkspaceView.tsx
+++ b/app/javascript/src/components/Reports/OutstandingInvoiceReport/WorkspaceView.tsx
@@ -27,6 +27,7 @@ import { useUserContext } from "../../../context/UserContext";
 import { i18n } from "../../../i18n";
 import { invoicesApi } from "apis/api";
 import type { Invoice } from "../../../types/invoice";
+import MobileView from "./MobileView";
 
 interface ClientGroup {
   client_id: string;
@@ -763,61 +764,75 @@ const OutstandingInvoicesWorkspaceView: React.FC = () => {
               ))}
             </div>
           ) : (
-            <div className="rounded-md border" data-testid="filtered-results">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{i18n.t("reports.clientHeader")}</TableHead>
-                    <TableHead>{i18n.t("reports.invoiceHeader")}</TableHead>
-                    <TableHead>{i18n.t("status")}</TableHead>
-                    <TableHead>{i18n.t("reports.originalAmount")}</TableHead>
-                    <TableHead>{i18n.t("reports.baseAmount")}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {(data?.invoices || []).length ? (
-                    (data?.invoices || []).map(invoice => (
-                      <TableRow key={invoice.id}>
-                        <TableCell>
-                          <a
-                            href="#"
-                            className="text-primary underline-offset-4 hover:underline"
-                            onClick={event => {
-                              event.preventDefault();
-                              setSelectedClientId(invoice.client_id);
-                            }}
-                          >
-                            {invoice.client_name || invoice.client?.name}
-                          </a>
-                        </TableCell>
-                        <TableCell>{invoice.invoice_number}</TableCell>
-                        <TableCell className="capitalize">
-                          {invoice.status}
-                        </TableCell>
-                        <TableCell>
-                          {currencyFormat(
-                            invoice.currency || baseCurrency,
-                            amountDue(invoice)
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {currencyFormat(
-                            baseCurrency,
-                            amountDueInBaseCurrency(invoice)
-                          )}
+            <>
+              <MobileView
+                baseCurrency={baseCurrency}
+                onSelectClient={setSelectedClientId}
+                rows={(data?.invoices || []).map(invoice => ({
+                  invoice,
+                  originalAmount: amountDue(invoice),
+                  baseAmount: amountDueInBaseCurrency(invoice),
+                }))}
+              />
+              <div
+                className="hidden rounded-md border sm:block"
+                data-testid="filtered-results"
+              >
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{i18n.t("reports.clientHeader")}</TableHead>
+                      <TableHead>{i18n.t("reports.invoiceHeader")}</TableHead>
+                      <TableHead>{i18n.t("status")}</TableHead>
+                      <TableHead>{i18n.t("reports.originalAmount")}</TableHead>
+                      <TableHead>{i18n.t("reports.baseAmount")}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(data?.invoices || []).length ? (
+                      (data?.invoices || []).map(invoice => (
+                        <TableRow key={invoice.id}>
+                          <TableCell>
+                            <a
+                              href="#"
+                              className="text-primary underline-offset-4 hover:underline"
+                              onClick={event => {
+                                event.preventDefault();
+                                setSelectedClientId(invoice.client_id);
+                              }}
+                            >
+                              {invoice.client_name || invoice.client?.name}
+                            </a>
+                          </TableCell>
+                          <TableCell>{invoice.invoice_number}</TableCell>
+                          <TableCell className="capitalize">
+                            {invoice.status}
+                          </TableCell>
+                          <TableCell>
+                            {currencyFormat(
+                              invoice.currency || baseCurrency,
+                              amountDue(invoice)
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {currencyFormat(
+                              baseCurrency,
+                              amountDueInBaseCurrency(invoice)
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={5} className="h-24 text-center">
+                          {i18n.t("reports.noOutstandingOrOverdueInvoices")}
                         </TableCell>
                       </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={5} className="h-24 text-center">
-                        {i18n.t("reports.noOutstandingOrOverdueInvoices")}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </div>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/app/javascript/src/components/Reports/PaymentReport/MobileView.tsx
+++ b/app/javascript/src/components/Reports/PaymentReport/MobileView.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import EmptyStates from "common/EmptyStates";
+import { i18n } from "../../../i18n";
+import type { Payment } from "../../../types/payment";
+
+import ReportMobileRow from "./ReportMobileRow";
+
+interface MobileViewProps {
+  currency: string;
+  payments: Payment[];
+}
+
+const MobileView = ({ currency, payments }: MobileViewProps) =>
+  payments.length ? (
+    <div className="md:hidden">
+      <div className="flex items-center justify-between border-b py-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+        <span>{i18n.t("client")}</span>
+        <span>{i18n.t("amount")}</span>
+      </div>
+      {payments.map(payment => (
+        <ReportMobileRow
+          currency={currency}
+          key={payment.id}
+          payment={payment}
+        />
+      ))}
+    </div>
+  ) : (
+    <div className="md:hidden">
+      <EmptyStates
+        Message={i18n.t("reports.noPaymentsFoundForSelectedPeriod")}
+        showNoSearchResultState={false}
+      />
+    </div>
+  );
+
+export default MobileView;

--- a/app/javascript/src/components/Reports/PaymentReport/ReportMobileRow.tsx
+++ b/app/javascript/src/components/Reports/PaymentReport/ReportMobileRow.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import { format } from "date-fns";
+
+import { Divider } from "common/Divider";
+import { currencyFormat } from "helpers";
+import { i18n } from "../../../i18n";
+import type { Payment } from "../../../types/payment";
+import { StatusBadge } from "../../ui/status-badge";
+
+interface ReportMobileRowProps {
+  currency: string;
+  payment: Payment;
+}
+
+const ReportMobileRow = ({ currency, payment }: ReportMobileRowProps) => (
+  <div>
+    <div className="min-h-20 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 text-left">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {payment.client_name}
+          </p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {payment.invoice_number}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end text-right">
+          <p className="whitespace-nowrap text-base font-bold text-foreground">
+            {currencyFormat(currency, payment.amount)}
+          </p>
+          <StatusBadge
+            className="mt-2 capitalize"
+            status={payment.status === "completed" ? "paid" : payment.status}
+          />
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-4 text-xs text-muted-foreground">
+        <p>
+          {payment.payment_date
+            ? format(new Date(payment.payment_date), "MMM dd, yyyy")
+            : i18n.t("reports.selectedPeriod")}
+        </p>
+        <p className="truncate text-right">{payment.payment_method}</p>
+      </div>
+    </div>
+    <Divider />
+  </div>
+);
+
+export default ReportMobileRow;

--- a/app/javascript/src/components/Reports/PaymentReport/index.tsx
+++ b/app/javascript/src/components/Reports/PaymentReport/index.tsx
@@ -35,6 +35,7 @@ import { DateRange } from "react-day-picker";
 import { useSearchParams } from "react-router-dom";
 import axios from "../../../apis/api";
 import useInfiniteLoadTrigger from "../../../hooks/useInfiniteLoadTrigger";
+import { useIsMobile } from "../../../hooks/use-mobile";
 import { Button } from "../../ui/button";
 import {
   Select,
@@ -71,6 +72,7 @@ import {
 } from "../filterUtils";
 import { i18n } from "../../../i18n";
 import ViewInAnalyticsButton from "../ViewInAnalyticsButton";
+import MobileView from "./MobileView";
 import type { Payment } from "../../../types/payment";
 
 interface PaymentReportData {
@@ -145,6 +147,7 @@ const getPaymentMethodColor = (method: string) => {
 };
 
 const PaymentReport: React.FC = () => {
+  const isMobile = useIsMobile();
   const [searchParams, setSearchParams] = useSearchParams();
   const initialPreset = searchParams.get("preset") || "this_year";
   const initialFrom = searchParams.get("from");
@@ -473,7 +476,7 @@ const PaymentReport: React.FC = () => {
                 value={dateRangePreset}
                 onValueChange={handleDateRangePreset}
               >
-                <SelectTrigger className="w-[180px]">
+                <SelectTrigger className="w-full sm:w-[180px]">
                   <SelectValue placeholder={i18n.t("selectPeriod")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -507,7 +510,7 @@ const PaymentReport: React.FC = () => {
                   <Button
                     variant="outline"
                     className={cn(
-                      "w-[280px] justify-start text-left font-normal",
+                      "w-full justify-start text-left font-normal sm:w-[280px]",
                       !dateRange && "text-muted-foreground"
                     )}
                   >
@@ -536,7 +539,7 @@ const PaymentReport: React.FC = () => {
                       setDateRange(range);
                       setDateRangePreset("custom");
                     }}
-                    numberOfMonths={2}
+                    numberOfMonths={isMobile ? 1 : 2}
                     disabled={date =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
@@ -551,7 +554,7 @@ const PaymentReport: React.FC = () => {
                     <PopoverTrigger asChild>
                       <Button
                         variant="outline"
-                        className="w-[180px] justify-between"
+                        className="w-full justify-between sm:w-[180px]"
                       >
                         <span className="truncate">
                           {selectedClients.length === 0
@@ -610,7 +613,7 @@ const PaymentReport: React.FC = () => {
                   setPaymentMethod(value === "all" ? "" : value)
                 }
               >
-                <SelectTrigger className="w-[180px]">
+                <SelectTrigger className="w-full sm:w-[180px]">
                   <SelectValue placeholder={i18n.t("reports.allMethods")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -770,7 +773,7 @@ const PaymentReport: React.FC = () => {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
                   {Object.entries(data.summary.by_payment_method).map(
                     ([method, amount]) => (
                       <div
@@ -805,7 +808,11 @@ const PaymentReport: React.FC = () => {
             <CardTitle>{i18n.t("reports.paymentDetails")}</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="rounded-md border">
+            <MobileView
+              currency={data?.currency || ""}
+              payments={table.getRowModel().rows.map(row => row.original)}
+            />
+            <div className="hidden rounded-md border md:block">
               <Table>
                 <TableHeader>
                   {table.getHeaderGroups().map(headerGroup => (

--- a/app/javascript/src/components/Reports/totalHoursLogged/MobileView.tsx
+++ b/app/javascript/src/components/Reports/totalHoursLogged/MobileView.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import EmptyStates from "common/EmptyStates";
+import { i18n } from "../../../i18n";
+
+const MobileView = () => (
+  <div className="w-full px-4 sm:hidden">
+    <EmptyStates
+      Message={i18n.t("reports.noTimeEntriesYet")}
+      showNoSearchResultState={false}
+    />
+  </div>
+);
+
+export default MobileView;

--- a/app/javascript/src/components/Reports/totalHoursLogged/index.tsx
+++ b/app/javascript/src/components/Reports/totalHoursLogged/index.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 
 import Header from "../Header";
+import MobileView from "./MobileView";
 
 const TotalHoursReport = () => (
-  <div>
+  <div className="w-full">
     <Header
-      setIsFilterVisible
+      setIsFilterVisible={() => {}}
       showExportButon
+      showFilterIcon={false}
       showNavFilters
       handleDownload={() => {}}
       isFilterVisible={() => {}}
@@ -14,7 +16,7 @@ const TotalHoursReport = () => (
       revenueFilterCounter={() => {}}
       type="Total Hours Logged"
     />
-    <div />
+    <MobileView />
   </div>
 );
 

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -1014,6 +1014,7 @@ const en = {
     ninetyPlusDays: "90+ Days",
     noClientsWithOutstandingBalances: "No clients with outstanding balances.",
     showingOfClients: "Showing %{displayed} of %{total} clients...",
+    loadMore: "Load more",
     errorLoadingReportData: "Error loading report data. Please try again.",
     projectClient: "PROJECT/ CLIENT",
     noteHeader: "NOTE",


### PR DESCRIPTION
## What

The last four desktop-only report screens from the mobile audit now render stacked, tap-friendly rows at phone widths (following the TimeEntryReport house pattern), with desktop tables unchanged:

- **Outstanding/Overdue invoices** — client/invoice rows with status, original and base-currency amounts; only the client name is tappable (guarded when client_id is absent)
- **Accounts Aging** — per-client rows show **all four aging buckets** plus total, respect the lazy-loading window, and get a mobile Load-more control (the desktop infinite scroll listener lives on a hidden container at phone widths)
- **Payments** — rows with amount/status/date/method; layout breakpoint aligned to md so the calendar month logic (useIsMobile, 768px) and the layout switch agree — closing a 640-767px band where a two-month calendar could overflow
- **Total Hours** — turned out to be a header-only stub; renders a proper empty state instead of a broken filter icon

All four routes join the responsive system spec (overflow assertions at 390×844 and 768×1024).

## Review

Codex implemented; Kimi reviewed with 3 P2s + 4 P3s — all folded: full aging buckets (a user could previously see a large total with the 31-90 day money invisible), lazy-load bypass, breakpoint mismatch, date-format drift, row-wide tap target, and a wrong prop contract on the hours header. Accepted residual (P3): the responsive spec remains overflow/smoke-level rather than asserting per-report content.

## Tests

Responsive suite green locally (two runs; one intermediate failure was a reproducible-under-load /login timeout flake, passing clean immediately after — worth watching in CI). 390px hands-on: all four aging buckets render, zero horizontal overflow across Outstanding/Aging/Payments. Vite + ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-friendly layouts for Accounts Aging, Outstanding Invoices, and Payments reports.
  * Mobile views now display key client, invoice, payment, aging, status, date, and currency details in easy-to-scan rows.
  * Added client selection from mobile outstanding-invoice entries.
  * Added a mobile “Load more” option for Accounts Aging results.
* **Improvements**
  * Report filters, date pickers, and breakdowns now adapt to smaller screens.
  * Added a clear empty state for mobile time-entry reports with no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->