### PR TITLE
fix: stop the remaining production 500s reported by Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include SetCurrentDetails
 
+  protect_from_forgery with: :exception
+
   # Vite handles asset compilation
 
   around_action :switch_locale

--- a/app/jobs/database_backup_job.rb
+++ b/app/jobs/database_backup_job.rb
@@ -2,6 +2,7 @@
 
 class DatabaseBackupJob < ApplicationJob
   queue_as :default
+  retry_on "Aws::S3::Errors::ServiceError", "Seahorse::Client::NetworkingError", wait: :polynomially_longer, attempts: 5
 
   def perform
     return unless ActiveModel::Type::Boolean.new.cast(ENV.fetch("DATABASE_BACKUP_ENABLED", Rails.env.production?))

--- a/app/jobs/database_backup_job.rb
+++ b/app/jobs/database_backup_job.rb
@@ -2,7 +2,9 @@
 
 class DatabaseBackupJob < ApplicationJob
   queue_as :default
-  retry_on "Aws::S3::Errors::ServiceError", "Seahorse::Client::NetworkingError", wait: :polynomially_longer, attempts: 5
+  retry_on "Aws::S3::Errors::InternalError", "Aws::S3::Errors::ServiceUnavailable", "Aws::S3::Errors::SlowDown",
+    "Aws::S3::Errors::RequestTimeout", "Seahorse::Client::NetworkingError",
+    wait: :polynomially_longer, attempts: 5
 
   def perform
     return unless ActiveModel::Type::Boolean.new.cast(ENV.fetch("DATABASE_BACKUP_ENABLED", Rails.env.production?))

--- a/app/models/timesheet_entry.rb
+++ b/app/models/timesheet_entry.rb
@@ -11,8 +11,8 @@ class TimesheetEntry < ApplicationRecord
   attribute :source_metadata, :json, default: {}
   attribute :proof_metadata, :json, default: {}
   attribute :review_status, :integer
-  enum :bill_status, [:non_billable, :unbilled, :billed]
-  enum :review_status, [:not_required, :pending_review, :approved, :rejected]
+  enum :bill_status, [:non_billable, :unbilled, :billed], validate: true
+  enum :review_status, [:not_required, :pending_review, :approved, :rejected], validate: true
 
   SOURCES = %w[manual cli mcp automation import].freeze
   SOURCE_METADATA_KEYS = %w[tool skill mcp_server].freeze

--- a/app/services/database_backup_service.rb
+++ b/app/services/database_backup_service.rb
@@ -73,8 +73,8 @@ class DatabaseBackupService
     end
 
     def upload_backup!(path)
-      client.put_object(bucket: bucket_name, key: archive_key, body: File.open(path, "rb"))
-      client.put_object(bucket: bucket_name, key: latest_key, body: File.open(path, "rb"))
+      File.open(path, "rb") { |file| client.put_object(bucket: bucket_name, key: archive_key, body: file) }
+      File.open(path, "rb") { |file| client.put_object(bucket: bucket_name, key: latest_key, body: file) }
       archive_key
     end
 

--- a/config/initializers/encoding_sanitizer.rb
+++ b/config/initializers/encoding_sanitizer.rb
@@ -11,6 +11,15 @@ class EncodingSanitizer
     "application/x-www-form-urlencoded",
     "text/"
   ].freeze
+  MULTIPART_ERRORS = %i[
+    EmptyContentError
+    BoundaryTooLongError
+    MultipartPartLimitError
+    MultipartTotalPartLimitError
+    MissingInputError
+  ].filter_map do |name|
+    Rack::Multipart.const_get(name, false) if Rack::Multipart.const_defined?(name, false)
+  end.freeze
 
   def initialize(app)
     @app = app
@@ -33,7 +42,11 @@ class EncodingSanitizer
     end
 
     @app.call(env)
-  rescue Rack::Multipart::BoundaryTooLongError
+  rescue *MULTIPART_ERRORS
+    [400, { "Content-Type" => "text/plain", "Content-Length" => "11" }, ["Bad Request"]]
+  rescue EOFError
+    raise unless multipart_form_data?(env)
+
     [400, { "Content-Type" => "text/plain", "Content-Length" => "11" }, ["Bad Request"]]
   end
 
@@ -61,6 +74,10 @@ class EncodingSanitizer
       return false if content_type.start_with?("multipart/form-data", "application/octet-stream")
 
       TEXTUAL_CONTENT_TYPES.any? { |type| content_type.start_with?(type) }
+    end
+
+    def multipart_form_data?(env)
+      env["CONTENT_TYPE"].to_s.downcase.start_with?("multipart/form-data")
     end
 
     # Wrapper for rack.input that sanitizes encoding on read

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -23,8 +23,9 @@ class Rack::Attack
   end
 
   throttle("reports/pdf/ip", limit: 5, period: 1.minute) do |req|
-    pdf_download = req.path.end_with?(".pdf") || req.params["format"] == "pdf"
-    req.ip if req.get? && pdf_download && req.path.match?(%r{\A/api/v1/reports/[^/]+/download(?:\.pdf)?\z})
+    next unless req.get? && req.path.match?(%r{\A/api/v1/reports/[^/]+/download(?:\.pdf)?\z})
+
+    req.ip if req.path.end_with?(".pdf") || req.GET["format"] == "pdf"
   end
 
   throttle("invitations/resend/ip", limit: 5, period: 1.minute) do |req|

--- a/spec/jobs/database_backup_job_spec.rb
+++ b/spec/jobs/database_backup_job_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe DatabaseBackupJob do
 
     expect(DatabaseBackupService).not_to have_received(:new)
   end
+
+  it "retries S3 service errors" do
+    ENV["DATABASE_BACKUP_ENABLED"] = "true"
+    service = instance_double(DatabaseBackupService)
+    allow(DatabaseBackupService).to receive(:new).and_return(service)
+    allow(service).to receive(:process).and_raise(Aws::S3::Errors::InternalError.new(nil, "boom"))
+
+    described_class.perform_now
+
+    expect(described_class).to have_been_enqueued
+  end
 end

--- a/spec/middleware/encoding_sanitizer_spec.rb
+++ b/spec/middleware/encoding_sanitizer_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe EncodingSanitizer do
         expect(status).to eq(400)
         expect(body).to eq(["Bad Request"])
       end
+
+      it "returns bad request when multipart content is empty" do
+        app = ->(_env) { raise Rack::Multipart::EmptyContentError }
+
+        status, _headers, body = described_class.new(app).call({})
+
+        expect(status).to eq(400)
+        expect(body).to eq(["Bad Request"])
+      end
     end
   end
 

--- a/spec/models/timesheet_entry_spec.rb
+++ b/spec/models/timesheet_entry_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe TimesheetEntry, type: :model do
         .is_less_than_or_equal_to(6000000)
         .is_greater_than_or_equal_to(0.0)
     end
+
+    it "validates an invalid bill status" do
+      timesheet_entry = build(:timesheet_entry)
+
+      expect { timesheet_entry.bill_status = "zzz" }.not_to raise_error
+      expect(timesheet_entry).not_to be_valid
+      expect(timesheet_entry.errors[:bill_status]).to be_present
+    end
   end
 
   describe "Callbacks" do

--- a/spec/requests/api/v1/cli/timesheet_entries/create_spec.rb
+++ b/spec/requests/api/v1/cli/timesheet_entries/create_spec.rb
@@ -76,4 +76,20 @@ RSpec.describe "Api::V1::Cli::TimesheetEntries#create", type: :request do
 
     expect(response).to have_http_status(:not_found)
   end
+
+  it "returns an error for an invalid bill status" do
+    create(:project_member, project:, user:)
+
+    send_request :post, api_v1_cli_timesheet_entries_path, params: {
+      timesheet_entry: {
+        project_id: project.id,
+        duration_minutes: 90,
+        work_date: Date.current.iso8601,
+        bill_status: "zzz"
+      }
+    }, headers: cli_auth_headers(cli_token)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(json_response["errors"]).to be_present
+  end
 end

--- a/spec/requests/forgery_protection_spec.rb
+++ b/spec/requests/forgery_protection_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Forgery protection", type: :request do
+  it "rejects an unverified confirmation request" do
+    with_forgery_protection do
+      post "/users/confirmation"
+    end
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+end

--- a/spec/requests/rack_attack_multipart_spec.rb
+++ b/spec/requests/rack_attack_multipart_spec.rb
@@ -25,4 +25,19 @@ RSpec.describe "Rack::Attack multipart handling", type: :request do
 
     expect(response.status).to be < 500
   end
+
+  it "keeps the reports pdf throttle from parsing the request body" do
+    env = Rack::MockRequest.env_for(
+      "/",
+      method: "POST",
+      input: "",
+      "CONTENT_TYPE" => "multipart/form-data; boundary=----x",
+      "CONTENT_LENGTH" => "64"
+    )
+    request = Rack::Attack::Request.new(env)
+    throttle = Rack::Attack.throttles.fetch("reports/pdf/ip")
+
+    expect { request.params }.to raise_error(EOFError)
+    expect(throttle.block.call(request)).to be_nil
+  end
 end

--- a/spec/requests/rack_attack_multipart_spec.rb
+++ b/spec/requests/rack_attack_multipart_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack multipart handling", type: :request do
+  around do |example|
+    enabled = Rack::Attack.enabled
+    store = Rack::Attack.cache.store
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    example.run
+  ensure
+    Rack::Attack.enabled = enabled
+    Rack::Attack.cache.store = store
+  end
+
+  it "does not raise for empty multipart content" do
+    post "/",
+      headers: {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=----x",
+        "CONTENT_LENGTH" => "64"
+      },
+      env: { "rack.input" => StringIO.new("") }
+
+    expect(response.status).to be < 500
+  end
+end


### PR DESCRIPTION
## Summary

- MIRU-WEB-5Q: the `reports/pdf/ip` rack-attack throttle parsed `req.params` for every request, so an empty multipart `POST /` crashed with `Rack::Multipart::EmptyContentError`; it now checks method and path first and reads only the query string, and `EncodingSanitizer` returns 400 for the whole `Rack::Multipart` error family
- MIRU-WEB-58: `forgery_protection_strategy` was nil on `ActionController::Base`, so unverified non-GET requests raised `NoMethodError` instead of `InvalidAuthenticityToken` (579 events); `ApplicationController` now declares `protect_from_forgery with: :exception`
- MIRU-WEB-5N: unknown `bill_status`/`review_status` values now fail validation (422) instead of raising `ArgumentError`
- MIRU-WEB-5R: `DatabaseBackupJob` retries S3 service and networking errors with backoff; the upload closes its file handles

The other nine unresolved Miru issues were already fixed on develop or came from the stale `miru-production.fly.dev` deployment and have been resolved in Sentry.

## Verification

- each fix has a reproduction spec that failed before the change: `spec/requests/rack_attack_multipart_spec.rb`, `spec/requests/forgery_protection_spec.rb`, `spec/models/timesheet_entry_spec.rb`, `spec/requests/api/v1/cli/timesheet_entries/create_spec.rb`, `spec/jobs/database_backup_job_spec.rb`, `spec/middleware/encoding_sanitizer_spec.rb`
- `bundle exec rspec` over the touched suites plus `spec/requests/api/v1/users/`, `spec/requests/users/`, `spec/requests/webhooks/`, `spec/requests/home/`, `spec/requests/rack_attack_spec.rb`: 283 examples, 0 failures
- `bundle exec rubocop` on the 12 changed files: no offenses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added request forgery protection to reject unverified form submissions.
  - Improved handling of malformed multipart requests with clear “Bad Request” responses.

- **Bug Fixes**
  - Invalid timesheet statuses now produce validation errors and an HTTP 422 response instead of raising exceptions.
  - Improved reliability for PDF download throttling.
  - Database backups now retry temporary storage and network failures and handle uploads more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->