### PR TITLE
fix(invoices): allow zero-rate invoice sending

### DIFF
--- a/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
@@ -19,6 +19,14 @@ import {
   SelectValue,
 } from "../../ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../ui/dialog";
 
 import { cn } from "../../../lib/utils";
 import { format } from "date-fns";
@@ -110,6 +118,11 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
   const [submitIntent, setSubmitIntent] = useState<"save" | "send" | null>(
     null
   );
+
+  const [showZeroRateConfirmation, setShowZeroRateConfirmation] =
+    useState(false);
+
+  const sendRequestedRef = useRef(false);
 
   const parseDate = (date: any): Date | undefined => {
     if (!date) return undefined;
@@ -302,8 +315,13 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
   const hasInvalidLineItems = useMemo(
     () =>
       activeLineItems.some(
-        item => Number(item?.quantity || 0) <= 0 || Number(item?.rate || 0) <= 0
+        item => Number(item?.quantity || 0) <= 0 || Number(item?.rate || 0) < 0
       ),
+    [activeLineItems]
+  );
+
+  const hasZeroRateLineItems = useMemo(
+    () => activeLineItems.some(item => Number(item?.rate || 0) === 0),
     [activeLineItems]
   );
 
@@ -345,6 +363,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
   useEffect(() => {
     if (!isLoading) {
       setSubmitIntent(null);
+      sendRequestedRef.current = false;
     }
   }, [isLoading]);
 
@@ -437,6 +456,21 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
         : Number(formData.tax || 0),
     [activeInvoiceTaxes, formData.tax]
   );
+
+  const sendInvoice = () => {
+    if (!onSend || sendRequestedRef.current) return;
+
+    sendRequestedRef.current = true;
+    setShowZeroRateConfirmation(false);
+    setSubmitIntent("send");
+    onSend({
+      ...formData,
+      status: "sent",
+      tax: taxTotal,
+      invoiceTaxes: submissionInvoiceTaxes,
+      invoiceLineItems: submissionLineItems,
+    });
+  };
 
   const total = useMemo(
     () => subtotal - formData.discount + taxTotal,
@@ -664,15 +698,11 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
               </Button>
               <Button
                 onClick={() => {
-                  setSubmitIntent("send");
-                  onSend &&
-                    onSend({
-                      ...formData,
-                      status: "sent",
-                      tax: taxTotal,
-                      invoiceTaxes: submissionInvoiceTaxes,
-                      invoiceLineItems: submissionLineItems,
-                    });
+                  if (hasZeroRateLineItems) {
+                    setShowZeroRateConfirmation(true);
+                  } else {
+                    sendInvoice();
+                  }
                 }}
                 size="sm"
                 disabled={isLoading || !canSubmitInvoice || isSentInvoice}
@@ -1039,6 +1069,38 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
           </div>
         </div>
       </div>
+
+      <Dialog
+        open={showZeroRateConfirmation}
+        onOpenChange={setShowZeroRateConfirmation}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Send zero-rate invoice?</DialogTitle>
+            <DialogDescription>
+              This invoice contains entries with a zero rate. Are you sure you
+              want to send it?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowZeroRateConfirmation(false)}
+            >
+              No, continue editing
+            </Button>
+            <Button
+              data-testid="confirm-zero-rate-send"
+              disabled={isLoading}
+              type="button"
+              onClick={sendInvoice}
+            >
+              Yes, send invoice
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
+++ b/app/javascript/src/components/Invoices/InvoiceEditor/index.tsx
@@ -314,14 +314,30 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
 
   const hasInvalidLineItems = useMemo(
     () =>
-      activeLineItems.some(
-        item => Number(item?.quantity || 0) <= 0 || Number(item?.rate || 0) < 0
-      ),
+      activeLineItems.some(item => {
+        const rate = item?.rate;
+
+        return (
+          Number(item?.quantity || 0) <= 0 ||
+          rate === "" ||
+          rate === null ||
+          rate === undefined ||
+          !Number.isFinite(Number(rate)) ||
+          Number(rate) < 0
+        );
+      }),
     [activeLineItems]
   );
 
   const hasZeroRateLineItems = useMemo(
-    () => activeLineItems.some(item => Number(item?.rate || 0) === 0),
+    () =>
+      activeLineItems.some(
+        item =>
+          item?.rate !== "" &&
+          item?.rate !== null &&
+          item?.rate !== undefined &&
+          Number(item.rate) === 0
+      ),
     [activeLineItems]
   );
 
@@ -1076,10 +1092,11 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Send zero-rate invoice?</DialogTitle>
+            <DialogTitle>
+              {i18n.t("invoices.zeroRateConfirmationTitle")}
+            </DialogTitle>
             <DialogDescription>
-              This invoice contains entries with a zero rate. Are you sure you
-              want to send it?
+              {i18n.t("invoices.zeroRateConfirmationDescription")}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -1088,7 +1105,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
               variant="outline"
               onClick={() => setShowZeroRateConfirmation(false)}
             >
-              No, continue editing
+              {i18n.t("invoices.zeroRateConfirmationCancel")}
             </Button>
             <Button
               data-testid="confirm-zero-rate-send"
@@ -1096,7 +1113,7 @@ const InvoiceEditor: React.FC<InvoiceEditorProps> = ({
               type="button"
               onClick={sendInvoice}
             >
-              Yes, send invoice
+              {i18n.t("invoices.zeroRateConfirmationSend")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/javascript/src/i18n/locales/en.ts
+++ b/app/javascript/src/i18n/locales/en.ts
@@ -710,6 +710,11 @@ const en = {
     alreadySent: "Already sent",
     downloading: "Downloading...",
     selectClientBeforeSending: "Select a client before sending the invoice.",
+    zeroRateConfirmationTitle: "Send zero-rate invoice?",
+    zeroRateConfirmationDescription:
+      "This invoice contains entries with a zero rate. Are you sure you want to send it?",
+    zeroRateConfirmationCancel: "No, continue editing",
+    zeroRateConfirmationSend: "Yes, send invoice",
 
     // Counters
     showingOf: "Showing %{shown} of %{total}",

--- a/spec/requests/api/v1/invoices/create_spec.rb
+++ b/spec/requests/api/v1/invoices/create_spec.rb
@@ -131,6 +131,44 @@ RSpec.describe "Api::V1::Invoices#create", type: :request do
         expect(line_item.timesheet_entry_id).to eq(timesheet_entry.id)
       end
 
+      it "accepts zero line-item rates and rejects negative rates" do
+        invoice_params = lambda do |invoice_number, rate|
+          {
+            client_id: client.id,
+            invoice_number:,
+            issue_date: Date.current.iso8601,
+            due_date: 30.days.from_now.to_date.iso8601,
+            status: "draft",
+            currency: company.base_currency,
+            invoice_line_items_attributes: [
+              {
+                name: "Trial period",
+                description: "Complimentary trial work",
+                date: Date.current.iso8601,
+                rate:,
+                quantity: 120
+              }
+            ]
+          }
+        end
+
+        send_request :post, api_v1_invoices_path(
+          invoice: invoice_params.call("INV-ZERO-RATE-001", 0)
+        ), headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(Invoice.find_by!(invoice_number: "INV-ZERO-RATE-001").invoice_line_items.sole.rate).to eq(0)
+
+        expect do
+          send_request :post, api_v1_invoices_path(
+            invoice: invoice_params.call("INV-NEGATIVE-RATE-001", -1)
+          ), headers: auth_headers(user)
+        end.not_to change(Invoice, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("greater than or equal to 0")
+      end
+
       it "creates aggregate invoice line items linked to multiple timesheet entries" do
         project = create(:project, client:, name: "Platform Build", billable: true)
         entries = create_list(

--- a/spec/system/invoices/create_spec.rb
+++ b/spec/system/invoices/create_spec.rb
@@ -44,6 +44,89 @@ RSpec.describe "Invoice creation", type: :system, js: true do
     end
   end
 
+  it "saves a zero-rate invoice" do
+    with_forgery_protection do
+      visit_new_invoice_for(client)
+
+      fill_in "invoiceNumber", with: "INV-ZERO-SAVE-001"
+      add_manual_line_item(
+        name: "Trial period",
+        rate: "0",
+        quantity: "02:00",
+        description: "Complimentary trial work"
+      )
+
+      expect(page).to have_button("Save", disabled: false)
+      save_invoice
+
+      expect(page).to have_text("Invoice created successfully", wait: 10)
+      expect(
+        Invoice.find_by!(invoice_number: "INV-ZERO-SAVE-001")
+          .invoice_line_items
+          .sole
+          .rate
+      ).to eq(0)
+    end
+  end
+
+  it "confirms before sending a zero-rate invoice and sends it only once" do
+    allow(InvoicePayment::PdfGeneration).to receive(:process).and_return("%PDF-1.4")
+
+    with_forgery_protection do
+      visit_new_invoice_for(client)
+
+      fill_in "invoiceNumber", with: "INV-ZERO-SEND-001"
+      add_manual_line_item(
+        name: "Trial period",
+        rate: "0",
+        quantity: "02:00",
+        description: "Complimentary trial work"
+      )
+
+      expect(page).to have_button("Send Invoice", disabled: false)
+      click_button "Send Invoice"
+
+      within("[role='dialog']") do
+        expect(page).to have_text("This invoice contains entries with a zero rate. Are you sure you want to send it?")
+        click_button "No, continue editing"
+      end
+
+      expect(page).to have_no_css("[role='dialog']")
+      expect(page).to have_field("invoiceNumber", with: "INV-ZERO-SEND-001")
+      expect(Invoice.where(invoice_number: "INV-ZERO-SEND-001")).to be_empty
+
+      click_button "Send Invoice"
+
+      expect do
+        page.execute_script(<<~JS)
+          const button = document.querySelector("[data-testid='confirm-zero-rate-send']");
+          button.click();
+          button.click();
+        JS
+        expect(page).to have_text("Invoice has been sent successfully", wait: 10)
+      end.to have_enqueued_mail(InvoiceMailer, :send_invoice).once
+
+      expect(Invoice.where(invoice_number: "INV-ZERO-SEND-001").count).to eq(1)
+      expect(Invoice.find_by!(invoice_number: "INV-ZERO-SEND-001")).to be_sent
+    end
+  end
+
+  it "keeps negative-rate invoices invalid" do
+    with_forgery_protection do
+      visit_new_invoice_for(client)
+
+      fill_in "invoiceNumber", with: "INV-NEGATIVE-RATE-001"
+      add_manual_line_item(
+        name: "Invalid work",
+        rate: "-1",
+        quantity: "02:00"
+      )
+
+      expect(page).to have_button("Save", disabled: true)
+      expect(page).to have_button("Send Invoice", disabled: true)
+    end
+  end
+
   it "keeps send failure feedback clear after creating a new invoice" do
     allow(InvoicePayment::PdfGeneration)
       .to receive(:process)

--- a/spec/system/invoices/create_spec.rb
+++ b/spec/system/invoices/create_spec.rb
@@ -127,6 +127,22 @@ RSpec.describe "Invoice creation", type: :system, js: true do
     end
   end
 
+  it "keeps blank-rate invoices invalid" do
+    with_forgery_protection do
+      visit_new_invoice_for(client)
+
+      fill_in "invoiceNumber", with: "INV-BLANK-RATE-001"
+      add_manual_line_item(
+        name: "Missing rate",
+        rate: "",
+        quantity: "02:00"
+      )
+
+      expect(page).to have_button("Save", disabled: true)
+      expect(page).to have_button("Send Invoice", disabled: true)
+    end
+  end
+
   it "keeps send failure feedback clear after creating a new invoice" do
     allow(InvoicePayment::PdfGeneration)
       .to receive(:process)


### PR DESCRIPTION
## Summary

- allow invoice line items with a zero rate while keeping negative rates invalid
- confirm before sending an invoice containing zero-rate entries
- prevent repeated confirmation clicks from creating or sending duplicates

## Verification

- `spec/system/invoices/create_spec.rb`: 23 examples, 0 failures
- invoice create/send/model request specs: 47 examples, 0 failures
- required Vite build, focused ESLint, RuboCop, and diff checks passed
- Playwright verified enablement, confirmation, cancel preservation, successful send, and one invoice after a double-click

Closes #2425
