### PR TITLE
feat(imports): import Harvest time entries via CLI and API

### DIFF
--- a/app/controllers/api/v1/cli/capabilities_controller.rb
+++ b/app/controllers/api/v1/cli/capabilities_controller.rb
@@ -63,6 +63,14 @@ class Api::V1::Cli::CapabilitiesController < Api::V1::Cli::BaseController
         {
           name: "expense create",
           description: "Create an expense in the current workspace"
+        },
+        {
+          name: "import",
+          description: "Import time entries from a Harvest Detailed Time CSV export; supports --dry-run and name-to-email mapping"
+        },
+        {
+          name: "import status",
+          description: "Show the status and summary of a data import"
         }
       ]
     }, status: 200

--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class Api::V1::ImportsController < Api::V1::ApplicationController
+  MAX_FILE_SIZE = 20.megabytes
+  MAX_USER_MAPPINGS = 500
+
+  rescue_from Imports::HarvestTimeEntriesImporter::InvalidFileError, JSON::ParserError, with: :render_invalid_import
+
+  def create
+    authorize DataImport
+    validate_file!
+    Imports::HarvestTimeEntriesImporter.validate_headers!(params[:file].tempfile.path)
+
+    data_import = current_company.data_imports.create!(
+      user: current_user,
+      source: params[:source],
+      kind: params[:kind].presence || "time_entries",
+      dry_run: ActiveModel::Type::Boolean.new.cast(params.fetch(:dry_run, false)),
+      options: import_options
+    )
+    data_import.file.attach(params[:file])
+
+    DataImportJob.perform_later(data_import.id)
+    render json: serialized(data_import), status: 202
+  end
+
+  def show
+    data_import = policy_scope(DataImport).find(params[:id])
+    authorize data_import
+    render json: serialized(data_import), status: 200
+  end
+
+  private
+
+    def validate_file!
+      file = params[:file]
+      unless file.respond_to?(:tempfile) && file.respond_to?(:original_filename)
+        raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.file_required")
+      end
+      unless File.extname(file.original_filename).casecmp?(".csv")
+        raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.csv_required")
+      end
+      if file.size > MAX_FILE_SIZE
+        raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.file_too_large")
+      end
+    end
+
+    def import_options
+      {
+        "user_map" => parsed_user_map,
+        "assign_unmatched_to" => params[:assign_unmatched_to].presence
+      }.compact
+    end
+
+    def parsed_user_map
+      value = params[:user_map]
+      return {} if value.blank?
+      if value.is_a?(String) && value.lstrip.start_with?("{", "[")
+        parsed = JSON.parse(value)
+        unless valid_user_map?(parsed)
+          raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.invalid_user_map")
+        end
+
+        return parsed
+      end
+
+      mappings = Array(value)
+      if mappings.size > MAX_USER_MAPPINGS
+        raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.invalid_user_map")
+      end
+
+      mappings.to_h do |mapping|
+        unless mapping.is_a?(String)
+          raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.invalid_user_map")
+        end
+        name, email = mapping.to_s.split("=", 2).map(&:strip)
+        unless name.present? && email.present?
+          raise Imports::HarvestTimeEntriesImporter::InvalidFileError, I18n.t("imports.errors.invalid_user_map")
+        end
+        [name, email]
+      end
+    end
+
+    def valid_user_map?(user_map)
+      user_map.is_a?(Hash) && user_map.size <= MAX_USER_MAPPINGS && user_map.all? do |name, email|
+        name.is_a?(String) && email.is_a?(String) && name.present? && email.present?
+      end
+    end
+
+    def render_invalid_import(error)
+      render json: { errors: error.message }, status: :unprocessable_entity
+    end
+
+    def serialized(data_import)
+      data_import.as_json(only: [
+        :id,
+        :source,
+        :kind,
+        :status,
+        :dry_run,
+        :total_rows,
+        :imported_rows,
+        :failed_rows,
+        :skipped_rows,
+        :summary,
+        :error_message,
+        :started_at,
+        :finished_at
+      ]).merge("row_errors" => data_import.row_errors.first(50))
+    end
+end

--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DataImportJob < ApplicationJob
+  queue_as :default
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(data_import_id)
+    data_import = DataImport.find(data_import_id)
+    Imports::HarvestTimeEntriesImporter.new(data_import).process
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -66,6 +66,7 @@ class Company < ApplicationRecord
   has_many :holiday_infos, through: :holidays, dependent: :destroy
   has_many :carryovers
   has_many :notification_preferences, dependent: :destroy
+  has_many :data_imports, dependent: :destroy
 
   resourcify
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DataImport < ApplicationRecord
+  MAX_ROW_ERRORS = 200
+  SOURCES = %w[harvest].freeze
+  KINDS = %w[time_entries].freeze
+  STATUSES = %w[pending processing completed failed].freeze
+
+  belongs_to :company
+  belongs_to :user
+  has_one_attached :file
+
+  validates :source, inclusion: { in: SOURCES }
+  validates :kind, inclusion: { in: KINDS }
+  validates :status, inclusion: { in: STATUSES }
+
+  before_validation { self.row_errors = Array(row_errors).first(MAX_ROW_ERRORS) }
+
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -229,6 +229,7 @@ class TimesheetEntry < ApplicationRecord
     end
 
     def inferred_source
+      return "import" if source.to_s.downcase == "import"
       return "mcp" if source_metadata["mcp_server"].present?
       return "automation" if source_metadata["tool"].present?
 

--- a/app/policies/data_import_policy.rb
+++ b/app/policies/data_import_policy.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class DataImportPolicy < ApplicationPolicy
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.where(company_id: user.current_workspace_id)
+    end
+
+    private
+
+      attr_reader :user, :scope
+  end
+
+  def create?
+    user_owner_role? || user_admin_role?
+  end
+
+  def show?
+    record.company_id == user.current_workspace_id && create?
+  end
+end

--- a/app/services/imports/harvest_time_entries_importer.rb
+++ b/app/services/imports/harvest_time_entries_importer.rb
@@ -121,15 +121,7 @@ module Imports
       end
 
       def build_plan
-        @warnings = Set.new
-        @row_errors = []
-        @zero_hour_rows = 0
-        @duplicate_rows = 0
-        @client_plans = {}
-        @project_plans = {}
-        @planned_rows = []
-        @failed_rows = 0
-        @imported_rows = 0
+        initialize_plan
 
         build_entity_plans
         load_database_duplicates
@@ -140,6 +132,18 @@ module Imports
         end
         @rows.each { |row| plan_row(row) }
         @summary = build_summary
+      end
+
+      def initialize_plan
+        @warnings = Set.new
+        @row_errors = []
+        @zero_hour_rows = 0
+        @duplicate_rows = 0
+        @client_plans = {}
+        @project_plans = {}
+        @planned_rows = []
+        @failed_rows = 0
+        @imported_rows = 0
       end
 
       def load_database_duplicates
@@ -162,16 +166,7 @@ module Imports
         @rows.each do |row|
           next if row[:client_name].blank? || row[:project_name].blank?
 
-          original_name = row[:client_name]
-          client_name = original_name[0, 30]
-          @warnings << "Client name truncated: #{original_name.truncate(80)}" if original_name.length > 30
-          client_key = key(client_name)
-          client_plan = @client_plans[client_key] ||= {
-            name: client_name,
-            existing: @existing_clients[client_key],
-            currency: row[:currency]
-          }
-          @warnings << "Restored archived client: #{client_name}" if client_plan[:existing]&.discarded?
+          client_key, client_plan = build_client_plan(row)
 
           original_project_name = row[:project_name]
           project_name = original_project_name[0, 30]
@@ -192,6 +187,20 @@ module Imports
         end
       end
 
+      def build_client_plan(row)
+        original_name = row[:client_name]
+        client_name = original_name[0, 30]
+        @warnings << "Client name truncated: #{original_name.truncate(80)}" if original_name.length > 30
+        client_key = key(client_name)
+        client_plan = @client_plans[client_key] ||= {
+          name: client_name,
+          existing: @existing_clients[client_key],
+          currency: row[:currency]
+        }
+        @warnings << "Restored archived client: #{client_name}" if client_plan[:existing]&.discarded?
+        [client_key, client_plan]
+      end
+
       def plan_row(row)
         error = row_error(row)
         return add_row_error(row, error) if error
@@ -206,27 +215,16 @@ module Imports
         work_date = parse_date(row[:date])
         return add_row_error(row, "Date is invalid: #{row[:date]}") unless work_date
 
-        user = resolved_user(row[:user_name])
+        user_name = row[:user_name]
+        user = resolved_user(user_name)
         unless user
-          message = if ambiguous_user?(row[:user_name])
-            "Harvest user \"#{row[:user_name]}\" matches more than one team member; pass --map \"#{row[:user_name]}=their@email\"."
-          else
-            "No team member in this Miru workspace matches Harvest user \"#{row[:user_name]}\". Invite them, or pass --map \"#{row[:user_name]}=their@email\"."
-          end
-          return add_row_error(
-            row,
-            message
-          )
+          return add_row_error(row, unmatched_user_message(user_name))
         end
 
         project_plan = row[:project_plan]
-        project = project_plan[:existing]
         bill_status = bill_status(row, project_plan)
 
-        if project && @database_duplicates.include?(duplicate_key(user.id, project.id, work_date, duration, row[:note]))
-          @duplicate_rows += 1
-          return
-        end
+        return if duplicate_row?(row, user, project_plan[:existing], work_date, duration)
 
         @planned_rows << row.merge(
           user:,
@@ -235,6 +233,21 @@ module Imports
           duration:,
           bill_status:
         )
+      end
+
+      def duplicate_row?(row, user, project, work_date, duration)
+        return false unless project && @database_duplicates.include?(duplicate_key(user.id, project.id, work_date, duration, row[:note]))
+
+        @duplicate_rows += 1
+        true
+      end
+
+      def unmatched_user_message(user_name)
+        if ambiguous_user?(user_name)
+          "Harvest user \"#{user_name}\" matches more than one team member; pass --map \"#{user_name}=their@email\"."
+        else
+          "No team member in this Miru workspace matches Harvest user \"#{user_name}\". Invite them, or pass --map \"#{user_name}=their@email\"."
+        end
       end
 
       def row_error(row)
@@ -293,9 +306,7 @@ module Imports
 
       def build_summary
         dates = @rows.filter_map { |row| parse_date(row[:date]) }
-        names = @rows.pluck(:user_name).compact_blank.uniq.sort
-        matched, unmatched = names.partition { |name| resolved_user(name) }
-        matched = matched.index_with { |name| resolved_user(name).email }
+        users = build_user_summary
         existing_clients = @client_plans.values.filter_map { |plan| plan[:existing]&.name }.sort
         new_clients = @client_plans.values.reject { |plan| plan[:existing] }.pluck(:name).sort.first(200)
         existing_projects = @project_plans.values.filter_map do |plan|
@@ -312,10 +323,18 @@ module Imports
           "zero_hour_skipped" => @zero_hour_rows,
           "clients" => { "existing" => existing_clients, "to_create" => new_clients },
           "projects" => { "existing" => existing_projects, "to_create" => new_projects },
-          "users" => { "matched" => matched, "unmatched" => unmatched.first(200) },
+          "users" => users,
           "date_range" => { "from" => dates.min&.iso8601, "to" => dates.max&.iso8601 },
           "warnings" => @warnings.to_a.sort
         }
+      end
+
+      def build_user_summary
+        names = @rows.pluck(:user_name).compact_blank.uniq.sort
+        matched, unmatched = names.partition { |name| resolved_user(name) }
+        matched = matched.index_with { |name| resolved_user(name).email }
+
+        { "matched" => matched, "unmatched" => unmatched.first(200) }
       end
 
       def persist_entries

--- a/app/services/imports/harvest_time_entries_importer.rb
+++ b/app/services/imports/harvest_time_entries_importer.rb
@@ -2,7 +2,7 @@
 
 require "csv"
 require "bigdecimal"
-require "digest/sha1"
+require "digest/sha2"
 
 module Imports
   class HarvestTimeEntriesImporter
@@ -441,7 +441,7 @@ module Imports
       end
 
       def duplicate_key(user_id, project_id, work_date, duration, note)
-        Digest::SHA1.hexdigest([user_id, project_id, work_date.to_date, duration.to_f, note].join("|"))
+        Digest::SHA256.hexdigest([user_id, project_id, work_date.to_date, duration.to_f, note].join("|"))
       end
 
       def project_label(plan)

--- a/app/services/imports/harvest_time_entries_importer.rb
+++ b/app/services/imports/harvest_time_entries_importer.rb
@@ -1,0 +1,436 @@
+# frozen_string_literal: true
+
+require "csv"
+require "bigdecimal"
+require "digest/sha1"
+
+module Imports
+  class HarvestTimeEntriesImporter
+    class InvalidFileError < StandardError; end
+
+    REQUIRED_HEADERS = %w[date client project hours first\ name last\ name].freeze
+    HEADER_CONVERTER = -> (header) { header.to_s.delete_prefix("\uFEFF").strip.downcase }
+    DATE_FORMATS = {
+      "DD-MM-YYYY" => "%d-%m-%Y",
+      "MM-DD-YYYY" => "%m-%d-%Y",
+      "YYYY-MM-DD" => "%Y-%m-%d"
+    }.freeze
+
+    attr_reader :data_import, :company
+
+    def initialize(data_import)
+      @data_import = data_import
+      @company = data_import.company
+    end
+
+    def self.validate_headers!(path)
+      CSV.open(path, "r:bom|utf-8", headers: true, liberal_parsing: true, header_converters: HEADER_CONVERTER) do |csv|
+        csv.shift
+        missing = REQUIRED_HEADERS - Array(csv.headers)
+        if missing.any?
+          raise InvalidFileError, I18n.t("imports.errors.missing_headers", headers: missing.map(&:titleize).join(", "))
+        end
+      end
+    rescue CSV::MalformedCSVError => error
+      raise InvalidFileError, I18n.t("imports.errors.invalid_csv", message: error.message)
+    end
+
+    def process
+      data_import.update!(
+        status: "processing",
+        started_at: Time.current,
+        finished_at: nil,
+        error_message: nil,
+        total_rows: 0,
+        imported_rows: 0,
+        failed_rows: 0,
+        skipped_rows: 0,
+        summary: {},
+        row_errors: []
+      )
+
+      load_rows
+      load_workspace_records
+      build_plan
+      persist_plan
+      persist_entries unless data_import.dry_run?
+      complete_import
+      data_import
+    rescue StandardError => error
+      message = error.message
+      unless error.is_a?(InvalidFileError)
+        Rails.logger.error("Data import ##{data_import.id} failed: #{message}")
+        message = I18n.t("imports.errors.unexpected")
+      end
+      data_import.update!(status: "failed", error_message: message, finished_at: Time.current)
+      raise
+    end
+
+    private
+
+      def load_rows
+        @rows = []
+
+        data_import.file.open do |file|
+          self.class.validate_headers!(file.path)
+          CSV.open(file.path, "r:bom|utf-8", headers: true, liberal_parsing: true, header_converters: HEADER_CONVERTER) do |csv|
+            csv.each { |row| @rows << normalized_row(row, csv.lineno) }
+          end
+        end
+      rescue CSV::MalformedCSVError => error
+        raise InvalidFileError, I18n.t("imports.errors.invalid_csv", message: error.message)
+      end
+
+      def normalized_row(row, line_number)
+        values = row.to_h.transform_values { |value| value.to_s.strip }
+        task = values["task"]
+        notes = values["notes"]
+
+        {
+          row: line_number,
+          date: values["date"],
+          client_name: values["client"],
+          project_name: values["project"],
+          project_code: values["project code"],
+          user_name: [values["first name"], values["last name"]].compact_blank.join(" "),
+          hours: values["hours"],
+          billable: yes?(values["billable?"]),
+          invoiced: yes?(values["invoiced?"]),
+          note: [task, notes].compact_blank.join(" - "),
+          currency: values["currency"].to_s[/([A-Z]{3})\z/, 1] || company.base_currency,
+          hourly_rate: BigDecimal(values["billable rate"], exception: false) || 0
+        }
+      end
+
+      def yes?(value)
+        value.to_s.casecmp?("yes")
+      end
+
+      def load_workspace_records
+        @users = company.users.merge(Employment.kept).distinct.to_a
+        @users_by_email = @users.index_by { |user| key(user.email) }
+        @users_by_name = @users.group_by { |user| key(user.full_name) }
+        @user_map = data_import.options.fetch("user_map", {}).to_h.transform_keys { |name| key(name) }
+        @assigned_user = @users_by_email[key(data_import.options["assign_unmatched_to"])]
+        @existing_clients = company.clients.to_a.index_by { |client| key(client.name) }
+        @existing_projects = Project.joins(:client)
+          .where(clients: { company_id: company.id })
+          .includes(:client)
+          .to_a
+          .index_by { |project| [project.client_id, key(project.name)] }
+      end
+
+      def build_plan
+        @warnings = Set.new
+        @row_errors = []
+        @zero_hour_rows = 0
+        @duplicate_rows = 0
+        @client_plans = {}
+        @project_plans = {}
+        @planned_rows = []
+        @failed_rows = 0
+        @imported_rows = 0
+
+        build_entity_plans
+        load_database_duplicates
+        @project_plans.each_value do |plan|
+          if plan[:existing] && !plan[:existing].billable && plan[:billable]
+            @warnings << "Harvest marks #{project_label(plan)} billable, but the Miru project is non-billable"
+          end
+        end
+        @rows.each { |row| plan_row(row) }
+        @summary = build_summary
+      end
+
+      def load_database_duplicates
+        project_ids = @project_plans.values.filter_map { |plan| plan[:existing]&.id }.uniq
+        work_dates = @rows.filter_map { |row| parse_date(row[:date]) }
+        @database_duplicates = if project_ids.empty? || work_dates.empty?
+          Set.new
+        else
+          TimesheetEntry.kept.joins(project: :client)
+            .merge(Project.kept)
+            .merge(Client.kept)
+            .where(project_id: project_ids, work_date: work_dates.min..work_dates.max, source: "import")
+            .pluck(:user_id, :project_id, :work_date, :duration, :note)
+            .map { |values| duplicate_key(*values) }
+            .to_set
+        end
+      end
+
+      def build_entity_plans
+        @rows.each do |row|
+          next if row[:client_name].blank? || row[:project_name].blank?
+
+          original_name = row[:client_name]
+          client_name = original_name[0, 30]
+          @warnings << "Client name truncated: #{original_name.truncate(80)}" if original_name.length > 30
+          client_key = key(client_name)
+          client_plan = @client_plans[client_key] ||= {
+            name: client_name,
+            existing: @existing_clients[client_key],
+            currency: row[:currency]
+          }
+          @warnings << "Restored archived client: #{client_name}" if client_plan[:existing]&.discarded?
+
+          original_project_name = row[:project_name]
+          project_name = original_project_name[0, 30]
+          @warnings << "Project name truncated: #{original_project_name.truncate(80)}" if original_project_name.length > 30
+          project_key = [client_key, key(project_name)]
+          existing_project = client_plan[:existing] && @existing_projects[[client_plan[:existing].id, key(project_name)]]
+          row[:project_plan] = @project_plans[project_key] ||= {
+            name: project_name,
+            client: client_plan,
+            existing: existing_project,
+            billable: false,
+            code: nil
+          }
+          project_plan = row[:project_plan]
+          @warnings << "Restored archived project: #{project_label(project_plan)}" if project_plan[:existing]&.discarded?
+          project_plan[:billable] ||= row[:billable]
+          project_plan[:code] ||= row[:project_code].presence
+        end
+      end
+
+      def plan_row(row)
+        error = row_error(row)
+        return add_row_error(row, error) if error
+
+        duration = duration_in_minutes(row[:hours])
+        return add_row_error(row, "Hours is invalid") unless duration
+        if duration <= 0
+          @zero_hour_rows += 1
+          return
+        end
+
+        work_date = parse_date(row[:date])
+        return add_row_error(row, "Date is invalid: #{row[:date]}") unless work_date
+
+        user = resolved_user(row[:user_name])
+        unless user
+          message = if ambiguous_user?(row[:user_name])
+            "Harvest user \"#{row[:user_name]}\" matches more than one team member; pass --map \"#{row[:user_name]}=their@email\"."
+          else
+            "No team member in this Miru workspace matches Harvest user \"#{row[:user_name]}\". Invite them, or pass --map \"#{row[:user_name]}=their@email\"."
+          end
+          return add_row_error(
+            row,
+            message
+          )
+        end
+
+        project_plan = row[:project_plan]
+        project = project_plan[:existing]
+        bill_status = bill_status(row, project_plan)
+
+        if project && @database_duplicates.include?(duplicate_key(user.id, project.id, work_date, duration, row[:note]))
+          @duplicate_rows += 1
+          return
+        end
+
+        @planned_rows << row.merge(
+          user:,
+          project_plan:,
+          work_date:,
+          duration:,
+          bill_status:
+        )
+      end
+
+      def row_error(row)
+        return "Client is blank" if row[:client_name].blank?
+        return "Project is blank" if row[:project_name].blank?
+        "First Name and Last Name are blank" if row[:user_name].blank?
+      end
+
+      def duration_in_minutes(hours)
+        decimal = BigDecimal(hours, exception: false)
+        (decimal * 60).round if decimal&.finite?
+      end
+
+      def parse_date(value)
+        Date.iso8601(value)
+      rescue Date::Error
+        formats = [DATE_FORMATS[company.date_format], "%m/%d/%Y"].compact.uniq
+        formats.each do |format|
+          return Date.strptime(value, format)
+        rescue Date::Error
+          next
+        end
+        nil
+      end
+
+      def resolved_user(name)
+        name_key = key(name)
+        mapped_user = @users_by_email[key(@user_map[name_key])]
+        return mapped_user if mapped_user
+
+        matching_users = @users_by_name.fetch(name_key, [])
+        return if matching_users.many?
+
+        matching_users.first || @assigned_user
+      end
+
+      def ambiguous_user?(name)
+        !@users_by_email.key?(key(@user_map[key(name)])) && @users_by_name.fetch(key(name), []).many?
+      end
+
+      def bill_status(row, project_plan)
+        project_billable = project_plan[:existing]&.billable || (!project_plan[:existing] && project_plan[:billable])
+        if row[:billable] && project_billable
+          row[:invoiced] ? "billed" : "unbilled"
+        else
+          "non_billable"
+        end
+      end
+
+      def add_row_error(row, message)
+        @failed_rows += 1
+        if @row_errors.length < DataImport::MAX_ROW_ERRORS
+          @row_errors << { "row" => row[:row], "message" => message }
+        end
+      end
+
+      def build_summary
+        dates = @rows.filter_map { |row| parse_date(row[:date]) }
+        names = @rows.pluck(:user_name).compact_blank.uniq.sort
+        matched, unmatched = names.partition { |name| resolved_user(name) }
+        matched = matched.index_with { |name| resolved_user(name).email }
+        existing_clients = @client_plans.values.filter_map { |plan| plan[:existing]&.name }.sort
+        new_clients = @client_plans.values.reject { |plan| plan[:existing] }.pluck(:name).sort.first(200)
+        existing_projects = @project_plans.values.filter_map do |plan|
+          project_label(plan) if plan[:existing]
+        end.sort
+        new_projects = @project_plans.values.reject do |plan|
+          plan[:existing]
+        end.map { |plan| project_label(plan) }.sort.first(200)
+
+        {
+          "rows" => @rows.length,
+          "entries_to_create" => @planned_rows.length,
+          "duplicates_skipped" => @duplicate_rows,
+          "zero_hour_skipped" => @zero_hour_rows,
+          "clients" => { "existing" => existing_clients, "to_create" => new_clients },
+          "projects" => { "existing" => existing_projects, "to_create" => new_projects },
+          "users" => { "matched" => matched, "unmatched" => unmatched.first(200) },
+          "date_range" => { "from" => dates.min&.iso8601, "to" => dates.max&.iso8601 },
+          "warnings" => @warnings.to_a.sort
+        }
+      end
+
+      def persist_entries
+        create_clients_and_projects
+        create_project_members
+
+        processed_rows = 0
+        @planned_rows.each_slice(500) do |rows|
+          ActiveRecord::Base.transaction do
+            rows.each do |row|
+              begin
+                ActiveRecord::Base.transaction(requires_new: true) { create_entry(row) }
+              rescue ActiveRecord::RecordInvalid => error
+                add_row_error(row, error.record.errors.full_messages.to_sentence)
+              end
+              processed_rows += 1
+              persist_progress if (processed_rows % 200).zero?
+            end
+          end
+        end
+
+        @summary["entries_created"] = @imported_rows
+        @summary["entries_failed"] = @failed_rows
+      end
+
+      def persist_plan
+        data_import.update!(
+          total_rows: @rows.length,
+          failed_rows: @failed_rows,
+          skipped_rows: @zero_hour_rows + @duplicate_rows,
+          summary: @summary,
+          row_errors: @row_errors
+        )
+      end
+
+      def create_clients_and_projects
+        ActiveRecord::Base.transaction do
+          @client_plans.each_value do |plan|
+            plan[:record] = plan[:existing] || company.clients.create!(name: plan[:name], currency: plan[:currency])
+            plan[:record].undiscard! if plan[:record].discarded?
+          end
+
+          @project_plans.each_value do |plan|
+            plan[:record] = plan[:existing] || plan[:client][:record].projects.create!(
+              name: plan[:name],
+              billable: plan[:billable],
+              description: plan[:code] && "Harvest project code: #{plan[:code]}"
+            )
+            plan[:record].undiscard! if plan[:record].discarded?
+          end
+        end
+      end
+
+      def create_project_members
+        pairs = @planned_rows.each_with_object({}) do |row, result|
+          result[[row[:project_plan][:record].id, row[:user].id]] ||= row
+        end
+        existing = ProjectMember.kept.where(project_id: pairs.keys.map(&:first), user_id: pairs.keys.map(&:last))
+          .pluck(:project_id, :user_id)
+          .to_set
+
+        pairs.each do |(project_id, user_id), row|
+          next if existing.include?([project_id, user_id])
+
+          ProjectMember.create!(project_id:, user_id:, hourly_rate: row[:hourly_rate])
+        end
+      end
+
+      def create_entry(row)
+        project = row[:project_plan][:record]
+        entry = TimesheetEntry.create!(
+          project:,
+          user: row[:user],
+          duration: row[:duration],
+          work_date: row[:work_date],
+          note: row[:note],
+          bill_status: row[:bill_status] == "billed" ? "unbilled" : row[:bill_status],
+          source: "import",
+          source_metadata: { tool: "harvest" }
+        ) do |timesheet_entry|
+          timesheet_entry.association(:company).target = company
+        end
+        entry.update!(bill_status: :billed) if row[:bill_status] == "billed"
+        @imported_rows += 1
+      end
+
+      def persist_progress
+        data_import.update!(imported_rows: @imported_rows, failed_rows: @failed_rows, row_errors: @row_errors)
+      end
+
+      def complete_import
+        imported_rows = data_import.dry_run? ? 0 : @imported_rows
+        data_import.update!(
+          status: "completed",
+          finished_at: Time.current,
+          total_rows: @rows.length,
+          imported_rows:,
+          failed_rows: @failed_rows,
+          skipped_rows: @zero_hour_rows + @duplicate_rows,
+          summary: @summary,
+          row_errors: @row_errors
+        )
+        data_import.file.purge_later unless data_import.dry_run?
+      end
+
+      def duplicate_key(user_id, project_id, work_date, duration, note)
+        Digest::SHA1.hexdigest([user_id, project_id, work_date.to_date, duration.to_f, note].join("|"))
+      end
+
+      def project_label(plan)
+        "#{plan[:client][:name]} / #{plan[:name]}"
+      end
+
+      def key(value)
+        value.to_s.strip.downcase
+      end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,15 @@ en:
     stripe:
       connect_not_enabled: Stripe Connect is not enabled for this Stripe account. Enable Connect in Stripe Dashboard and try again.
       generic: "%{message}"
+  imports:
+    errors:
+      csv_required: File must be a CSV
+      file_required: File is required
+      file_too_large: File must be 20 MB or smaller
+      invalid_csv: "Invalid CSV: %{message}"
+      invalid_user_map: User mappings must use First Last=email
+      missing_headers: "Missing required headers: %{headers}"
+      unexpected: Import failed. Support has been notified.
   avatar:
     destroy:
       success: Avatar deleted successfully

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -37,7 +37,6 @@ namespace :api, defaults: { format: "json" } do
     end
 
     resource :chatbase_token, only: [:show]
-
     resources :clients, only: [:index, :update, :destroy, :show, :create] do
       collection do
         get "invoices", to: "clients/invoices#index"
@@ -59,6 +58,7 @@ namespace :api, defaults: { format: "json" } do
         resource :bulk_action, only: [:update, :destroy], controller: "timesheet_entry/bulk_action"
       end
     end
+    resources :imports, only: [:create, :show]
     namespace :cli do
       resource :capabilities, only: [:show], controller: "capabilities"
       resource :session, only: [:destroy], controller: "sessions"

--- a/db/migrate/20260905000000_create_data_imports.rb
+++ b/db/migrate/20260905000000_create_data_imports.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateDataImports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :data_imports do |t|
+      t.references :company, null: false, foreign_key: true, index: false
+      t.references :user, null: false, foreign_key: true
+      t.string :source, null: false
+      t.string :kind, null: false, default: "time_entries"
+      t.string :status, null: false, default: "pending"
+      t.boolean :dry_run, null: false, default: false
+      t.jsonb :options, null: false, default: {}
+      t.integer :total_rows, null: false, default: 0
+      t.integer :imported_rows, null: false, default: 0
+      t.integer :failed_rows, null: false, default: 0
+      t.integer :skipped_rows, null: false, default: 0
+      t.jsonb :summary, null: false, default: {}
+      t.jsonb :row_errors, null: false, default: []
+      t.text :error_message
+      t.datetime :started_at
+      t.datetime :finished_at
+
+      t.timestamps
+    end
+
+    add_index :data_imports, [:company_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_022000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_05_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -332,6 +332,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_022000) do
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["leave_id"], name: "index_custom_leaves_on_leave_id"
+  end
+
+  create_table "data_imports", force: :cascade do |t|
+    t.bigint "company_id", null: false
+    t.datetime "created_at", null: false
+    t.boolean "dry_run", default: false, null: false
+    t.text "error_message"
+    t.integer "failed_rows", default: 0, null: false
+    t.datetime "finished_at"
+    t.integer "imported_rows", default: 0, null: false
+    t.string "kind", default: "time_entries", null: false
+    t.jsonb "options", default: {}, null: false
+    t.jsonb "row_errors", default: [], null: false
+    t.integer "skipped_rows", default: 0, null: false
+    t.string "source", null: false
+    t.datetime "started_at"
+    t.string "status", default: "pending", null: false
+    t.jsonb "summary", default: {}, null: false
+    t.integer "total_rows", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["company_id", "created_at"], name: "index_data_imports_on_company_id_and_created_at"
+    t.index ["user_id"], name: "index_data_imports_on_user_id"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
@@ -1206,6 +1229,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_022000) do
   add_foreign_key "custom_leave_users", "custom_leaves", column: "custom_leave_id"
   add_foreign_key "custom_leave_users", "users"
   add_foreign_key "custom_leaves", "leaves", column: "leave_id"
+  add_foreign_key "data_imports", "companies"
+  add_foreign_key "data_imports", "users"
   add_foreign_key "desktop_current_timers", "companies"
   add_foreign_key "desktop_current_timers", "users"
   add_foreign_key "devices", "companies"

--- a/docs/miru-cli.md
+++ b/docs/miru-cli.md
@@ -328,6 +328,47 @@ Example:
 miru time delete --id 631
 ```
 
+## Import Commands
+
+Export a Harvest Detailed Time CSV from **Reports > Detailed Time**, set the range to **All Time**, then choose **Export > CSV**.
+
+Run a dry run first. The dry run runs in the background and the CLI waits for it to finish:
+
+```bash
+miru import --file harvest-detailed-time.csv --format harvest --dry-run
+```
+
+Harvest exports names but not email addresses. When a name does not exactly match a Miru team member, map it to an existing workspace email. `--map` can be repeated:
+
+```bash
+miru import \
+  --file harvest-detailed-time.csv \
+  --format harvest \
+  --dry-run \
+  --map "Paul Connors=paul@example.com" \
+  --map "Jane Doe=jane@example.com"
+```
+
+To assign every otherwise unmatched Harvest user to one team member:
+
+```bash
+miru import --file harvest-detailed-time.csv --format harvest --dry-run --assign-unmatched-to owner@example.com
+```
+
+After the dry run is clean, omit `--dry-run` to start the import. The CLI polls until it completes:
+
+```bash
+miru import --file harvest-detailed-time.csv --format harvest --map "Paul Connors=paul@example.com"
+```
+
+Time entries are the default and only supported import type. `--type time` may be supplied explicitly.
+
+Check an existing import:
+
+```bash
+miru import status --id 42
+```
+
 ## Invoice Commands
 
 ### `miru invoice list`
@@ -538,6 +579,8 @@ miru invoice send --id 1 --recipients client@example.com
 - `miru invoice send` -> `POST /api/v1/invoices/:id/send_invoice`
 - `miru payment list` -> `GET /api/v1/payments`
 - `miru payment show` -> `GET /api/v1/payments/:id`
+- `miru import` -> `POST /api/v1/imports`
+- `miru import status` -> `GET /api/v1/imports/:id`
 - `miru time list` -> `GET /api/v1/timesheet_entry`
 - `miru time create` -> `POST /api/v1/cli/timesheet_entries`
 - `miru time update` -> `PATCH /api/v1/cli/timesheet_entries/:id`
@@ -597,6 +640,7 @@ Current supported CLI surface:
 - expenses: `expense list`, `expense create`
 - invoices: `invoice list`, `invoice create`, `invoice show`, `invoice send`
 - payments: `payment list`, `payment show`
+- imports: `import`, `import status`
 
 MCP parity:
 

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :imports do
+  task :harvest_time_entries, [:company_id, :actor_email, :csv_path, :dry_run] => :environment do |_task, args|
+    company = Company.find(args[:company_id])
+    actor = company.users.merge(Employment.kept).find_by!("LOWER(users.email) = ?", args[:actor_email].to_s.downcase)
+    data_import = company.data_imports.create!(
+      user: actor,
+      source: "harvest",
+      dry_run: ActiveModel::Type::Boolean.new.cast(args[:dry_run])
+    )
+    File.open(args[:csv_path]) do |file|
+      data_import.file.attach(io: file, filename: File.basename(args[:csv_path]), content_type: "text/csv")
+    end
+    Imports::HarvestTimeEntriesImporter.new(data_import).process
+    puts JSON.pretty_generate(data_import.summary)
+  end
+end

--- a/spec/factories/data_imports.rb
+++ b/spec/factories/data_imports.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: data_imports
+#
+#  id            :bigint           not null, primary key
+#  dry_run       :boolean          default(FALSE), not null
+#  error_message :text
+#  failed_rows   :integer          default(0), not null
+#  finished_at   :datetime
+#  imported_rows :integer          default(0), not null
+#  kind          :string           default("time_entries"), not null
+#  options       :jsonb            not null
+#  row_errors    :jsonb            not null
+#  skipped_rows  :integer          default(0), not null
+#  source        :string           not null
+#  started_at    :datetime
+#  status        :string           default("pending"), not null
+#  summary       :jsonb            not null
+#  total_rows    :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  company_id    :bigint           not null
+#  user_id       :bigint           not null
+#
+# Indexes
+#
+#  index_data_imports_on_company_id_and_created_at  (company_id,created_at)
+#  index_data_imports_on_user_id                    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (company_id => companies.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :data_import do
+    company
+    user
+    source { "harvest" }
+    kind { "time_entries" }
+    status { "pending" }
+    dry_run { false }
+    options { {} }
+  end
+end

--- a/spec/fixtures/files/harvest_detailed_time.csv
+++ b/spec/fixtures/files/harvest_detailed_time.csv
@@ -1,0 +1,14 @@
+﻿Date,Client,Project,Project Code,Task,Notes,Hours,Billable?,Invoiced?,Approved?,First Name,Last Name,Employee Id,Roles,Teams,Employee?,Billable Rate,Billable Amount,Cost Rate,Cost Amount,Currency,External Reference URL
+2026-01-02,Acme LLC,Website,WEB,Programming,"Built landing
+and tests",1.25,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,187.50,80,100,United States Dollar - USD,https://example.test/1
+2026-01-03,Acme LLC,Website,WEB,Design,Wireframes,25.38,Yes,Yes,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,3807,80,2030.40,United States Dollar - USD,https://example.test/2
+2026-01-04,Acme LLC,Internal,INT,Administration,Payroll,0.5,No,No,Yes,Jane,Doe,2,Operations,Admin,Yes,90,0,40,20,United States Dollar - USD,
+2026-01-05,Very Long Client Name That Exceeds Thirty Characters,Advisory,ADV,Research,Memo,1.333,Yes,No,Yes,Jane,Doe,2,Consultant,Delivery,Yes,120,159.96,60,79.98,United States Dollar - USD,
+2026-01-05,Acme LLC,Website,WEB,Programming,Skipped timer,0,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,0,80,0,United States Dollar - USD,
+01/06/2026,Acme LLC,Website,WEB,Review,Final review,0.5,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,75,80,40,United States Dollar - USD,
+01-07-2026,Acme LLC,Website,WEB,Review,Client feedback,0.75,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,112.50,80,60,United States Dollar - USD,
+2026-01-08,Acme LLC,Website,WEB,Meeting,Daily sync,0.5,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,75,80,40,United States Dollar - USD,
+2026-01-08,Acme LLC,Website,WEB,Meeting,Daily sync,0.5,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,75,80,40,United States Dollar - USD,
+2026-01-09,Acme LLC,Internal,INT,Administration,Planning,0.25,No,Yes,Yes,Jane,Doe,2,Operations,Admin,Yes,90,0,40,10,United States Dollar - USD,
+2026-01-10,Very Long Client Name That Exceeds Thirty Characters,Advisory,ADV,Research,Follow-up,2,No,No,Yes,Jane,Doe,2,Consultant,Delivery,Yes,120,0,60,120,United States Dollar - USD,
+2026-01-11,Acme LLC,Website,WEB,Programming,Polish,1.1,Yes,No,Yes,Paul,Connors,1,Developer,Delivery,Yes,150,165,80,88,United States Dollar - USD,

--- a/spec/fixtures/files/harvest_missing_headers.csv
+++ b/spec/fixtures/files/harvest_missing_headers.csv
@@ -1,0 +1,2 @@
+Date,Client
+2026-01-01,Acme LLC

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataImportJob, type: :job do
+  let(:company) { create(:company) }
+  let(:actor) { create(:user, current_workspace_id: company.id) }
+  let(:data_import) { create(:data_import, company:, user: actor, dry_run: true, options: { "assign_unmatched_to" => actor.email }) }
+
+  before do
+    create(:employment, company:, user: actor)
+    File.open(Rails.root.join("spec/fixtures/files/harvest_detailed_time.csv")) do |file|
+      data_import.file.attach(io: file, filename: "harvest.csv", content_type: "text/csv")
+    end
+  end
+
+  it "runs the importer" do
+    described_class.perform_now(data_import.id)
+
+    expect(data_import.reload).to have_attributes(status: "completed", total_rows: 12)
+  end
+
+  it "marks the import failed and re-raises an error" do
+    importer = Imports::HarvestTimeEntriesImporter.new(data_import)
+    allow(Imports::HarvestTimeEntriesImporter).to receive(:new).with(data_import).and_return(importer)
+    allow(importer).to receive(:load_rows).and_raise("database credentials exposed")
+
+    expect do
+      described_class.perform_now(data_import.id)
+    end.to raise_error(RuntimeError, "database credentials exposed")
+
+    expect(data_import.reload).to have_attributes(
+      status: "failed",
+      error_message: "Import failed. Support has been notified."
+    )
+  end
+end

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -164,6 +164,13 @@ RSpec.describe TimesheetEntry, type: :model do
   end
 
   describe "source normalization" do
+    it "preserves the explicit import source when tool metadata is present" do
+      timesheet_entry.assign_attributes(source: "import", source_metadata: { tool: "harvest" })
+      timesheet_entry.valid?
+
+      expect(timesheet_entry.source).to eq("import")
+    end
+
     it "normalizes blank and unknown sources to manual" do
       timesheet_entry.assign_attributes(source: "unknown", source_metadata: { tool: "", skill: nil, extra: "ignore-me" })
       timesheet_entry.valid?

--- a/spec/requests/api/v1/imports/create_spec.rb
+++ b/spec/requests/api/v1/imports/create_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Imports#create", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:cli_token) { CliSession.issue_for(user:, company:).last }
+  let(:headers) { cli_auth_headers(cli_token) }
+  let(:file) do
+    fixture_file_upload(
+      Rails.root.join("spec/fixtures/files/harvest_detailed_time.csv"),
+      "text/csv"
+    )
+  end
+
+  before do
+    create(:employment, company:, user:)
+  end
+
+  it "enqueues an admin dry run" do
+    user.add_role :admin, company
+
+    expect do
+      send_request :post, api_v1_imports_path, params: {
+        file:,
+        source: "harvest",
+        dry_run: "true",
+        assign_unmatched_to: user.email
+      }, headers: headers
+    end.to have_enqueued_job(DataImportJob)
+
+    expect(response).to have_http_status(:accepted)
+    expect(json_response).to include("status" => "pending", "dry_run" => true)
+  end
+
+  it "enqueues an admin real import" do
+    user.add_role :admin, company
+
+    expect do
+      send_request :post, api_v1_imports_path, params: {
+        file:,
+        source: "harvest"
+      }, headers: headers
+    end.to have_enqueued_job(DataImportJob)
+
+    expect(response).to have_http_status(:accepted)
+    expect(json_response).to include("status" => "pending", "dry_run" => false)
+  end
+
+  it "allows an owner to create an import" do
+    user.add_role :owner, company
+
+    send_request :post, api_v1_imports_path, params: {
+      file:,
+      source: "harvest",
+      dry_run: "true",
+      assign_unmatched_to: user.email
+    }, headers: headers
+
+    expect(response).to have_http_status(:accepted)
+  end
+
+  it "stores array user mappings in the import options" do
+    user.add_role :admin, company
+
+    send_request :post, api_v1_imports_path, params: {
+      file:,
+      source: "harvest",
+      user_map: ["Paul Connors=paul@example.com", "Jane Doe=jane@example.com"]
+    }, headers: headers
+
+    expect(response).to have_http_status(:accepted)
+    expect(DataImport.last.options["user_map"]).to eq(
+      "Paul Connors" => "paul@example.com",
+      "Jane Doe" => "jane@example.com"
+    )
+  end
+
+  it "stores JSON object user mappings in the import options" do
+    user.add_role :admin, company
+
+    send_request :post, api_v1_imports_path, params: {
+      file:,
+      source: "harvest",
+      user_map: { "Paul Connors" => "paul@example.com" }.to_json
+    }, headers: headers
+
+    expect(response).to have_http_status(:accepted)
+    expect(DataImport.last.options["user_map"]).to eq("Paul Connors" => "paul@example.com")
+  end
+
+  it "forbids an employee" do
+    user.add_role :employee, company
+
+    send_request :post, api_v1_imports_path, params: { file:, source: "harvest" }, headers: headers
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "returns an unprocessable response when the file is missing" do
+    user.add_role :admin, company
+
+    send_request :post, api_v1_imports_path, params: { source: "harvest" }, headers: headers
+
+    expect(response).to have_http_status(422)
+    expect(json_response).to eq("errors" => "File is required")
+  end
+
+  it "returns an unprocessable response for a malformed user mapping" do
+    user.add_role :admin, company
+
+    send_request :post, api_v1_imports_path, params: {
+      file:,
+      source: "harvest",
+      user_map: ["Paul Connors"]
+    }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json_response).to eq("errors" => "User mappings must use First Last=email")
+  end
+
+  it "returns an unprocessable response for more than 500 user mappings" do
+    user.add_role :admin, company
+
+    send_request :post, api_v1_imports_path, params: {
+      file:,
+      source: "harvest",
+      user_map: Array.new(501) { |index| "Person #{index}=person#{index}@example.com" }
+    }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json_response).to eq("errors" => "User mappings must use First Last=email")
+  end
+
+  it "returns an unprocessable response for a non-CSV file" do
+    user.add_role :admin, company
+    text_file = Rack::Test::UploadedFile.new(
+      Rails.root.join("spec/fixtures/files/harvest_detailed_time.csv"),
+      "text/plain",
+      original_filename: "harvest.txt"
+    )
+
+    send_request :post, api_v1_imports_path, params: { file: text_file, source: "harvest" }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json_response).to eq("errors" => "File must be a CSV")
+  end
+
+  it "returns an unprocessable response for an oversized file" do
+    user.add_role :admin, company
+    allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(20.megabytes + 1)
+
+    send_request :post, api_v1_imports_path, params: { file:, source: "harvest" }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json_response).to eq("errors" => "File must be 20 MB or smaller")
+  end
+
+  it "returns an unprocessable response when required headers are missing" do
+    user.add_role :admin, company
+    invalid_file = fixture_file_upload(
+      Rails.root.join("spec/fixtures/files/harvest_missing_headers.csv"),
+      "text/csv"
+    )
+
+    send_request :post, api_v1_imports_path, params: {
+      file: invalid_file,
+      source: "harvest"
+    }, headers: headers
+
+    expect(response).to have_http_status(422)
+    expect(json_response["errors"]).to include("Missing required headers")
+  end
+end

--- a/spec/requests/api/v1/imports/show_spec.rb
+++ b/spec/requests/api/v1/imports/show_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Imports#show", type: :request do
+  let(:company) { create(:company) }
+  let(:user) { create(:user, current_workspace_id: company.id) }
+  let(:cli_token) { CliSession.issue_for(user:, company:).last }
+
+  before do
+    create(:employment, company:, user:)
+    user.add_role :admin, company
+  end
+
+  it "shows an import from the current company" do
+    data_import = create(:data_import, company:, user:, summary: { "rows" => 12 })
+
+    send_request :get, api_v1_import_path(data_import), headers: cli_auth_headers(cli_token)
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response).to include("id" => data_import.id, "summary" => { "rows" => 12 })
+  end
+
+  it "returns not found for another company's import" do
+    other_company = create(:company)
+    other_user = create(:user, current_workspace_id: other_company.id)
+    data_import = create(:data_import, company: other_company, user: other_user)
+
+    send_request :get, api_v1_import_path(data_import), headers: cli_auth_headers(cli_token)
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "forbids an employee from showing an import" do
+    user.remove_role :admin, company
+    user.add_role :employee, company
+    data_import = create(:data_import, company:, user:)
+
+    send_request :get, api_v1_import_path(data_import), headers: cli_auth_headers(cli_token)
+
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/spec/services/imports/harvest_time_entries_importer_spec.rb
+++ b/spec/services/imports/harvest_time_entries_importer_spec.rb
@@ -1,0 +1,307 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Imports::HarvestTimeEntriesImporter do
+  let(:company) { create(:company, base_currency: "INR", date_format: "MM-DD-YYYY") }
+  let(:actor) { create(:user, current_workspace_id: company.id) }
+  let(:paul) { create(:user, first_name: "Paul", last_name: "Connors", email: "paul@example.com", current_workspace_id: company.id) }
+  let(:jane) { create(:user, first_name: "Jane", last_name: "Doe", email: "jane@example.com", current_workspace_id: company.id) }
+  let(:data_import) { create(:data_import, company:, user: actor, options:) }
+  let(:options) { {} }
+  let(:fixture_path) { Rails.root.join("spec/fixtures/files/harvest_detailed_time.csv") }
+
+  before do
+    create(:employment, company:, user: actor)
+    create(:employment, company:, user: paul)
+    create(:employment, company:, user: jane)
+    attach_csv(data_import, fixture_path)
+  end
+
+  it "creates clients, projects, members, and entries with Harvest values" do
+    described_class.new(data_import).process
+
+    expect(data_import.reload).to have_attributes(
+      status: "completed",
+      total_rows: 12,
+      imported_rows: 11,
+      failed_rows: 0,
+      skipped_rows: 1
+    )
+    expect(company.clients.kept.pluck(:name)).to contain_exactly("Acme LLC", "Very Long Client Name That Exc")
+    expect(company.projects.kept.count).to eq(3)
+    expect(ProjectMember.kept.joins(project: :client).where(clients: { company_id: company.id }).count).to eq(3)
+
+    website = company.projects.kept.find_by!(name: "Website")
+    expect(website).to have_attributes(billable: true, description: "Harvest project code: WEB")
+    expect(website.timesheet_entries.kept.where(note: "Meeting - Daily sync").count).to eq(2)
+
+    first_entry = website.timesheet_entries.kept.find_by!(note: "Programming - Built landing\nand tests")
+    expect(first_entry).to have_attributes(duration: 75, bill_status: "unbilled", source: "import")
+    expect(first_entry.source_metadata).to eq("tool" => "harvest")
+    expect(website.timesheet_entries.kept.find_by!(duration: 1523)).to be_billed
+    internal = company.projects.kept.find_by!(name: "Internal")
+    expect(internal).not_to be_billable
+    expect(internal.timesheet_entries.kept).to all(be_non_billable)
+    expect(company.clients.kept.find_by!(name: "Very Long Client Name That Exc").currency).to eq("USD")
+    expect(website.project_members.kept.find_by!(user: paul).hourly_rate).to eq(150)
+  end
+
+  it "avoids per-row project membership and company queries" do
+    select_queries = 0
+    project_member_queries = 0
+    company_queries = 0
+    subscriber = lambda do |*, payload|
+      sql = payload[:sql]
+      next unless sql.start_with?("SELECT")
+
+      select_queries += 1
+      project_member_queries += 1 if sql.include?('FROM "project_members"')
+      company_queries += 1 if sql.include?('FROM "companies"')
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      described_class.new(data_import).process
+    end
+
+    expect(select_queries).to be < 66
+    expect(project_member_queries).to be < 6
+    expect(company_queries).to be < 6
+  end
+
+  it "matches users by name and rounds decimal hours to minutes" do
+    described_class.new(data_import).process
+
+    advisory = company.projects.kept.find_by!(name: "Advisory")
+    entry = advisory.timesheet_entries.kept.find_by!(note: "Research - Memo")
+    expect(entry).to have_attributes(user: jane, duration: 80)
+    expect(data_import.reload.summary.dig("users", "matched")).to include(
+      "Jane Doe" => "jane@example.com",
+      "Paul Connors" => "paul@example.com"
+    )
+  end
+
+  context "with a user map" do
+    let(:jane) { create(:user, first_name: "Janet", last_name: "Smith", email: "jane@example.com", current_workspace_id: company.id) }
+    let(:options) { { "user_map" => { "Jane Doe" => "jane@example.com" } } }
+
+    it "maps a Harvest name to a workspace email" do
+      described_class.new(data_import).process
+
+      expect(company.projects.kept.find_by!(name: "Advisory").timesheet_entries.kept.pluck(:user_id)).to all(eq(jane.id))
+    end
+  end
+
+  context "with an unmatched user" do
+    before { jane.employments.find_by!(company:).discard! }
+
+    it "records an error for every unmatched row and continues" do
+      described_class.new(data_import).process
+
+      expect(data_import.reload).to have_attributes(status: "completed", imported_rows: 7, failed_rows: 4)
+      expect(data_import.row_errors).to all(include("message" => include("No team member in this Miru workspace matches Harvest user \"Jane Doe\"")))
+      expect(data_import.summary.dig("users", "unmatched")).to eq(["Jane Doe"])
+    end
+  end
+
+  context "with an ambiguous user name" do
+    before do
+      duplicate = create(:user, first_name: "paul", last_name: "CONNORS", current_workspace_id: company.id)
+      create(:employment, company:, user: duplicate)
+    end
+
+    it "requires an explicit user mapping" do
+      described_class.new(data_import).process
+
+      messages = data_import.reload.row_errors.pluck("message")
+      expect(messages).to all(eq(
+        "Harvest user \"Paul Connors\" matches more than one team member; pass --map \"Paul Connors=their@email\"."
+      ))
+      expect(data_import.summary.dig("users", "unmatched")).to include("Paul Connors")
+    end
+  end
+
+  context "with assign_unmatched_to" do
+    let(:fallback) { create(:user, first_name: "Fallback", last_name: "User", email: "fallback@example.com", current_workspace_id: company.id) }
+    let(:options) { { "assign_unmatched_to" => "fallback@example.com" } }
+
+    before do
+      jane.employments.find_by!(company:).discard!
+      create(:employment, company:, user: fallback)
+    end
+
+    it "assigns otherwise unmatched rows to the selected user" do
+      described_class.new(data_import).process
+
+      expect(data_import.reload.failed_rows).to eq(0)
+      expect(company.projects.kept.find_by!(name: "Advisory").timesheet_entries.kept.pluck(:user_id)).to all(eq(fallback.id))
+    end
+  end
+
+  context "with a dry run" do
+    let(:data_import) { create(:data_import, company:, user: actor, options:, dry_run: true) }
+
+    it "only writes import bookkeeping and reports the plan" do
+      expect do
+        described_class.new(data_import).process
+      end.not_to change { [Client.count, Project.count, ProjectMember.count, TimesheetEntry.count] }
+
+      expect(data_import.reload).to have_attributes(status: "completed", imported_rows: 0, skipped_rows: 1)
+      expect(data_import.summary).to include(
+        "rows" => 12,
+        "entries_to_create" => 11,
+        "zero_hour_skipped" => 1,
+        "duplicates_skipped" => 0
+      )
+      expect(data_import.summary.dig("clients", "to_create")).to contain_exactly("Acme LLC", "Very Long Client Name That Exc")
+      expect(data_import.summary.dig("projects", "to_create")).to contain_exactly(
+        "Acme LLC / Internal",
+        "Acme LLC / Website",
+        "Very Long Client Name That Exc / Advisory"
+      )
+      expect(data_import.summary.dig("date_range")).to eq("from" => "2026-01-02", "to" => "2026-01-11")
+      expect(data_import.summary).not_to have_key("row_errors")
+    end
+  end
+
+  it "matches users, clients, and projects case-insensitively" do
+    paul.update!(first_name: "PAUL", last_name: "connors")
+    client = create(:client, company:, name: "acme llc")
+    project = create(:project, client:, name: "website", billable: true)
+
+    described_class.new(data_import).process
+
+    expect(company.clients.where("LOWER(name) = ?", "acme llc").count).to eq(1)
+    expect(client.projects.where("LOWER(name) = ?", "website").count).to eq(1)
+    expect(project.timesheet_entries.kept.where(user: paul)).to exist
+  end
+
+  it "parses dates using the company day-month-year format" do
+    company.update!(date_format: "DD-MM-YYYY")
+    attach_csv_contents(data_import, <<~CSV)
+      Date,Client,Project,Hours,First Name,Last Name
+      07-01-2026,Acme LLC,Website,1,Paul,Connors
+    CSV
+
+    described_class.new(data_import).process
+
+    expect(TimesheetEntry.kept.last.work_date).to eq(Date.new(2026, 1, 7))
+  end
+
+  it "records invalid hours, date, and blank client rows without creating entries" do
+    attach_csv_contents(data_import, <<~CSV)
+      Date,Client,Project,Hours,First Name,Last Name
+      2026-01-01,Acme LLC,Website,abc,Paul,Connors
+      31-31-2026,Acme LLC,Website,1,Paul,Connors
+      2026-01-03,,Website,1,Paul,Connors
+    CSV
+
+    expect do
+      described_class.new(data_import).process
+    end.not_to change(TimesheetEntry, :count)
+
+    expect(data_import.reload.row_errors).to eq([
+      { "row" => 2, "message" => "Hours is invalid" },
+      { "row" => 3, "message" => "Date is invalid: 31-31-2026" },
+      { "row" => 4, "message" => "Client is blank" }
+    ])
+  end
+
+  it "skips entries already imported without de-duplicating rows within the file" do
+    described_class.new(data_import).process
+    second_import = create(:data_import, company:, user: actor)
+    attach_csv(second_import, fixture_path)
+
+    expect do
+      described_class.new(second_import).process
+    end.not_to change(TimesheetEntry, :count)
+
+    expect(second_import.reload).to have_attributes(imported_rows: 0, skipped_rows: 12)
+    expect(second_import.summary["duplicates_skipped"]).to eq(11)
+    expect(second_import.summary["date_range"]).to eq("from" => "2026-01-02", "to" => "2026-01-11")
+  end
+
+  it "rejects files missing required headers" do
+    invalid_import = create(:data_import, company:, user: actor)
+    invalid_import.file.attach(io: StringIO.new("Date,Client\n2026-01-01,Acme\n"), filename: "invalid.csv", content_type: "text/csv")
+
+    expect do
+      described_class.new(invalid_import).process
+    end.to raise_error(described_class::InvalidFileError, /Missing required headers: Project, Hours, First Name, Last Name/)
+  end
+
+  it "reports client name truncation" do
+    described_class.new(data_import).process
+
+    expect(data_import.reload.summary["warnings"]).to include(
+      "Client name truncated: Very Long Client Name That Exceeds Thirty Characters"
+    )
+  end
+
+  it "truncates project names and reuses a matching project" do
+    client = create(:client, company:, name: "Acme LLC")
+    project = create(:project, client:, name: "A Project Name Longer Than Thi", billable: true)
+    attach_csv_contents(data_import, <<~CSV)
+      Date,Client,Project,Hours,First Name,Last Name,Billable?
+      2026-01-01,Acme LLC,A Project Name Longer Than Thirty Characters,1,Paul,Connors,Yes
+    CSV
+
+    described_class.new(data_import).process
+
+    expect(client.projects.count).to eq(1)
+    expect(project.timesheet_entries.kept).to exist
+    expect(data_import.reload.summary["warnings"]).to include(
+      "Project name truncated: A Project Name Longer Than Thirty Characters"
+    )
+  end
+
+  it "restores an archived client before importing entries" do
+    client = create(:client, company:, name: "Acme LLC")
+    client.discard!
+
+    described_class.new(data_import).process
+
+    expect(client.reload).to be_kept
+    expect(client.projects.kept.find_by!(name: "Website").timesheet_entries.kept).to exist
+    expect(data_import.reload.summary["warnings"]).to include("Restored archived client: Acme LLC")
+  end
+
+  it "restores an archived project before importing entries" do
+    client = create(:client, company:, name: "Acme LLC")
+    project = create(:project, client:, name: "Website", billable: true)
+    project.discard!
+
+    described_class.new(data_import).process
+
+    expect(project.reload).to be_kept
+    expect(project.timesheet_entries.kept).to exist
+    expect(data_import.reload.summary["warnings"]).to include("Restored archived project: Acme LLC / Website")
+  end
+
+  it "schedules the uploaded CSV for purge after a real run" do
+    expect do
+      described_class.new(data_import).process
+    end.to have_enqueued_job(ActiveStorage::PurgeJob).with(data_import.file.blob)
+  end
+
+  it "keeps an existing non-billable project non-billable and warns once" do
+    client = create(:client, company:, name: "Acme LLC")
+    project = create(:project, client:, name: "Website", billable: false)
+
+    described_class.new(data_import).process
+
+    expect(project.timesheet_entries.kept).to all(be_non_billable)
+    warnings = data_import.reload.summary["warnings"].grep(/Acme LLC \/ Website/)
+    expect(warnings).to contain_exactly("Harvest marks Acme LLC / Website billable, but the Miru project is non-billable")
+  end
+
+  def attach_csv(import, path)
+    File.open(path) do |file|
+      import.file.attach(io: file, filename: File.basename(path), content_type: "text/csv")
+    end
+  end
+
+  def attach_csv_contents(import, contents)
+    import.file.attach(io: StringIO.new(contents), filename: "harvest.csv", content_type: "text/csv")
+  end
+end

--- a/tools/miru-cli/README.md
+++ b/tools/miru-cli/README.md
@@ -73,11 +73,31 @@ miru invoice show --id <id>
 miru invoice send --id <id> --recipients <email1,email2> [--subject <text>] [--message <text>]
 miru payment list [--query <term>]
 miru payment show --id <id>
+miru import --file <path> --format harvest [--type time] [--dry-run] [--map "First Last=email"]... [--assign-unmatched-to <email>]
+miru import status --id <id>
 miru time list --from <YYYY-MM-DD> --to <YYYY-MM-DD>
 miru time create --project-id <id> --duration <minutes> --date <YYYY-MM-DD> [--note <text>] [--bill-status <status>]
 miru time update --id <id> --project-id <id> --duration <minutes> --date <YYYY-MM-DD> [--note <text>] [--bill-status <status>]
 miru time delete --id <id>
 ```
+
+## Harvest Import
+
+In Harvest, open **Reports > Detailed Time**, set the range to **All Time**, and choose **Export > CSV**. Preview the import before writing anything:
+
+```bash
+miru import --file harvest-detailed-time.csv --format harvest --dry-run
+```
+
+Map Harvest names that do not exactly match Miru team members by repeating `--map`:
+
+```bash
+miru import --file harvest-detailed-time.csv --format harvest --dry-run \
+  --map "Paul Connors=paul@example.com" \
+  --map "Jane Doe=jane@example.com"
+```
+
+The dry run runs in the background and the CLI waits for it to finish. When the preview is clean, run the same command without `--dry-run`. Use `miru import status --id <id>` to inspect an existing import.
 
 ## Session Behavior
 
@@ -95,7 +115,7 @@ miru config token --format shell
 
 ## Current Scope
 
-Version `0.2.0` supports:
+Version `0.3.0` supports:
 
 - client listing
 - expense list/create
@@ -103,3 +123,4 @@ Version `0.2.0` supports:
 - time list/create/update/delete
 - invoice list/create/show/send
 - payment list/show
+- Harvest time import/status

--- a/tools/miru-cli/cmd/miru/main.go
+++ b/tools/miru-cli/cmd/miru/main.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +21,7 @@ import (
 	"golang.org/x/term"
 )
 
-const version = "0.2.0"
+const version = "0.3.0"
 
 type client struct {
 	baseURL string
@@ -30,6 +32,58 @@ type config struct {
 	BaseURL string `json:"base_url"`
 	Token   string `json:"token"`
 }
+
+type importOptions struct {
+	filePath          string
+	dryRun            bool
+	userMap           []string
+	assignUnmatchedTo string
+}
+
+type importResponse struct {
+	ID           int              `json:"id"`
+	Status       string           `json:"status"`
+	DryRun       bool             `json:"dry_run"`
+	TotalRows    int              `json:"total_rows"`
+	ImportedRows int              `json:"imported_rows"`
+	FailedRows   int              `json:"failed_rows"`
+	Summary      importSummary    `json:"summary"`
+	RowErrors    []importRowError `json:"row_errors"`
+	ErrorMessage string           `json:"error_message"`
+}
+
+type importSummary struct {
+	Rows              int `json:"rows"`
+	EntriesToCreate   int `json:"entries_to_create"`
+	EntriesCreated    int `json:"entries_created"`
+	EntriesFailed     int `json:"entries_failed"`
+	DuplicatesSkipped int `json:"duplicates_skipped"`
+	ZeroHourSkipped   int `json:"zero_hour_skipped"`
+	Clients           struct {
+		Existing []string `json:"existing"`
+		ToCreate []string `json:"to_create"`
+	} `json:"clients"`
+	Projects struct {
+		Existing []string `json:"existing"`
+		ToCreate []string `json:"to_create"`
+	} `json:"projects"`
+	Users struct {
+		Matched   map[string]string `json:"matched"`
+		Unmatched []string          `json:"unmatched"`
+	} `json:"users"`
+	DateRange struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"date_range"`
+	Warnings []string `json:"warnings"`
+}
+
+type importRowError struct {
+	Row     int    `json:"row"`
+	Message string `json:"message"`
+}
+
+var importPollInterval = 2 * time.Second
 
 func main() {
 	args := os.Args[1:]
@@ -84,6 +138,8 @@ func main() {
 		err = cli.expenses(args[1:])
 	case "invoice", "invoices":
 		err = cli.invoices(args[1:])
+	case "import":
+		err = cli.imports(args[1:])
 	case "payment":
 		err = cli.payments(args[1:])
 	case "time":
@@ -420,6 +476,219 @@ func (c *client) expenses(args []string) error {
 	default:
 		return fmt.Errorf("unknown command: miru expense %s", strings.Join(args, " "))
 	}
+}
+
+func (c *client) imports(args []string) error {
+	if len(args) > 0 && args[0] == "status" {
+		return c.importStatus(args[1:])
+	}
+
+	options, err := parseImportOptions(args)
+	if err != nil {
+		return err
+	}
+
+	fields := map[string][]string{
+		"source":     {"harvest"},
+		"kind":       {"time_entries"},
+		"dry_run":    {strconv.FormatBool(options.dryRun)},
+		"user_map[]": options.userMap,
+	}
+	if options.assignUnmatchedTo != "" {
+		fields["assign_unmatched_to"] = []string{options.assignUnmatchedTo}
+	}
+
+	responseBody, err := c.doMultipartRequest(http.MethodPost, "/api/v1/imports", options.filePath, fields)
+	if err != nil {
+		return err
+	}
+	dataImport, err := decodeImport(responseBody)
+	if err != nil {
+		return err
+	}
+
+	if options.dryRun {
+		fmt.Printf("Dry run #%d started\n", dataImport.ID)
+		fmt.Println("Planning...")
+	} else {
+		fmt.Printf("Import #%d started\n", dataImport.ID)
+	}
+
+	for {
+		time.Sleep(importPollInterval)
+		dataImport, err = c.fetchImport(dataImport.ID)
+		if err != nil {
+			return err
+		}
+		if !options.dryRun {
+			fmt.Printf("Imported %d/%d (%d failed)\n", dataImport.ImportedRows, dataImport.TotalRows, dataImport.FailedRows)
+		}
+		switch dataImport.Status {
+		case "completed":
+			renderImportSummary(dataImport)
+			if options.dryRun && (len(dataImport.Summary.Users.Unmatched) > 0 || len(dataImport.RowErrors) > 0) {
+				return fmt.Errorf("dry run has unmatched users or row errors")
+			}
+			if dataImport.FailedRows > 0 {
+				return fmt.Errorf("import completed with %d failed rows", dataImport.FailedRows)
+			}
+			return nil
+		case "failed":
+			return errors.New(defaultString(dataImport.ErrorMessage, "import failed"))
+		}
+	}
+}
+
+func parseImportOptions(args []string) (importOptions, error) {
+	normalized := make([]string, 0, len(args)+1)
+	for index := 0; index < len(args); index++ {
+		normalized = append(normalized, args[index])
+		if args[index] == "--dry-run" && (index+1 >= len(args) || strings.HasPrefix(args[index+1], "--")) {
+			normalized = append(normalized, "true")
+		}
+	}
+
+	flags, err := parseRepeatedFlags(normalized)
+	if err != nil {
+		return importOptions{}, err
+	}
+	if err := validateAllowedFlags(flags, map[string]bool{
+		"assign-unmatched-to": true,
+		"dry-run":             true,
+		"file":                true,
+		"format":              true,
+		"map":                 true,
+		"type":                true,
+	}); err != nil {
+		return importOptions{}, err
+	}
+
+	if flagValue(flags, "format") != "harvest" {
+		return importOptions{}, fmt.Errorf("format must be harvest")
+	}
+	importType := defaultString(flagValue(flags, "type"), "time")
+	if importType == "expenses" {
+		return importOptions{}, fmt.Errorf("expenses import is not supported yet")
+	}
+	if importType != "time" {
+		return importOptions{}, fmt.Errorf("type must be time")
+	}
+
+	filePath := strings.TrimSpace(flagValue(flags, "file"))
+	file, err := os.Open(filePath)
+	if err != nil {
+		return importOptions{}, fmt.Errorf("file must exist and be readable: %w", err)
+	}
+	info, err := file.Stat()
+	file.Close()
+	if err != nil || !info.Mode().IsRegular() {
+		return importOptions{}, fmt.Errorf("file must exist and be readable")
+	}
+
+	dryRun := false
+	if value := flagValue(flags, "dry-run"); value != "" {
+		dryRun, err = strconv.ParseBool(value)
+		if err != nil {
+			return importOptions{}, fmt.Errorf("dry-run must be true or false")
+		}
+	}
+
+	return importOptions{
+		filePath:          filePath,
+		dryRun:            dryRun,
+		userMap:           flags["map"],
+		assignUnmatchedTo: strings.TrimSpace(flagValue(flags, "assign-unmatched-to")),
+	}, nil
+}
+
+func (c *client) importStatus(args []string) error {
+	flags, err := parseRepeatedFlags(args)
+	if err != nil {
+		return err
+	}
+	if err := validateAllowedFlags(flags, map[string]bool{"id": true}); err != nil {
+		return err
+	}
+	id, err := positiveIntFlag(flags, "id")
+	if err != nil {
+		return err
+	}
+
+	dataImport, err := c.fetchImport(id)
+	if err != nil {
+		return err
+	}
+	renderImportSummary(dataImport)
+	if dataImport.Status == "failed" {
+		return errors.New(defaultString(dataImport.ErrorMessage, "import failed"))
+	}
+	return nil
+}
+
+func (c *client) fetchImport(id int) (importResponse, error) {
+	responseBody, err := c.doRequest(http.MethodGet, fmt.Sprintf("/api/v1/imports/%d", id), nil)
+	if err != nil {
+		return importResponse{}, err
+	}
+	return decodeImport(responseBody)
+}
+
+func decodeImport(responseBody []byte) (importResponse, error) {
+	var dataImport importResponse
+	if err := json.Unmarshal(responseBody, &dataImport); err != nil {
+		return importResponse{}, err
+	}
+	return dataImport, nil
+}
+
+func renderImportSummary(dataImport importResponse) {
+	summary := dataImport.Summary
+	fmt.Printf("Rows: %d\n", summary.Rows)
+	fmt.Printf("Date range: %s to %s\n", summary.DateRange.From, summary.DateRange.To)
+	fmt.Printf("Clients existing: %s\n", listOrNone(summary.Clients.Existing))
+	fmt.Printf("Clients to create: %s\n", listOrNone(summary.Clients.ToCreate))
+	fmt.Printf("Projects existing: %s\n", listOrNone(summary.Projects.Existing))
+	fmt.Printf("Projects to create: %s\n", listOrNone(summary.Projects.ToCreate))
+
+	names := make([]string, 0, len(summary.Users.Matched))
+	for name := range summary.Users.Matched {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Printf("Team member: %s -> %s\n", name, summary.Users.Matched[name])
+	}
+	for _, name := range summary.Users.Unmatched {
+		fmt.Printf("Unmatched team member: %s\n", name)
+	}
+	if len(summary.Users.Unmatched) > 0 {
+		fmt.Println("Map unmatched users with --map \"First Last=email\"")
+	}
+
+	if dataImport.DryRun {
+		fmt.Printf("Entries to create: %d\n", summary.EntriesToCreate)
+	} else if dataImport.Status == "completed" {
+		fmt.Printf("Entries created: %d\n", summary.EntriesCreated)
+		fmt.Printf("Entries failed: %d\n", summary.EntriesFailed)
+	}
+	fmt.Printf("Duplicates skipped: %d\n", summary.DuplicatesSkipped)
+	fmt.Printf("Zero-hour rows skipped: %d\n", summary.ZeroHourSkipped)
+	for index, rowError := range dataImport.RowErrors {
+		if index == 20 {
+			break
+		}
+		fmt.Printf("Row %d: %s\n", rowError.Row, rowError.Message)
+	}
+	for _, warning := range summary.Warnings {
+		fmt.Printf("Warning: %s\n", warning)
+	}
+}
+
+func listOrNone(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
 }
 
 func (c *client) listTimeEntries(args []string) error {
@@ -988,6 +1257,55 @@ func (c *client) doRequest(method, path string, body map[string]any) ([]byte, er
 	return responseBody, nil
 }
 
+func (c *client) doMultipartRequest(method, path, filePath string, fields map[string][]string) ([]byte, error) {
+	var payload bytes.Buffer
+	writer := multipart.NewWriter(&payload)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, err
+	}
+	for name, values := range fields {
+		for _, value := range values {
+			if err := writer.WriteField(name, value); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, c.baseURL+path, &payload)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode >= http.StatusBadRequest {
+		return nil, parseError(response.StatusCode, responseBody)
+	}
+	return responseBody, nil
+}
+
 func parseError(statusCode int, responseBody []byte) error {
 	var payload map[string]any
 	if err := json.Unmarshal(responseBody, &payload); err == nil {
@@ -1236,6 +1554,8 @@ miru invoice show --id <id>
 miru invoice send --id <id> --recipients <email1,email2> [--subject <text>] [--message <text>]
 miru payment list [--query <term>]
 miru payment show --id <id>
+miru import --file <path> --format harvest [--type time] [--dry-run] [--map "First Last=email"]... [--assign-unmatched-to <email>]
+miru import status --id <id>
 miru time list --from <YYYY-MM-DD> --to <YYYY-MM-DD>
 miru time create --project-id <id> --duration <minutes> --date <YYYY-MM-DD> [--note <text>] [--bill-status <status>]
 miru time update --id <id> --project-id <id> --duration <minutes> --date <YYYY-MM-DD> [--note <text>] [--bill-status <status>]

--- a/tools/miru-cli/cmd/miru/main_test.go
+++ b/tools/miru-cli/cmd/miru/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sync/atomic"
 	"testing"
 )
 
@@ -164,4 +169,227 @@ func TestParseErrorFallsBackToStatusAndBody(t *testing.T) {
 	if err == nil || err.Error() != "request failed with status 500: oops" {
 		t.Fatalf("expected fallback error, got %v", err)
 	}
+}
+
+func TestParseImportOptionsCollectsUserMappings(t *testing.T) {
+	path := writeImportFixture(t)
+	options, err := parseImportOptions([]string{
+		"--file", path,
+		"--format", "harvest",
+		"--dry-run",
+		"--map", "Paul Connors=paul@example.com",
+		"--map", "Jane Doe=jane@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !options.dryRun {
+		t.Fatal("expected dry run")
+	}
+	expected := []string{"Paul Connors=paul@example.com", "Jane Doe=jane@example.com"}
+	if !reflect.DeepEqual(options.userMap, expected) {
+		t.Fatalf("expected user mappings %v, got %v", expected, options.userMap)
+	}
+}
+
+func TestParseImportOptionsRejectsOtherFormats(t *testing.T) {
+	_, err := parseImportOptions([]string{"--file", writeImportFixture(t), "--format", "toggl"})
+	if err == nil || err.Error() != "format must be harvest" {
+		t.Fatalf("expected format error, got %v", err)
+	}
+}
+
+func TestImportDryRunSendsMultipartFields(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/imports/1" {
+			fmt.Fprint(w, `{"id":1,"status":"completed","dry_run":true,"summary":{"rows":1,"entries_to_create":1,"duplicates_skipped":0,"zero_hour_skipped":0,"clients":{"existing":[],"to_create":["Acme"]},"projects":{"existing":[],"to_create":["Acme / Website"]},"users":{"matched":{"Paul Connors":"paul@example.com"},"unmatched":[]},"date_range":{"from":"2026-01-01","to":"2026-01-01"},"warnings":[]},"row_errors":[]}`)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/imports" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected authorization header: %s", r.Header.Get("Authorization"))
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart form: %v", err)
+			http.Error(w, "invalid multipart form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("source") != "harvest" || r.FormValue("kind") != "time_entries" || r.FormValue("dry_run") != "true" {
+			t.Errorf("unexpected multipart fields: %#v", r.MultipartForm.Value)
+		}
+		expectedMappings := []string{"Paul Connors=paul@example.com", "Jane Doe=jane@example.com"}
+		if !reflect.DeepEqual(r.MultipartForm.Value["user_map[]"], expectedMappings) {
+			t.Errorf("unexpected mappings: %#v", r.MultipartForm.Value["user_map[]"])
+		}
+		if r.FormValue("assign_unmatched_to") != "fallback@example.com" {
+			t.Errorf("unexpected fallback: %s", r.FormValue("assign_unmatched_to"))
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("read uploaded file: %v", err)
+			http.Error(w, "missing file", http.StatusBadRequest)
+			return
+		}
+		file.Close()
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"id":1,"status":"pending","dry_run":true,"summary":{},"row_errors":[]}`)
+	}))
+	defer server.Close()
+
+	originalInterval := importPollInterval
+	importPollInterval = 0
+	defer func() { importPollInterval = originalInterval }()
+	cli := &client{baseURL: server.URL, token: "test-token"}
+	err := cli.imports([]string{
+		"--file", writeImportFixture(t),
+		"--format", "harvest",
+		"--dry-run",
+		"--map", "Paul Connors=paul@example.com",
+		"--map", "Jane Doe=jane@example.com",
+		"--assign-unmatched-to", "fallback@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("expected POST and one poll, got %d requests", requests.Load())
+	}
+}
+
+func TestImportRealRunPollsUntilCompleted(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/imports":
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, `{"id":42,"status":"pending","summary":{},"row_errors":[]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/imports/42":
+			fmt.Fprint(w, `{"id":42,"status":"completed","total_rows":1,"imported_rows":1,"failed_rows":0,"summary":{"rows":1,"entries_created":1,"entries_failed":0,"duplicates_skipped":0,"zero_hour_skipped":0,"clients":{"existing":["Acme"],"to_create":[]},"projects":{"existing":["Acme / Website"],"to_create":[]},"users":{"matched":{"Paul Connors":"paul@example.com"},"unmatched":[]},"date_range":{"from":"2026-01-01","to":"2026-01-01"},"warnings":[]},"row_errors":[]}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	originalInterval := importPollInterval
+	importPollInterval = 0
+	defer func() { importPollInterval = originalInterval }()
+	cli := &client{baseURL: server.URL, token: "test-token"}
+	if err := cli.imports([]string{"--file", writeImportFixture(t), "--format", "harvest"}); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("expected POST and one poll, got %d requests", requests.Load())
+	}
+}
+
+func TestImportRealRunReturnsServerFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, `{"id":42,"status":"pending","summary":{},"row_errors":[]}`)
+			return
+		}
+		fmt.Fprint(w, `{"id":42,"status":"failed","error_message":"Import failed. Support has been notified.","summary":{},"row_errors":[]}`)
+	}))
+	defer server.Close()
+
+	originalInterval := importPollInterval
+	importPollInterval = 0
+	defer func() { importPollInterval = originalInterval }()
+	err := (&client{baseURL: server.URL, token: "test-token"}).imports([]string{
+		"--file", writeImportFixture(t), "--format", "harvest",
+	})
+	if err == nil || err.Error() != "Import failed. Support has been notified." {
+		t.Fatalf("expected server failure message, got %v", err)
+	}
+}
+
+func TestImportRealRunReturnsFailedRows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, `{"id":42,"status":"pending","summary":{},"row_errors":[]}`)
+			return
+		}
+		fmt.Fprint(w, `{"id":42,"status":"completed","failed_rows":2,"summary":{"entries_created":3,"entries_failed":2},"row_errors":[]}`)
+	}))
+	defer server.Close()
+
+	originalInterval := importPollInterval
+	importPollInterval = 0
+	defer func() { importPollInterval = originalInterval }()
+	err := (&client{baseURL: server.URL, token: "test-token"}).imports([]string{
+		"--file", writeImportFixture(t), "--format", "harvest",
+	})
+	if err == nil || err.Error() != "import completed with 2 failed rows" {
+		t.Fatalf("expected failed row error, got %v", err)
+	}
+}
+
+func TestImportDryRunReturnsUnmatchedUsers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, `{"id":1,"status":"pending","dry_run":true,"summary":{},"row_errors":[]}`)
+			return
+		}
+		fmt.Fprint(w, `{"id":1,"status":"completed","dry_run":true,"summary":{"users":{"matched":{},"unmatched":["Paul Connors"]}},"row_errors":[]}`)
+	}))
+	defer server.Close()
+
+	originalInterval := importPollInterval
+	importPollInterval = 0
+	defer func() { importPollInterval = originalInterval }()
+	err := (&client{baseURL: server.URL, token: "test-token"}).imports([]string{
+		"--file", writeImportFixture(t), "--format", "harvest", "--dry-run",
+	})
+	if err == nil || err.Error() != "dry run has unmatched users or row errors" {
+		t.Fatalf("expected unmatched user error, got %v", err)
+	}
+}
+
+func TestImportStatus(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/imports/42" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":42,"status":"completed","summary":{"entries_created":3,"entries_failed":0},"row_errors":[]}`)
+	}))
+	defer server.Close()
+
+	err := (&client{baseURL: server.URL, token: "test-token"}).imports([]string{"status", "--id", "42"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("expected one status request, got %d", requests.Load())
+	}
+}
+
+func writeImportFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "harvest.csv")
+	if err := os.WriteFile(path, []byte("Date,Client,Project,Hours,First Name,Last Name\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }


### PR DESCRIPTION
## Why

miru.so/migrate/from-harvest promises `miru import --file harvest-export.csv --format harvest` and a Settings > Import Data screen. Neither existed: the CLI had no `import` command, the in-app Import modal was an orphaned component with no backend, and the marketing installer 404s. A trial customer (4-person law firm, Harvest renewal on Sept 14) followed the guide and got stuck.

## What

**Server**
- `data_imports` table + `DataImport` model (ActiveStorage file, status, counts, jsonb summary/options/row_errors capped at 200).
- `Imports::HarvestTimeEntriesImporter`: parses Harvest's Detailed Time export (header-name matching, BOM/extra columns tolerated, quoted multi-line notes), matches Harvest first/last names to workspace users (case-insensitive, `user_map` override, `assign_unmatched_to`, ambiguous names are unmatched), upserts clients/projects (30-char truncation with warnings, archived records restored, currency parsed from "United States Dollar - USD"), derives project billable from rows, maps Billable?/Invoiced? to non_billable/unbilled/billed, joins Task + Notes, rounds hours to minutes, skips zero-hour rows and duplicates on re-run (digest of user/project/date/duration/note over `source: "import"`), creates project members in one pass, writes entries in 500-row transactions with per-row savepoints, updates progress every 200 rows, purges the CSV after a completed run.
- `DataImportJob` (dry runs and real runs both async), `POST/GET /api/v1/imports` (owner/admin via `DataImportPolicy`, works with the CLI bearer token and the web session), `imports:harvest_time_entries` rake task for support-run imports.
- `TimesheetEntry#inferred_source` keeps an explicit `import` source (label "Harvest via Import").

**CLI** (`tools/miru-cli`, version 0.3.0)
- `miru import --file <csv> --format harvest [--dry-run] [--map "First Last=email"]... [--assign-unmatched-to <email>]` uploads multipart, polls `import status`, prints a human-readable plan/summary; non-zero exit on unmatched users, row errors, or failed rows. `miru import status --id N`.
- Docs: `docs/miru-cli.md` and `tools/miru-cli/README.md` Import section; capabilities endpoint lists `import`.

## Verified

- Real Harvest export from the Saeloun account (3,540 entries, 2019-02 to 2026-04, 8 projects): dry run in 0.3s; real import 3,540/3,540 in 16s with 0 failures; DB counts matched the CSV exactly (208 billed, 2,250 unbilled, 1,082 non-billable, 10,115.5h); re-run created 0 and skipped 3,540 as duplicates; Projects, Clients and Time Entry report pages render the imported data with no console errors.
- Five-reviewer council (security, testing, Rails architecture, code quality, performance) + two fix rounds: atomic entity creation, archived-record collisions, ambiguous names, error-text redaction, bounded `user_map`, membership N+1 removed, association-target memory growth removed (was ~68 KB/row retained), duplicate lookup scoped and hashed, dry run moved to the job.
- Specs: see CI. rubocop clean; `go vet`, `gofmt`, `go test -race` clean.

## Follow-ups (not in this PR)
- Marketing: saeloun/miru-marketing-website#65 adds `public/install.sh` (prebuilt binary from the `miru-cli-v0.3.0` release) and fixes the guide.
- Web importer UI (Settings > Import Data) can now sit on the same endpoints.
- Expense import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3bYrgbLb92Are6stRLmRk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Harvest time-entry imports through the Miru CLI and API.
  - Added dry-run support, user mapping, unmatched-user assignment, validation, progress tracking, summaries, and import status checks.
  - Added safeguards for invalid CSV files, missing headers, oversized uploads, duplicate records, and unauthorized access.
  - Import results now report completion status, row counts, errors, and summaries.

- **Documentation**
  - Added CLI guidance and examples for importing Harvest time entries and checking import status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->