### PR TITLE
chore(deps): bump rubyzip to ~> 3.4 (fix CVE-2026-85396)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,7 @@ gem "ruby_audit", require: false
 gem "sentry-rails"
 gem "sentry-ruby", "~> 5.17"
 
-gem "rubyzip"
+gem "rubyzip", "~> 3.4"
 
 gem "httparty"
 gem "observer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,7 +792,7 @@ GEM
       logger
     ruby_audit (3.1.0)
       bundler-audit (~> 0.9.0)
-    rubyzip (2.3.2)
+    rubyzip (3.6.0)
     safely_block (0.4.0)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
@@ -1059,7 +1059,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-thread_safety
   ruby_audit
-  rubyzip
+  rubyzip (~> 3.4)
   sentry-rails
   sentry-ruby (~> 5.17)
   shoulda-callback-matchers (~> 1.1.1)


### PR DESCRIPTION
## Why

`bundler-audit` fails repo-wide on rubyzip 2.3.2 — high-severity path-traversal advisory **CVE-2026-85396 / GHSA-47m2-wp7j-p9vc** (disclosed 2026-09-05). The fix is `>= 3.4.0`. This is the red "Security audit" check on recent PRs (unrelated to their content).

## What

- `gem "rubyzip", "~> 3.4"`; Bundler resolves to **3.6.0**, which stays under selenium-webdriver's `< 4.0` cap.
- rubyzip is a direct dep and a transitive dep of selenium-webdriver (test-only). The only application usage is `lib/zipper.rb` (`Zip::File.open(path, create: true)` and `zipfile.add`), whose API is unchanged across the rubyzip 3.0 major.

## Verified

```
$ bundle exec bundler-audit check --update
No vulnerabilities found

$ bundle exec rspec spec/lib/zipper_spec.rb spec/services/bulk_invoice_download_service_spec.rb \
    spec/jobs/bulk_invoice_download_job_spec.rb spec/requests/api/v1/invoices/bulk_download \
    spec/requests/api/v1/payments/bulk_download_spec.rb
34 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3bYrgbLb92Are6stRLmRk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained the `rubyzip` dependency to the 3.4 release range for more predictable compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->